### PR TITLE
Remove "static compute graph" terminology

### DIFF
--- a/www/docs/getting_started.md
+++ b/www/docs/getting_started.md
@@ -87,8 +87,8 @@ Skip is designed to bridge this gap, letting you express the moment-in-time logi
 At its core, a Skip service is a reactive computation graph describing how to compute some output _resources_ from some input data and/or external API inputs.
 
 A service is specified by an object passed to `runService`, which will then spin up a Skip runtime and server.
-That object consists of `initialData` used to populate the service's input collections, some `resources` to make available over HTTP, and a function `createGraph` defining a static computation graph mapping the `ServiceInputs` to `ResourceInputs`.
-This static computation graph will be maintained up-to-date at all times, and can be an arbitrarily complex computation graph or as simple as returning the input collections directly, depending on the service.
+That object consists of `initialData` used to populate the service's input collections, some `resources` to make available over HTTP, and a function `createGraph` defining a shared computation graph mapping the `ServiceInputs` to `ResourceInputs`.
+This shared computation graph will be maintained up-to-date at all times, and can be an arbitrarily complex computation graph or as simple as returning the input collections directly, depending on the service.
 
 In this example, we pull initial user and group data from an external source-of-truth database, expose a single resource called `activeFriends`, and define a reactive computation of the active users in each group. 
 
@@ -137,7 +137,7 @@ await runService(service);
 ```
 
 This example service operates over two _input collections_ (one for users and one for groups, as specified by `ServiceInputs`) and passes some `ResourceInputs` to its resources: a reactively-computed collection `activeMembers` of the set of active users in each group, along with the `users` input collection.
-This `activeMembers` collection is the "output" of the static computation graph, produced by mapping over the input groups and taking users that have the `active` flag set; since this only has to be done once for the entire service, it can be maintained at all times.
+This `activeMembers` collection is the "output" of the shared computation graph, produced by mapping over the input groups and taking users that have the `active` flag set; since this only has to be done once for the entire service, it can be maintained at all times.
 
 Our service wants to expose a resource -- parameterized by a user ID -- which can be queried or subscribed to by clients to view that user's active friends in each group.
 Maintaining this resource up-to-date for all users at all times would be infeasible at scale, so resources can make dynamic extensions to the reactive computation graph which are instantiated/dropped as needed to serve requests.

--- a/www/docs/resources.md
+++ b/www/docs/resources.md
@@ -12,7 +12,7 @@ A Skip [reactive service](api/core/interfaces/SkipService) describes a reactive 
 
 A service's inputs are its *input collections* (data owned by the service that can be freely read/written/mapped over) and its *external services* (any dependencies on outside systems or APIs).
 
-A service's outputs are its *resource*, which define the types of requests that the service can handle, either by accessing data from its static computation graph or by dynamically extending it with further reactive computation as needed to handle the request.
+A service's outputs are its *resource*, which define the types of requests that the service can handle, either by accessing data from its shared computation graph or by dynamically extending it with further reactive computation as needed to handle the request.
 In this way, we can think of resources as parameterized outputs; request parameters are used to instantiate the resource and produce a *resource instance* containing the requested data.
 
 For a concrete example, take the "active friends" resource from the getting-started [example](getting_started.md#the-anatomy-of-a-skip-service) service:
@@ -57,7 +57,7 @@ class ActiveFriends implements Resource<ResourceInputs> {
 ```
 
 In this setup, the reactive service exposes some routes corresponding to the resource, each expecting an HTTP query parameter `uid`.
-When a request is made, the `constructor` is invoked with the given parameters and then `instantiate` is called on the resulting object, extending the static computation graph (which updates `inputs`) with additional reactive computation, getting the relevant `user` and filtering active users according to whether or not they are friends.
+When a request is made, the `constructor` is invoked with the given parameters and then `instantiate` is called on the resulting object, extending the shared computation graph (which updates `inputs`) with additional reactive computation, getting the relevant `user` and filtering active users according to whether or not they are friends.
 The eager collection returned by the `instantiate` function is the output served to the client for this request, reactively updating according to any changes to input data: users, groups, friend relationships, etc.
 
 This _resource instance_ can be explicitly closed by the client, or it will be garbage collected by the Skip framework after a period of inactivity.


### PR DESCRIPTION
It is not technically correct since the writes received to a service's input
collections might, in a mapper, lead to creating new eager or lazy
collections.