### PR TITLE
[skip-adapter/postgres] Support non-unique key columns

### DIFF
--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -632,8 +632,8 @@ DROP TABLE IF EXISTS skip_test;
 CREATE TABLE skip_test (id INTEGER PRIMARY KEY, x INTEGER, "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
 INSERT INTO skip_test (id, x) VALUES (1, 1), (2, 2), (3, 3);
 DROP TABLE IF EXISTS skip_test2;
-CREATE TABLE skip_test2 (id INTEGER PRIMARY KEY, x INTEGER, "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
-INSERT INTO skip_test2 (id, x) VALUES (1, 100), (2, 200), (3, 300);`);
+CREATE TABLE skip_test2 (id INTEGER, x INTEGER, "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP);
+INSERT INTO skip_test2 (id, x) VALUES (1, 100), (2, 100), (2, 100), (3, 100), (3, 100), (3, 100);`);
     await pgSetupClient.end();
     pgIsSetup = true;
   }


### PR DESCRIPTION
The previous code relied on an assumption that `key`s were _primary_ or at least unique.  But it may be useful to index on a foreign (or otherwise non-unique) key column  for some data models, to skip the step of re-keying your skip collection.

This PR drops that assumption and tweaks the unit test to include a table with non-unique key.