### PR TITLE
[hackernews example] Pull round-robin logic from Docker compose to HAproxy

### DIFF
--- a/examples/hackernews/compose.distributed.yml
+++ b/examples/hackernews/compose.distributed.yml
@@ -44,10 +44,6 @@ services:
   skip_follower1: &follower
     image: reactive-hackernews/reactive-service
     build: ./reactive_service
-    networks:
-      default:
-        aliases:
-          - skip_followers
     depends_on:
       skip_leader:
         condition: service_healthy

--- a/examples/hackernews/compose.distributed.yml
+++ b/examples/hackernews/compose.distributed.yml
@@ -23,7 +23,7 @@ services:
         condition: service_healthy
     environment:
       DISTRIBUTED_MODE: true
-
+      SKIP_CONTROL_URL: "http://haproxy:8081/v1"
   # SQL database
   db:
     image: reactive-hackernews/db

--- a/examples/hackernews/compose.yml
+++ b/examples/hackernews/compose.yml
@@ -19,7 +19,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-
+    environment:
+      SKIP_CONTROL_URL: "http://haproxy:8081/v1"
   # SQL database
   db:
     image: reactive-hackernews/db

--- a/examples/hackernews/reverse_proxy/haproxy.cfg
+++ b/examples/hackernews/reverse_proxy/haproxy.cfg
@@ -23,6 +23,12 @@ backend api
 
     server web1 web:3031
 
+
+listen control
+    mode http
+    bind :8081
+    server control1 reactive_service:8081
+
 backend stream
     mode http
 

--- a/examples/hackernews/reverse_proxy/haproxy.distributed.cfg
+++ b/examples/hackernews/reverse_proxy/haproxy.distributed.cfg
@@ -4,9 +4,10 @@ frontend www
     bind :443 ssl crt /etc/ssl/selfsigned.crt
     http-request redirect scheme https unless { ssl_fc }
 
-    # Dispatch /streams/$follower/$uuid to $follower
+    # Dispatch /streams/$follower/$uuid to streaming backend, stashing $follower in a header
     acl url_streams path_beg -i /streams/
-    use_backend %[path,field(3,/)] if url_streams
+    http-request set-header Follower-Prefix %[path,field(3,/)] if url_streams
+    use_backend stream if url_streams
 
     # Dispatch /api/... to the api backend
     acl url_api path_beg -i /api/
@@ -15,18 +16,27 @@ frontend www
     # Default to serving the www frontend.
     default_backend www
 
-# Skip streaming backends
-backend follower1
+
+# Skip control backend
+listen control
+    mode http
+    bind :8081
+    # Writes to input collections go to leader
+    use-server leader if { path_beg -i /v1/inputs/ }
+    server leader skip_leader:8081 weight 0
+    # Other (stream-creation) requests go to followers
+    balance roundrobin
+    server follower1 skip_follower1:8081
+    server follower2 skip_follower2:8081
+    server follower3 skip_follower3:8081
+
+# Skip streaming backend
+backend stream
     mode http
     http-request set-path /v1/streams/%[path,field(4,/)]
+    use-server %[req.hdr(Follower-Prefix)] if TRUE
     server follower1 skip_follower1:8080
-backend follower2
-    mode http
-    http-request set-path /v1/streams/%[path,field(4,/)]
     server follower2 skip_follower2:8080
-backend follower3
-    mode http
-    http-request set-path /v1/streams/%[path,field(4,/)]
     server follower3 skip_follower3:8080
 
 backend api

--- a/examples/hackernews/web_service/app.py
+++ b/examples/hackernews/web_service/app.py
@@ -21,8 +21,7 @@ app = Flask(__name__)
 
 app.secret_key = b"53cr37_changeme"
 
-
-SKIP_CONTROL_URL = "http://haproxy:8081/v1"
+SKIP_CONTROL_URL = os.environ.get("SKIP_CONTROL_URL")
 
 
 @app.before_request

--- a/examples/hackernews/web_service/app.py
+++ b/examples/hackernews/web_service/app.py
@@ -22,16 +22,7 @@ app = Flask(__name__)
 app.secret_key = b"53cr37_changeme"
 
 
-SKIP_WRITE_URL = (
-    "http://skip_leader:8081/v1"
-    if "DISTRIBUTED_MODE" in os.environ
-    else "http://reactive_service:8081/v1"
-)
-SKIP_READ_URL = (
-    "http://skip_followers:8081/v1"
-    if "DISTRIBUTED_MODE" in os.environ
-    else "http://reactive_service:8081/v1"
-)
+SKIP_CONTROL_URL = "http://haproxy:8081/v1"
 
 
 @app.before_request
@@ -74,7 +65,7 @@ def login():
 
     # TODO: Error handling.
     requests.patch(
-        f"{SKIP_WRITE_URL}/inputs/sessions",
+        f"{SKIP_CONTROL_URL}/inputs/sessions",
         json=[[session["session_id"], [user_session]]],
     )
 
@@ -84,7 +75,7 @@ def login():
 @app.post("/logout")
 def logout():
     requests.patch(
-        f"{SKIP_WRITE_URL}/inputs/sessions",
+        f"{SKIP_CONTROL_URL}/inputs/sessions",
         json=[[session["session_id"], []]],
     )
 
@@ -97,7 +88,7 @@ def logout():
 def user_session():
     if "text/event-stream" in request.accept_mimetypes:
         resp = requests.post(
-            f"{SKIP_READ_URL}/streams/sessions",
+            f"{SKIP_CONTROL_URL}/streams/sessions",
             json={
                 "session_id": session["session_id"],
             },
@@ -108,7 +99,7 @@ def user_session():
 
     else:
         resp = requests.post(
-            f"{SKIP_READ_URL}/snapshot/sessions",
+            f"{SKIP_CONTROL_URL}/snapshot/sessions",
             json={
                 "session_id": session["session_id"],
             },
@@ -137,7 +128,7 @@ def posts_index():
 
     if "text/event-stream" in request.accept_mimetypes:
         resp = requests.post(
-            f"{SKIP_READ_URL}/streams/posts",
+            f"{SKIP_CONTROL_URL}/streams/posts",
             json={
                 "limit": 10,
                 "session_id": session["session_id"],
@@ -151,7 +142,7 @@ def posts_index():
 
     else:
         resp = requests.post(
-            f"{SKIP_READ_URL}/snapshot/posts",
+            f"{SKIP_CONTROL_URL}/snapshot/posts",
             json={
                 "limit": 10,
                 "session_id": session["session_id"],


### PR DESCRIPTION
This PR hands control of load-balancing back to ... the load-balancer, routing web-service -> skip traffic through the reverse proxy.  That also means the web service now need not care whether the skip service is running in "distributed mode" or not.

@beauby I think this is more or less what you had in mind -- what do you think?  One thing I didn't bother with yet that is probably important in practice is locking down the `:8081` listeners in the haproxy configs to not accept any external IPs.
