### PR TITLE
Clean up formatting and Make targets for native example tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ test-skjson:
 
 .PHONY: test-skipruntime-ts
 test-skipruntime-ts:
-	$(MAKE) -C skipruntime-ts install-all build-with-exemple run-test run-wasm-examples run-native-examples test-error-types
+	$(MAKE) -C skipruntime-ts test-all
 
 test-%:
 	cd $* && skargo test --profile $(SKARGO_PROFILE)

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -16,10 +16,6 @@ install-all:
 build:
 	../bin/cd_sh .. "npm run build $(NPM_WORKSPACES) --if-present"
 
-.PHONY: build-with-exemple
-build-with-exemple: build
-	../bin/cd_sh examples "npm run build -w skipruntime-examples"
-
 bunrun-%: build
 	bun run examples/$*.ts
 
@@ -52,8 +48,8 @@ run-test:
 test: install build run-test
 
 .PHONY: build-examples
-build-examples:
-	../bin/cd_sh examples "npm install && npm run build"
+build-examples: build
+	../bin/cd_sh examples "npm run build -w skipruntime-examples"
 
 test-example-%:
 	../bin/cd_sh tests/examples "./$*.sh /tmp/$*.out /tmp/$*.err"
@@ -72,19 +68,11 @@ test-native-example-%:
 
 EXAMPLES := $(patsubst tests/examples/%.sh,%,$(wildcard tests/examples/*.sh))
 
-WASM_EXAMPLE_TARGETS := $(patsubst %,test-wasm-example-%,$(EXAMPLES))
-.PHONY: run-wasm-examples
-run-wasm-examples: $(WASM_EXAMPLE_TARGETS)
-
 .PHONY: test-wasm-examples
-test-wasm-examples: build-examples run-wasm-examples
-
-NATIVE_EXAMPLE_TARGETS := $(patsubst %,test-native-example-%,$(EXAMPLES))
-.PHONY: run-native-examples
-run-native-examples: $(NATIVE_EXAMPLE_TARGETS)
+test-wasm-examples: $(patsubst %,test-wasm-example-%,$(EXAMPLES))
 
 .PHONY: test-native-examples
-test-native-examples: build-examples run-native-examples
+test-native-examples: $(patsubst %,test-native-example-%,$(EXAMPLES))
 
 .PHONY: test-error-types
 test-error-types: # Best-effort check that we don't throw generic JS errors; prefer some version of SkipError instead.
@@ -95,9 +83,12 @@ test-error-types: # Best-effort check that we don't throw generic JS errors; pre
 	--exclude-dir examples \
 	--exclude-dir tests
 
+.PHONY: test-all
+test-all: install-all build-examples run-test test-wasm-examples test-native-examples test-error-types
+
 regen-%:
 	cd tests/examples && ./$*.sh ../tests/examples/$*.exp.out ../tests/examples/$*.exp.err
 
 REGEN_TARGETS := $(patsubst %,regen-%,$(EXAMPLES))
 .PHONY: regenerate-expectations
-regenerate-expectations: build build-examples $(REGEN_TARGETS)
+regenerate-expectations: build-examples $(REGEN_TARGETS)

--- a/skipruntime-ts/tests/examples/database.sh
+++ b/skipruntime-ts/tests/examples/database.sh
@@ -13,10 +13,10 @@ if [ "$#" -lt 2 ]; then
 fi
 
 if [ "$3" = "native" ]; then
-    echo "Run database with native platform"
+    echo "Running 'database' example on @skipruntime/native"
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/database.js >/dev/null &
 else
-    echo "Run database with wasm platform"
+    echo "Running 'database' example on @skipruntime/wasm"
     node dist/database.js >/dev/null &
 fi
 

--- a/skipruntime-ts/tests/examples/departures.sh
+++ b/skipruntime-ts/tests/examples/departures.sh
@@ -13,10 +13,10 @@ if [ "$#" -lt 2 ]; then
 fi
 
 if [ "$3" = "native" ]; then
-    echo "Run departures with native platform"
+    echo "Running 'departures' example on @skipruntime/native"
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/departures.js >/dev/null &
 else
-    echo "Run departures with wasm platform"
+    echo "Running 'departures' example on @skipruntime/wasm"
     node dist/departures.js >/dev/null &
 fi
 

--- a/skipruntime-ts/tests/examples/groups.sh
+++ b/skipruntime-ts/tests/examples/groups.sh
@@ -13,10 +13,10 @@ if [ "$#" -lt 2 ]; then
 fi
 
 if [ "$3" = "native" ]; then
-    echo "Run groups with native platform"
+    echo "Running 'groups' example on @skipruntime/native"
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/groups.js >/dev/null &
 else
-    echo "Run groups with wasm platform"
+    echo "Running 'groups' example on @skipruntime/wasm"
     node dist/groups.js >/dev/null &
 fi
 

--- a/skipruntime-ts/tests/examples/remote.sh
+++ b/skipruntime-ts/tests/examples/remote.sh
@@ -13,11 +13,11 @@ if [ "$#" -lt 2 ]; then
 fi
 
 if [ "$3" = "native" ]; then
-    echo "Run remote with native platform"
+    echo "Running 'remote' example on @skipruntime/native"
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/remote.js >/dev/null &
 else
-    echo "Run remote with wasm platform"
+    echo "Running 'remote' example on @skipruntime/wasm"
     node dist/sum.js >/dev/null &
     node dist/remote.js >/dev/null &
 fi

--- a/skipruntime-ts/tests/examples/sheet.sh
+++ b/skipruntime-ts/tests/examples/sheet.sh
@@ -13,10 +13,10 @@ if [ "$#" -lt 2 ]; then
 fi
 
 if [ "$3" = "native" ]; then
-    echo "Run sheet with native platform"
+    echo "Running 'sheet' example on @skipruntime/native"
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sheet.js >/dev/null &
 else
-    echo "Run sheet with wasm platform"
+    echo "Running 'sheet' example on @skipruntime/wasm"
     node dist/sheet.js >/dev/null &
 fi
 

--- a/skipruntime-ts/tests/examples/sum.sh
+++ b/skipruntime-ts/tests/examples/sum.sh
@@ -13,10 +13,10 @@ if [ "$#" -lt 2 ]; then
 fi
 
 if [ "$3" = "native" ]; then
-    echo "Run sum with native platform"
+    echo "Running 'sum' example on @skipruntime/native"
     LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
 else
-    echo "Run sum with wasm platform"
+    echo "Running 'sum' example on @skipruntime/wasm"
     node dist/sum.js >/dev/null &
 fi
 


### PR DESCRIPTION
Some semantics-preserving updates to follow up on #743 

I noticed that there were some heavily overlapping/redundant make targets, and that the `echo`'ed script output was a bit sparse/confusing.

I believe this preserves the intent of the makefile changes from #743, but happy to drop it if there's something I'm missing @skiplabsdaniel 