### PR TITLE
[skipruntime] Type cleanups and improvements

### DIFF
--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -30,6 +30,7 @@ import type {
   ReactiveResponse,
   CollectionUpdate,
   Watermark,
+  SubscriptionID,
 } from "../skipruntime_api.js";
 
 import type { SKJSON } from "skjson";
@@ -1116,7 +1117,10 @@ class SkipRuntimeImpl implements SkipRuntime {
     }
     const [values, reactive] = result as [Entry<K, V>[], [string, string]];
     const [collection, watermark] = reactive;
-    return { values, reactive: { collection, watermark: BigInt(watermark) as Watermark } };
+    return {
+      values,
+      reactive: { collection, watermark: BigInt(watermark) as Watermark },
+    };
   }
 
   getOne<V extends TJSON>(
@@ -1175,7 +1179,7 @@ class SkipRuntimeImpl implements SkipRuntime {
     since: Watermark,
     f: (update: CollectionUpdate<K, V>) => void,
     reactiveAuth?: Uint8Array,
-  ): bigint {
+  ): SubscriptionID {
     const session = this.refs.skjson.runWithGC(() => {
       const sknotifier = this.refs.fromWasm.SkipRuntime_createNotifier(
         this.refs.handles.register(f),
@@ -1196,10 +1200,10 @@ class SkipRuntimeImpl implements SkipRuntime {
     } else if (session < 0n) {
       throw new Error("Unknown error");
     }
-    return session;
+    return session as SubscriptionID;
   }
 
-  unsubscribe(id: bigint): void {
+  unsubscribe(id: SubscriptionID): void {
     const result = this.refs.skjson.runWithGC(() => {
       return this.refs.fromWasm.SkipRuntime_Runtime__unsubscribe(id);
     });

--- a/skipruntime-ts/core/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/core/src/internals/skipruntime_module.ts
@@ -29,6 +29,7 @@ import type {
   SkipRuntime,
   ReactiveResponse,
   CollectionUpdate,
+  Watermark,
 } from "../skipruntime_api.js";
 
 import type { SKJSON } from "skjson";
@@ -649,7 +650,7 @@ class LinksImpl implements Links {
   notifyOfNotifier<K extends TJSON, V extends TJSON>(
     sknotifier: Handle<(update: CollectionUpdate<K, V>) => void>,
     skvalues: ptr<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
-    watermark: bigint,
+    watermark: Watermark,
     isInitial: boolean,
   ) {
     const skjson = this.getSkjson();
@@ -1092,7 +1093,7 @@ class SkipRuntimeImpl implements SkipRuntime {
       throw this.refs.handles.deleteAsError(result as Handle<ErrorObject>);
     }
     const [collection, watermark] = result as [string, string];
-    return { collection, watermark: BigInt(watermark) };
+    return { collection, watermark: BigInt(watermark) as Watermark };
   }
 
   getAll<K extends TJSON, V extends TJSON>(
@@ -1115,7 +1116,7 @@ class SkipRuntimeImpl implements SkipRuntime {
     }
     const [values, reactive] = result as [Entry<K, V>[], [string, string]];
     const [collection, watermark] = reactive;
-    return { values, reactive: { collection, watermark: BigInt(watermark) } };
+    return { values, reactive: { collection, watermark: BigInt(watermark) as Watermark } };
   }
 
   getOne<V extends TJSON>(
@@ -1171,7 +1172,7 @@ class SkipRuntimeImpl implements SkipRuntime {
 
   subscribe<K extends TJSON, V extends TJSON>(
     reactiveId: string,
-    since: bigint,
+    since: Watermark,
     f: (update: CollectionUpdate<K, V>) => void,
     reactiveAuth?: Uint8Array,
   ): bigint {

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -19,6 +19,7 @@ export type {
   ExternalSupplier,
   CollectionUpdate,
   Watermark,
+  SubscriptionID,
 } from "./skipruntime_api.js";
 
 export { UnknownCollectionError } from "./skipruntime_errors.js";

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -18,6 +18,7 @@ export type {
   Resource,
   ExternalSupplier,
   CollectionUpdate,
+  Watermark,
 } from "./skipruntime_api.js";
 
 export { UnknownCollectionError } from "./skipruntime_errors.js";

--- a/skipruntime-ts/core/src/skip-runtime.ts
+++ b/skipruntime-ts/core/src/skip-runtime.ts
@@ -17,6 +17,7 @@ export type {
   SkipService,
   Resource,
   ExternalSupplier,
+  CollectionUpdate,
 } from "./skipruntime_api.js";
 
 export { UnknownCollectionError } from "./skipruntime_errors.js";

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -18,8 +18,8 @@ export type JSONObject = { [key: string]: TJSON | null };
 /**
  * A `Param` is a valid parameter to a Skip runtime mapper function: either a constant JS
  * value or a Skip-runtime-managed value.  In either case, restricting mapper parameters to
- * this type ensures that reactive computations can be re-evaluated as needed with consistent
- * semantics.
+ * this type helps developers to ensure that reactive computations can be re-evaluated as
+ * needed with consistent semantics.
  */
 export type Param =
   | null

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -262,6 +262,7 @@ export interface Context extends Constant {
 export type Entry<K extends TJSON, V extends TJSON> = [K, V[]];
 
 export type Watermark = Opaque<bigint, "watermark">;
+export type SubscriptionID = Opaque<bigint, "subscription">;
 
 /**
  * Represents some update(s) to a collection, containing: an array of all updated keys and
@@ -309,9 +310,9 @@ export interface SkipRuntime {
     since: Watermark,
     f: (update: CollectionUpdate<K, V>) => void,
     reactiveAuth?: Uint8Array,
-  ): bigint;
+  ): SubscriptionID;
 
-  unsubscribe(id: bigint): void;
+  unsubscribe(id: SubscriptionID): void;
 
   // WRITE
 

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -261,11 +261,17 @@ export interface Context extends Constant {
 
 export type Entry<K extends TJSON, V extends TJSON> = [K, V[]];
 
-export type Notifier<K extends TJSON, V extends TJSON> = (
-  values: Entry<K, V>[],
-  watermark: number,
-  update: boolean,
-) => void;
+/**
+ * Represents some update(s) to a collection, containing: an array of all updated keys and
+ * their new `values`, where an empty value array indicates deletion; a new `watermark` for
+ * the point after these updates; and, a flag `isInitial` which is set when this update is
+ * the initial chunk of data rather than an update to the preceding state.
+ */
+export type CollectionUpdate<K extends TJSON, V extends TJSON> = {
+  values: Entry<K, V>[];
+  watermark: bigint;
+  isInitial?: boolean;
+};
 
 export interface SkipRuntime {
   // READ
@@ -298,8 +304,8 @@ export interface SkipRuntime {
 
   subscribe<K extends TJSON, V extends TJSON>(
     reactiveId: string,
-    from: string,
-    notify: Notifier<K, V>,
+    since: bigint,
+    f: (update: CollectionUpdate<K, V>) => void,
     reactiveAuth?: Uint8Array,
   ): bigint;
 
@@ -349,5 +355,5 @@ export interface SkipService {
 
 export type ReactiveResponse = {
   collection: string;
-  watermark: number;
+  watermark: bigint;
 };

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -4,7 +4,7 @@
  * overview page] for a detailed description and introduction to the SkipRuntime system.
  */
 
-import type { Opt, int } from "std";
+import type { Opaque, Opt, int } from "std";
 import type { Constant } from "./internals/skipruntime_module.js";
 
 /**
@@ -261,6 +261,8 @@ export interface Context extends Constant {
 
 export type Entry<K extends TJSON, V extends TJSON> = [K, V[]];
 
+export type Watermark = Opaque<bigint, "watermark">;
+
 /**
  * Represents some update(s) to a collection, containing: an array of all updated keys and
  * their new `values`, where an empty value array indicates deletion; a new `watermark` for
@@ -269,7 +271,7 @@ export type Entry<K extends TJSON, V extends TJSON> = [K, V[]];
  */
 export type CollectionUpdate<K extends TJSON, V extends TJSON> = {
   values: Entry<K, V>[];
-  watermark: bigint;
+  watermark: Watermark;
   isInitial?: boolean;
 };
 
@@ -304,7 +306,7 @@ export interface SkipRuntime {
 
   subscribe<K extends TJSON, V extends TJSON>(
     reactiveId: string,
-    since: bigint,
+    since: Watermark,
     f: (update: CollectionUpdate<K, V>) => void,
     reactiveAuth?: Uint8Array,
   ): bigint;
@@ -355,5 +357,5 @@ export interface SkipService {
 
 export type ReactiveResponse = {
   collection: string;
-  watermark: bigint;
+  watermark: Watermark;
 };

--- a/skipruntime-ts/core/src/skipruntime_api.ts
+++ b/skipruntime-ts/core/src/skipruntime_api.ts
@@ -234,7 +234,7 @@ export interface EagerCollection<K extends TJSON, V extends TJSON>
  * The type of a _lazy_ reactive function which produces a value for some `key`, possibly using a `self` reference to get/produce other lazily-computed results.
  */
 export interface LazyCompute<K extends TJSON, V extends TJSON> {
-  compute(selfHdl: LazyCollection<K, V>, key: K): Opt<V>;
+  compute(self: LazyCollection<K, V>, key: K): Opt<V>;
 }
 
 export interface Context extends Constant {

--- a/skipruntime-ts/examples/database-client.ts
+++ b/skipruntime-ts/examples/database-client.ts
@@ -40,7 +40,7 @@ const client = await connect(`ws://localhost:${replication.toString()}`, creds);
 
 client.subscribe(
   reactive.collection,
-  BigInt(reactive.watermark),
+  reactive.watermark,
   (updates: [string, TJSON[]][], isInit: boolean) => {
     console.log("Update", Object.fromEntries(updates), isInit);
   },

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -87,7 +87,7 @@ class SkipHttpAccessV1 {
     }
     this.client.subscribe(
       reactive.collection,
-      BigInt(reactive.watermark),
+      reactive.watermark,
       (updates: [string, TJSON[]][], isInit: boolean) => {
         console.log("Update", Object.fromEntries(updates), isInit);
       },

--- a/skipruntime-ts/server/src/replication.ts
+++ b/skipruntime-ts/server/src/replication.ts
@@ -1,5 +1,5 @@
 import { WebSocket, type WebSocketServer, type MessageEvent } from "ws";
-import type { Entry, TJSON, SkipRuntime } from "@skipruntime/core";
+import type { TJSON, SkipRuntime, CollectionUpdate } from "@skipruntime/core";
 import { Protocol } from "@skipruntime/client";
 
 class TailingSession {
@@ -13,19 +13,12 @@ class TailingSession {
   subscribe(
     collection: string,
     since: bigint,
-    callback: (
-      updates: Entry<string, TJSON>[],
-      isInit: boolean,
-      tick: bigint,
-    ) => void,
+    callback: (update: CollectionUpdate<string, TJSON>) => void,
   ) {
-    // FIXME: Pass pubkey down to replication.
     const subsession = this.replication.subscribe<string, TJSON>(
       collection,
-      since.toString(),
-      (v, w, u) => {
-        callback(v, !u, BigInt(w));
-      },
+      since,
+      callback,
       new Uint8Array(this.pubkey),
     );
     this.subsessions.set(collection, subsession);
@@ -82,14 +75,14 @@ function handleMessage(
     case "tail": {
       // FIXME: Respond with error 1004 if collection does not exist
       // (for current user).
-      session.subscribe(msg.collection, msg.since, (updates, isInit, tick) => {
+      session.subscribe(msg.collection, msg.since, (update) => {
         ws.send(
           Protocol.encodeMsg({
             type: "data",
             collection: msg.collection,
-            isInit,
-            tick,
-            payload: JSON.stringify(updates),
+            isInit: update.isInitial ?? false,
+            tick: update.watermark,
+            payload: JSON.stringify(update.values),
           }),
         );
       });

--- a/skipruntime-ts/server/src/replication.ts
+++ b/skipruntime-ts/server/src/replication.ts
@@ -4,11 +4,12 @@ import type {
   SkipRuntime,
   CollectionUpdate,
   Watermark,
+  SubscriptionID,
 } from "@skipruntime/core";
 import { Protocol } from "@skipruntime/client";
 
 class TailingSession {
-  private subsessions = new Map<string, bigint>();
+  private subsessions = new Map<string, SubscriptionID>();
 
   constructor(
     private replication: SkipRuntime,

--- a/skipruntime-ts/server/src/replication.ts
+++ b/skipruntime-ts/server/src/replication.ts
@@ -1,5 +1,10 @@
 import { WebSocket, type WebSocketServer, type MessageEvent } from "ws";
-import type { TJSON, SkipRuntime, CollectionUpdate } from "@skipruntime/core";
+import type {
+  TJSON,
+  SkipRuntime,
+  CollectionUpdate,
+  Watermark,
+} from "@skipruntime/core";
 import { Protocol } from "@skipruntime/client";
 
 class TailingSession {
@@ -12,7 +17,7 @@ class TailingSession {
 
   subscribe(
     collection: string,
-    since: bigint,
+    since: Watermark,
     callback: (update: CollectionUpdate<string, TJSON>) => void,
   ) {
     const subsession = this.replication.subscribe<string, TJSON>(
@@ -75,7 +80,7 @@ function handleMessage(
     case "tail": {
       // FIXME: Respond with error 1004 if collection does not exist
       // (for current user).
-      session.subscribe(msg.collection, msg.since, (update) => {
+      session.subscribe(msg.collection, msg.since as Watermark, (update) => {
         ws.send(
           Protocol.encodeMsg({
             type: "data",


### PR DESCRIPTION
* Use opaque type instead of raw bigint for subscription IDs
* Use bigint instead of converting to/from string for watermarks, and introduce an opaque type there as well
* Unify treatment of collection diffs/updates: now the same type is used for the return value of `getDiff` and the callback argument in `subscribe` (which previously took the same three values, but destructured into separate arguments). I think this is an improvement on the `Notifier` function type alias I deleted in #362 in terms of clarity, but open to reverting if people prefer the previous setup.
* Some minor semantics-preserving changes, getting rid of some single-letter type variables and tweaking comment prose.