### PR TITLE
Support for binary releases of the skip runtime, for native node addon

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -55,7 +55,7 @@ jobs:
           submodules: true
       - run:
           name: Typecheck and lint typescript sources
-          command: SKIPRUNTIME=$(pwd)/build/skipruntime npm install && npm run build && npm run lint
+          command: make check-ts
 
   compiler:
     docker:

--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -152,15 +152,23 @@ jobs:
           KAFKA_CFG_LISTENERS: "PLAINTEXT://:9092,CONTROLLER://:9093"
           KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@localhost:9093"
           KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+    resource_class: xlarge
     steps:
       - custom-checkout:
           submodules: true
+      - setup_remote_docker
       - run:
           name: Run wasm skip runtime tests
           no_output_timeout: 10m
           command: |
             mkdir -p ~/test-results
             make test-skipruntime-ts
+      - run:
+          name: Run native addon unreleased test
+          no_output_timeout: 10m
+          command: |
+            cd skipruntime-ts/tests/native_addon_unreleased
+            ./run.sh
       - store_test_results:
           path: ~/test-results/skipruntime.xml
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,25 +24,8 @@ make
 
 ### Installing the toolchain
 
-```make install prefix=<instalation_dir_prefix>```
+```make install prefix=<installation_dir_prefix>```
 
-`<instalation_dir_prefix>/bin` and `<instalation_dir_prefix>/lib` directories will be created.
+`<installation_dir_prefix>/bin` and `<installation_dir_prefix>/lib` directories will be created.
 
-Then make sure <instalation_dir_prefix>/bin is available in $PATH.
-
-## Native Skip runtime
-
-The native runtime is currently only available for Node.
-
-### Building the native runtime
-
-To build the native Skip runtime, you need the Skiplang toolchain. You can install the tool chain by following the instructions above.
-
-```sh
-cd skip
-skargo b -r --manifest-path=skipruntime-ts/native/Skargo.toml --lib --out-dir=<target_dir>
-```
-
-### Installing the `@skipruntime/native` package
-
-```SKIPRUNTIME=<target_dir> npm install @skipruntime/native```
+Then make sure `<installation_dir_prefix>/bin` is available in `$PATH`.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # this builds the artifacts of this repository, orchestrating the
 # various build systems
 
-.PHONY: all
-all: npm build/skdb build/init.sql
+.PHONY: default
+default: check check-ts
 
 PRETTIER_LOG_LEVEL?=warn
 
@@ -11,6 +11,9 @@ SKARGO_PROFILE?=release
 SKDB_WASM=sql/target/wasm32-unknown-unknown/$(SKARGO_PROFILE)/skdb.wasm
 SKDB_BIN=sql/target/host/$(SKARGO_PROFILE)/skdb
 SDKMAN_DIR?=$(HOME)/.sdkman
+
+.PHONY: skdb
+skdb: npm build/skdb build/init.sql
 
 ################################################################################
 # skdb wasm + js client

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ SKARGO_PROFILE?=release
 SKDB_WASM=sql/target/wasm32-unknown-unknown/$(SKARGO_PROFILE)/skdb.wasm
 SKDB_BIN=sql/target/host/$(SKARGO_PROFILE)/skdb
 SDKMAN_DIR?=$(HOME)/.sdkman
-SKIPRUNTIME?=$(CURDIR)/build/skipruntime
-
-export SKIPRUNTIME
 
 ################################################################################
 # skdb wasm + js client
@@ -75,9 +72,9 @@ check:
 	find * -name Skargo.toml -exec sh -c 'bin/cd_sh $$(dirname {}) "skargo check"' \;
 
 .PHONY: check-ts
-check-ts:
-	npm install
-	bin/check-ts.sh
+check-ts:	
+#	delegate to pick up build-time config for libskipruntime
+	${MAKE} -C skipruntime-ts check-ts
 
 .PHONY: check-sh
 check-sh:

--- a/bin/README.md
+++ b/bin/README.md
@@ -44,3 +44,35 @@ changes, the addon package version must be bumped.)  To update from version
    building/running with the new versions, add those changes to your PR, and
    land it!
 
