### PR TITLE
Print reason for service initialization failure

### DIFF
--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -129,7 +129,10 @@ export async function runService(
       throw e;
     }
   }
-  const instance = await runtime.initService(service);
+  const instance = await runtime.initService(service).catch((e) => {
+    console.error("Service could not be initialized; reason: ", e);
+    throw e;
+  });
   const controlHttpServer = controlService(instance).listen(
     options.control_port,
     () => {

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -136,7 +136,10 @@ export async function runService(
       throw e;
     }
   }
-  const instance = await runtime.initService(service);
+  const instance = await runtime.initService(service).catch((e: unknown) => {
+    console.error("Service could not be initialized; reason: ", e);
+    throw e;
+  });
 
   const controlApp = express();
   controlApp.use(logger_middleware);


### PR DESCRIPTION
Would have saved me some headache earlier... without this, errors during service initialization are silently dropped and the process exits 0 without ever spinning up servers.