+8. Release the Skip runtime binaries, as below.
+
+## Release Skip runtime binaries
+
+The `@skipruntime/native` node addon dynamically links to a native library
+containing the Skip runtime. The versions of the NPM package and binary
+release must match. Therefore whenever NPM packages are released the binary
+runtime release must be as well. The installation scripts download the
+binary runtime library from a github release tagged with `vM.N.O` where
+`M.N.O` is the version of the NPM packages.
+
+The release procedure for the runtime library binary is:
+
+1. Run `bin/build_runtime.sh` from a clean repo with HEAD at the commit that
+   was/will be used for version `M.N.O` of the NPM packages. This leaves
+   `libskipruntime.so-<OS>-<ARCH>` files in the `build` directory.
+
+2. Visit https://github.com/skiplabs/skip/releases/new
+
+3. Click "Choose a tag"
+
+4. Enter `vM.N.O` as the tag name
+
+5. Click "Create new tag...on publish"
+
+6. Enter a release title and description
+
+7. Attach `build/libskipruntime.so-linux-arm64` and `build/libskipruntime.so-linux-amd64`
+
+8. Click "Publish release"
+
+9. Test the new release by running `cd skipruntime-ts/tests/native_addon/ ; ./run.sh`

--- a/bin/README.md
+++ b/bin/README.md
@@ -13,8 +13,11 @@ clone, you can run `release_docker_ci_images.sh`.
 
 We keep all **public** NPM packages (i.e. `@skipruntime/*`, `@skiplabs/skip`,
 and `@skip-adapter/*`) at the same version so as to keep updates, documentation,
-and version management simple.  To update from version `$OLD` to version `$NEW`,
-perform the following steps:
+and version management simple.  (Note that the build script of the native addon
+relies on this convention since it links to the skipruntime library with the same
+version as the addon package, so whenever anything in the skipruntime library
+changes, the addon package version must be bumped.)  To update from version
+`$OLD` to version `$NEW`, perform the following steps:
 
 1. Check out `main` and make sure your working copy is clean
 
@@ -24,7 +27,7 @@ perform the following steps:
 
 3. Bump _all_ `./skipruntime-ts/**/package.json` version strings and
    inter-dependencies from `$OLD` to `$NEW`, e.g. by running `sed -i ''
-   's/$OLD/$NEW/g' $(g grep -l $OLD skipruntime-ts/**/package.json)`.
+   's/$OLD/$NEW/g' $(git grep -l $OLD skipruntime-ts/**/package.json)`.
 
 4. Build and test with `make -C skipruntime-ts build test`.
 

--- a/bin/build_runtime.sh
+++ b/bin/build_runtime.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+# Script to build skipruntime binary release
+# Usage: build_runtime.sh [arch]
+# Example: build_runtime.sh arm64
+# Default: arm64,amd64
+
+set -xeuo pipefail
+
+if [ $# -gt 0 ]; then
+    ARCH="$1"
+else
+    ARCH="arm64,amd64"
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_DIR="$SCRIPT_DIR/../"
+cd "$REPO_DIR" || exit
+
+git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
+echo ".git" >> .dockerignore
+
+builder=$(docker buildx create --use)
+
+for arch in ${ARCH//,/ }; do
+    {
+        docker buildx build \
+            --progress=plain \
+            --platform="linux/$arch" \
+            --file=skipruntime-ts/Dockerfile \
+            --output=type=local,dest=build/linux_$arch \
+            .
+    } > "build_$arch.log" 2>&1 &
+done
+wait
+
+docker buildx stop "$builder"
+docker buildx rm "$builder"
+
+git restore .dockerignore
+
+for arch in ${ARCH//,/ }; do
+    echo "=== Build log for linux/$arch ==="
+    cat "build_$arch.log"
+    rm "build_$arch.log"
+    mv "build/linux_$arch/libskipruntime.so" "build/libskipruntime.so-linux-$arch"
+    rmdir "build/linux_$arch"
+done

--- a/bin/install_runtime.sh
+++ b/bin/install_runtime.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Script to download and install skipruntime binary release
+# Usage: VERSION=<version> PREFIX=<prefix dir> SOURCE=<source url> TMP=<tmp dir> install_runtime.sh
+
+set -euo pipefail
+
+# overridable parameters
+## version to install
+VERSION=${VERSION:-$(npm view @skiplabs/skip version)}
+
+## url from which to download release
+SOURCE=${SOURCE:-'https://github.com/skiplabs/skip/releases/download'}
+
+## directory to install into
+PREFIX=${PREFIX:-'/usr/local'}
+
+## directory for downloaded files
+TMP=${TMPDIR:-'/tmp'}
+
+# check operating system
+OS=$(uname --kernel-name || echo unknown)
+OS=${OS,,}
+if [ ! "$OS" = "linux" ] ; then
+  echo "unsupported operating system: $OS"; exit 1
+fi
+
+# check architecture
+ARCH=$(uname --machine || echo unknown)
+case "$ARCH" in
+  aarch64) ARCH="arm64";;
+  amd64|x86_64) ARCH="amd64";;
+  *) echo "unsupported architecture: $ARCH"; exit 1
+esac
+
+SKIPRUNTIME_BIN="libskipruntime.so-${OS}-${ARCH}"
+SKIPRUNTIME_BIN_URL="${SOURCE}/v${VERSION}/${SKIPRUNTIME_BIN}"
+TMP_BIN="${TMP}/${SKIPRUNTIME_BIN}"
+
+# download binary release to tmp dir
+if command -v curl >/dev/null; then
+  curl --fail --silent --show-error --output "${TMP_BIN}" --location "${SKIPRUNTIME_BIN_URL}"
+else
+  wget --quiet --output-document="${TMP_BIN}" "${SKIPRUNTIME_BIN_URL}"
+fi
+
+# install into prefix
+if [ ! -w "${PREFIX}/lib/" ]; then
+  sudo install "${TMP_BIN}" "${PREFIX}/lib/libskipruntime-${VERSION}.so"
+else
+  install "${TMP_BIN}" "${PREFIX}/lib/libskipruntime-${VERSION}.so"
+fi

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -14,6 +14,7 @@ usage() {
     echo "Usage: $0 NAME:TAG+"
     echo "  where NAME:TAG is one of"
     echo "    skiplang:latest"
+    echo "    skiplang-bin-builder:latest"
     echo "    skip:latest"
     echo "    skdb:latest"
     echo "    skdb-base:latest"
@@ -30,6 +31,9 @@ for name_tag in "$@"; do
   case "${name_tag%:latest}" in
     skiplang)
       BUILD_SKIPLANG=true
+      ;;
+    skiplang-bin-builder)
+      BUILD_SKIPLANG_BIN_BUILDER=true
       ;;
     skip)
       BUILD_SKIP=true
@@ -71,6 +75,10 @@ dockerbuild () {
 
 if ${BUILD_SKIPLANG:-false}; then
   dockerbuild --file Dockerfile --target skiplang --tag skiplabs/skiplang:latest
+fi
+
+if ${BUILD_SKIPLANG_BIN_BUILDER:-false}; then
+  dockerbuild --file skiplang/Dockerfile --tag skiplabs/skiplang-bin-builder:latest
 fi
 
 if ${BUILD_SKIP:-false}; then

--- a/bin/release_docker_ci_images.sh
+++ b/bin/release_docker_ci_images.sh
@@ -5,4 +5,4 @@
 set -e
 set -x
 
-"$(dirname -- "${BASH_SOURCE[0]}")"/release_docker.sh skiplang skip skdb-base
+"$(dirname -- "${BASH_SOURCE[0]}")"/release_docker.sh skiplang skiplang-bin-builder skip skdb-base

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -1,0 +1,37 @@
+# skiplabs/skiplang-bin-builder
+# Dockerfile to build skiplang toolchain to build binary releases
+
+# aim to start from an image with a version of glibc that is as widely
+# compatible as possible while still receiving security updates
+FROM debian:stable-slim AS base
+
+ARG LLVM_VERSION=20
+
+RUN apt-get update --quiet
+RUN apt-get install --quiet --yes gnupg lsb-release make software-properties-common wget
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh ${LLVM_VERSION} && \
+    rm llvm.sh && \
+    update-alternatives \
+      --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 101 \
+      --slave /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} \
+      --slave /usr/bin/llc llc /usr/bin/llc-${LLVM_VERSION} \
+      --slave /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-${LLVM_VERSION} \
+      --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_VERSION} \
+      --slave /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-${LLVM_VERSION}
+
+ENV CC=clang
+ENV CXX=clang++
+
+FROM base AS skiplang
+
+COPY ./skiplang /work/skiplang
+
+WORKDIR /work/skiplang/compiler
+RUN make clean && make STAGE=0
+
+FROM base AS final
+
+COPY --from=skiplang /work/skiplang/compiler/stage0/bin/ /usr/bin/
+COPY --from=skiplang /work/skiplang/compiler/stage0/lib/ /usr/lib/

--- a/skipruntime-ts/Dockerfile
+++ b/skipruntime-ts/Dockerfile
@@ -1,0 +1,14 @@
+# Dockerfile to build skipruntime binary release
+# see also: ../skiplang/Dockerfile and ../bin/build_runtime.sh
+
+FROM skiplabs/skiplang-bin-builder AS build
+
+COPY ./skiplang /work/skiplang
+COPY ./skipruntime-ts /work/skipruntime-ts
+
+WORKDIR /work
+RUN skargo build --release --lib --manifest-path=skipruntime-ts/skiplang/ffi/Skargo.toml --out-dir=build/skipruntime
+
+FROM scratch
+COPY --from=build /work/build/skipruntime/libskipruntime.so /libskipruntime.so
+ENTRYPOINT ["/libskipruntime.so"]

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -2,20 +2,31 @@ SHELL := /bin/bash
 
 SKARGO_PROFILE?=release
 NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select((startswith(\"sql\") or contains(\"examples\")) | not)] | map(\"-w \" + .) | .[]" ../package.json)
-SKIPRUNTIME?=$(realpath $(CURDIR)/..)/build/skipruntime
 
-export SKIPRUNTIME
+.PHONY: default
+default: install
+
+export LDFLAGS=-L$(realpath $(CURDIR)/..)/build/skipruntime/
+export LD_LIBRARY_PATH=$(realpath $(CURDIR)/..)/build/skipruntime/
+
+.PHONY: libskipruntime
+libskipruntime:
+	skargo build --release --lib --manifest-path=skiplang/ffi/Skargo.toml --out-dir=../build/skipruntime/
 
 .PHONY: install
-install:
+install: libskipruntime
 	../bin/cd_sh .. "npm install $(NPM_WORKSPACES)"
 
 .PHONY: install-all
-install-all:
+install-all: libskipruntime
 	../bin/cd_sh .. "npm install"
 
+.PHONY: check-ts
+check-ts: install-all
+	../bin/check-ts.sh
+
 .PHONY: build
-build:
+build: libskipruntime
 	../bin/cd_sh .. "npm run build $(NPM_WORKSPACES) --if-present"
 
 bunrun-%: build

--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -6,8 +6,12 @@ NPM_WORKSPACES=$(shell jq --raw-output "[.workspaces[] | select((startswith(\"sq
 .PHONY: default
 default: install
 
+# tell skipruntime-ts/addon build script to link unversioned libskipruntime.so
+export SKIPRUNTIME_VERSION=dev
+# config linker to find libskipruntime.so
 export LDFLAGS=-L$(realpath $(CURDIR)/..)/build/skipruntime/
 export LD_LIBRARY_PATH=$(realpath $(CURDIR)/..)/build/skipruntime/
+
 
 .PHONY: libskipruntime
 libskipruntime:

--- a/skipruntime-ts/addon/README.md
+++ b/skipruntime-ts/addon/README.md
@@ -5,18 +5,35 @@ _Either_ this package or its WebAssembly analogue
 [`@skipruntime/wasm`](https://www.npmjs.com/package/@skipruntime/wasm) is
 required to run a Skip reactive service.
 
-See the [docs](https://skiplabs.io/docs) for more details.
+See the [docs](https://skiplabs.io/docs/getting_started#installation) for more details.
 
 ## Installation
 
-Install directly using npm (`npm i @skipruntime/native`)
+Installing the native add-on version of the Skip runtime is done in two steps:
+1. Install the `libskipruntime` native library; and then
+2. Install the `@skipruntime/native` npm package.
+The versions of the two *must* match.
 
-Note that, if this package is installed alongside the
-[`@skiplabs/skip`](https://www.npmjs.com/package/@skiplabs/skip) meta-package,
-you will pull in both this native add-on _and_ the WebAssembly
-[runtime](https://www.npmjs.com/package/@skipruntime/wasm); if a minimal
-installation is required, then specify exactly the component packages that you
-need and avoid `@skiplabs/skip`.
+Installation can be performed by executing:
+```bash
+# calculate the version of the skipruntime
+  VERSION=$(npm install --dry-run @skipruntime/native | grep native | cut -d' ' -f3) \
+# install the skipruntime binary release
+&& wget --quiet --output-document=- \
+      https://raw.githubusercontent.com/skiplabs/skip/refs/tags/v${VERSION}/bin/install_runtime.sh \
+  | bash - \
+# install the skipruntime native node addon package
+&& npm install @skipruntime/native
+```
+This command uses `npm install --dry-run` to determine the version of the runtime to install, but any mechanism that ensures the versions match will suffice.
+If the versions of the npm package and binary runtime do not match, `npm install @skipruntime/native` will fail with an error such as:
+```
+npm error /usr/bin/ld: cannot find -lskipruntime-1.0.0: No such file or directory
+```
+
+It may be helpful to consult the small [Dockerfile](https://github.com/skiplabs/skip/blob/main/skipruntime-ts/tests/native_addon/Dockerfile) that installs the native node addon and runs a trivial Skip service.
+
+Note that, if this package is installed alongside the [`@skiplabs/skip`](https://www.npmjs.com/package/@skiplabs/skip) meta-package, you will pull in both this native add-on _and_ the WebAssembly [runtime](https://www.npmjs.com/package/@skipruntime/wasm); if a minimal installation is required, then specify exactly the component packages that you need and avoid `@skiplabs/skip`.
 
 ## Support
 

--- a/skipruntime-ts/addon/binding.gyp
+++ b/skipruntime-ts/addon/binding.gyp
@@ -11,7 +11,10 @@
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "libraries": ["-lskipruntime -Wl,--require-defined=SKIP_new_Obstack"]
+      "libraries": [
+        "-lskipruntime<!(echo $VERSION)",
+        "-Wl,--require-defined=SKIP_new_Obstack"
+      ]
     }
   ]
 }

--- a/skipruntime-ts/addon/binding.gyp
+++ b/skipruntime-ts/addon/binding.gyp
@@ -12,7 +12,7 @@
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
       "libraries": [
-        "-L<!(realpath $SKIPRUNTIME) -lskip-runtime-ts -Wl,--require-defined=SKIP_new_Obstack"
+        "-L<!(realpath $SKIPRUNTIME) -lskipruntime -Wl,--require-defined=SKIP_new_Obstack"
       ]
     }
   ]

--- a/skipruntime-ts/addon/binding.gyp
+++ b/skipruntime-ts/addon/binding.gyp
@@ -11,9 +11,7 @@
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      "libraries": [
-        "-L<!(realpath $SKIPRUNTIME) -lskipruntime -Wl,--require-defined=SKIP_new_Obstack"
-      ]
+      "libraries": ["-lskipruntime -Wl,--require-defined=SKIP_new_Obstack"]
     }
   ]
 }

--- a/skipruntime-ts/addon/calculate_version.sh
+++ b/skipruntime-ts/addon/calculate_version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Script to calculate the version of the skipruntime library to link
+# Used by build script in package.json
+#
+# Set SKIPRUNTIME_VERSION to "dev" to link unversioned skipruntime.so
+# Set SKIPRUNTIME_VERSION to a specific version to link that version
+# Unset SKIPRUNTIME_VERSION to read version from package.json
+
+if [ "$SKIPRUNTIME_VERSION" = "dev" ]; then
+  echo ""
+elif [ -n "$SKIPRUNTIME_VERSION" ]; then
+  echo "-$SKIPRUNTIME_VERSION"
+else
+  echo "-$(npm pkg get version | tr -d '{}" \n' | cut -d: -f2)"
+fi

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -7,8 +7,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "prepare": "skargo build -r --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=../../build/skipruntime",
-    "build": "skargo build -r --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=../../build/skipruntime && tsc && SKIPRUNTIME=$(realpath ../../build/skipruntime) node-gyp configure && node-gyp build",
+    "build": "tsc && node-gyp configure && node-gyp build",
     "clean": "rm -rf dist && node-gyp clean",
     "lint": "eslint"
   },

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -7,7 +7,8 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc && node-gyp configure && node-gyp build",
+    "build": "tsc",
+    "install": "VERSION=$(./calculate_version.sh) node-gyp rebuild",
     "clean": "rm -rf dist && node-gyp clean",
     "lint": "eslint"
   },

--- a/skipruntime-ts/addon/src/common.cc
+++ b/skipruntime-ts/addon/src/common.cc
@@ -138,7 +138,8 @@ void SKTryCatchVoid(Isolate* isolate, Local<Function> fn, Local<Value> recv,
                     std::function<void(Isolate*)> failure) {
   Local<Context> context = isolate->GetCurrentContext();
   TryCatch tryCatch(isolate);
-  (void)fn->Call(context, recv, argc, argv);
+  auto result = fn->Call(context, recv, argc, argv);
+  (void)result;
   if (!tryCatch.HasCaught()) {
     success(isolate);
   } else {

--- a/skipruntime-ts/addon/src/main.cc
+++ b/skipruntime-ts/addon/src/main.cc
@@ -22,7 +22,8 @@ void InitToBinding(const v8::FunctionCallbackInfo<v8::Value>& args) {
   skipruntime::SetFromJSBinding(isolate, binding);
 }
 
-void Initialize(v8::Local<v8::Object> exports) {
+void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> module,
+                void* context) {
   NODE_SET_METHOD(exports, "runWithGC", skbinding::RunWithGC);
   NODE_SET_METHOD(exports, "getErrorObject", skbinding::GetErrorObject);
   NODE_SET_METHOD(exports, "getJsonBinding", skjson::GetBinding);

--- a/skipruntime-ts/skiplang/ffi/Skargo.toml
+++ b/skipruntime-ts/skiplang/ffi/Skargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "skip-runtime-ts"
+name = "skipruntime"
 version = "0.1.0"
 
 [dependencies]

--- a/skipruntime-ts/tests/examples/database.sh
+++ b/skipruntime-ts/tests/examples/database.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'database' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/database.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/database.js >/dev/null &
 else
     echo "Running 'database' example on @skipruntime/wasm"
     node dist/database.js >/dev/null &

--- a/skipruntime-ts/tests/examples/departures.sh
+++ b/skipruntime-ts/tests/examples/departures.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'departures' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/departures.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/departures.js >/dev/null &
 else
     echo "Running 'departures' example on @skipruntime/wasm"
     node dist/departures.js >/dev/null &

--- a/skipruntime-ts/tests/examples/groups.sh
+++ b/skipruntime-ts/tests/examples/groups.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'groups' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/groups.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/groups.js >/dev/null &
 else
     echo "Running 'groups' example on @skipruntime/wasm"
     node dist/groups.js >/dev/null &

--- a/skipruntime-ts/tests/examples/remote.sh
+++ b/skipruntime-ts/tests/examples/remote.sh
@@ -14,8 +14,8 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'remote' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/remote.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/remote.js >/dev/null &
 else
     echo "Running 'remote' example on @skipruntime/wasm"
     node dist/sum.js >/dev/null &

--- a/skipruntime-ts/tests/examples/sheet.sh
+++ b/skipruntime-ts/tests/examples/sheet.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'sheet' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sheet.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/sheet.js >/dev/null &
 else
     echo "Running 'sheet' example on @skipruntime/wasm"
     node dist/sheet.js >/dev/null &

--- a/skipruntime-ts/tests/examples/sum.sh
+++ b/skipruntime-ts/tests/examples/sum.sh
@@ -14,7 +14,7 @@ fi
 
 if [ "$3" = "native" ]; then
     echo "Running 'sum' example on @skipruntime/native"
-    LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
+    SKIP_PLATFORM="native" node dist/sum.js >/dev/null &
 else
     echo "Running 'sum' example on @skipruntime/wasm"
     node dist/sum.js >/dev/null &

--- a/skipruntime-ts/tests/native_addon/Dockerfile
+++ b/skipruntime-ts/tests/native_addon/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:latest
+
+# install dependencies needed to build the node addon
+RUN apt-get update --quiet \
+ && apt-get install --quiet --yes g++ make python3 wget \
+ && wget --quiet --output-document=- https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install --quiet --yes nodejs \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && npm install --global typescript
+
+# copy the test code
+COPY package.json test.ts /work/
+
+WORKDIR /work
+
+# calculate the version of the skipruntime
+RUN VERSION=$(npm install --dry-run @skipruntime/native | grep native | cut -d' ' -f3) \
+# install the skipruntime binary release
+ && wget --quiet --output-document=- \
+      https://raw.githubusercontent.com/skiplabs/skip/refs/tags/v${VERSION}/bin/install_runtime.sh \
+  | bash - \
+# install the skipruntime native node addon package
+ && npm install @skipruntime/native
+
+# build and run the test
+RUN npm install
+CMD ["bash", "-c", "tsc --module node16 test.ts && LD_LIBRARY_PATH=/usr/local/lib node test.js"]

--- a/skipruntime-ts/tests/native_addon/package.json
+++ b/skipruntime-ts/tests/native_addon/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@skipruntime/core": "",
+    "@skipruntime/native": ""
+  }
+}

--- a/skipruntime-ts/tests/native_addon/run.sh
+++ b/skipruntime-ts/tests/native_addon/run.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+set -euo pipefail
+
+# build, run, and remove the test container
+TEMP_FILE=$(mktemp)
+docker build --iidfile "$TEMP_FILE" .
+docker run --rm "$(cat "$TEMP_FILE")"
+rm "$TEMP_FILE"

--- a/skipruntime-ts/tests/native_addon/test.ts
+++ b/skipruntime-ts/tests/native_addon/test.ts
@@ -1,0 +1,16 @@
+import type { SkipService } from "@skipruntime/core";
+import { initService } from "@skipruntime/native";
+
+const emptyService: SkipService = {
+  initialData: {},
+  resources: {},
+  createGraph(inputCollections) {
+    return inputCollections;
+  },
+};
+
+console.log("starting service...");
+const service = await initService(emptyService);
+console.log("closing service...");
+await service.close();
+console.log("done");

--- a/skipruntime-ts/tests/native_addon_unreleased/Dockerfile
+++ b/skipruntime-ts/tests/native_addon_unreleased/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest
+
+# install dependencies needed to build the node addon
+RUN apt-get update --quiet \
+ && apt-get install --quiet --yes g++ make python3 wget \
+ && wget --quiet --output-document=- https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install --quiet --yes nodejs \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && npm install --global typescript
+
+# copy the npm pack archives, libskipruntime.so files, and install_runtime.sh
+COPY build /work/build
+
+# copy the test code
+COPY package.json test.ts /work/
+
+WORKDIR /work
+
+# calculate the version of the skipruntime
+RUN VERSION=$(npm install --dry-run @skipruntime/native | grep native | cut -d' ' -f3) \
+# specify to obtain the binary release from a local directory
+ && SOURCE="file:///work/build" \
+# install the skipruntime binary release
+    build/install_runtime.sh \
+# install the skipruntime native node addon package
+ && npm install @skipruntime/native
+
+# build and run the test
+RUN npm install
+CMD ["bash", "-c", "tsc --module node16 test.ts && LD_LIBRARY_PATH=/usr/local/lib node test.js"]

--- a/skipruntime-ts/tests/native_addon_unreleased/package.json
+++ b/skipruntime-ts/tests/native_addon_unreleased/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@skipruntime/core": "file:build/skipruntime-core.tgz",
+    "@skipruntime/native": "file:build/skipruntime-native.tgz"
+  }
+}

--- a/skipruntime-ts/tests/native_addon_unreleased/run.sh
+++ b/skipruntime-ts/tests/native_addon_unreleased/run.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+# Test script for native addon using current sources
+# Usage: run.sh [arch]
+# Example: run.sh arm64,amd64
+# Default: current Docker architecture
+
+set -xeuo pipefail
+
+if [ $# -gt 0 ]; then
+    ARCH="$1"
+else
+    ARCH=$(docker version --format '{{.Server.Arch}}')
+fi
+
+# build and copy the runtime
+../../../bin/build_runtime.sh "$ARCH"
+VERSION=$(jq --raw-output .version ../../metapackage/package.json)
+mkdir -p build/v"$VERSION"
+cp ../../../build/libskipruntime.so-* build/v"$VERSION"
+
+# copy the install script
+cp ../../../bin/install_runtime.sh build/
+
+# build and pack npm packages
+make -C ../.. install
+for pkg in core addon; do
+    (cd ../../"$pkg" && npm run build && npm pack)
+    mv ../../"$pkg"/skipruntime-*.tgz build/skipruntime-${pkg/addon/native}.tgz
+done
+
+# build, run, and remove the test container
+for arch in ${ARCH//,/ }; do
+    echo "Testing linux/$arch..."
+    TEMP_FILE=$(mktemp)
+    docker build --platform="linux/$arch" --iidfile "$TEMP_FILE" .
+    docker run --rm "$(cat "$TEMP_FILE")"
+    rm "$TEMP_FILE"
+done

--- a/skipruntime-ts/tests/native_addon_unreleased/test.ts
+++ b/skipruntime-ts/tests/native_addon_unreleased/test.ts
@@ -1,0 +1,16 @@
+import type { SkipService } from "@skipruntime/core";
+import { initService } from "@skipruntime/native";
+
+const emptyService: SkipService = {
+  initialData: {},
+  resources: {},
+  createGraph(inputCollections) {
+    return inputCollections;
+  },
+};
+
+console.log("starting service...");
+const service = await initService(emptyService);
+console.log("closing service...");
+await service.close();
+console.log("done");

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "lint": "eslint src/",
-    "test": "LD_LIBRARY_PATH=$(realpath ../../build/skipruntime) mocha"
+    "test": "mocha"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/skipruntime-ts/wasm/src/skipruntime_init.ts
+++ b/skipruntime-ts/wasm/src/skipruntime_init.ts
@@ -26,13 +26,13 @@ async function wasmUrl(): Promise<URL | string> {
   //@ts-expect-error  ImportMeta is incomplete
   if (import.meta.env || import.meta.webpack) {
     const imported = (await import(
-      //@ts-expect-error  Cannot find module './skstore.wasm?url' or its corresponding type declarations.
-      "./libskip-runtime-ts.wasm?url"
+      //@ts-expect-error  Cannot find module './libskipruntime.wasm?url' or its corresponding type declarations.
+      "./libskipruntime.wasm?url"
     )) as Imported;
     return imported.default;
   }
 
-  return new URL("./libskip-runtime-ts.wasm", import.meta.url);
+  return new URL("./libskipruntime.wasm", import.meta.url);
 }
 
 export async function initServiceFor(

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -3,9 +3,6 @@ SHELL := /bin/bash
 SKARGO_PROFILE?=release
 
 SCRIPT_DIR=$(shell dirname $(shell realpath $(firstword $(MAKEFILE_LIST))))
-SKIPRUNTIME?=$(realpath $(SCRIPT_DIR)/..)/build/skipruntime
-
-export SKIPRUNTIME
 
 .PHONY: check-src
 check-src: build
@@ -20,7 +17,8 @@ check-all: check-src check-tests
 
 .PHONY: build
 build:
-	../bin/cd_sh .. "npm install && npm run build -w skdb -w skdb-tests"
+	${MAKE} -C ../skipruntime-ts install-all
+	../bin/cd_sh .. "npm run build -w skdb -w skdb-tests"
 
 .PHONY: clean
 clean:

--- a/www/docs/getting_started.md
+++ b/www/docs/getting_started.md
@@ -22,7 +22,7 @@ The Wasm runtime works with both `node` and `bun`, but is limited to Wasm's 32-b
 The native runtime does not have this limitation, but it is currently only available for Node and is a bit more involved to install.
 
 The Wasm runtime is installed by default, but a package using Skip can choose to explicitly depend on only `@skipruntime/core`, `@skipruntime/server`, and `@skipruntime/native` to reduce weight.
-The Wasm runtime can be installed separately with `npm install @skipruntime/wasm` and the native runtime by following the [instructions](https://github.com/SkipLabs/skip/blob/main/INSTALL.md).
+The Wasm runtime can be installed separately with `npm install @skipruntime/wasm` and the native runtime by following the [instructions](https://github.com/SkipLabs/skip/blob/main/skipruntime-ts/addon/README.md#installation).
 
 ## Introduction
 


### PR DESCRIPTION
This PR changes the build, adds release and install scripts, and updates docs to support building the native node addon against a precompiled skipruntime library. The aim is to enable end users to first install the binary skip runtime to their system and then install the addon just as a standard npm dependency, without needing to build the skiplang toolchain or have it installed.

In short, this PR:

- adapts the npm build (package.json and binding.gyp files) to expect the skipruntime library to be installed on the host

- adapts the dev build (Makefiles) to build the skipruntime library from the current sources, and set the other builds and tests to use this current version

- adds scripts to build and install the binary runtime library

- adds a small test that installs and uses the native node addon in a container

- updates user and dev docs

At a high level, the build changes mean that the npm commands use the system-installed skipruntime, and are therefore meant for use by end users; while the make commands use the skipruntime built from current sources, and are therefore meant for development and testing use.