### PR TITLE
[skiplang/skc] Run IR to IR opt passes for wasm.

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -39,6 +39,7 @@ for step in "${steps[@]}"; do
                 --slave /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$LLVM_VERSION \
                 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-$LLVM_VERSION \
                 --slave /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-$LLVM_VERSION \
+                --slave /usr/bin/opt opt /usr/bin/opt-$LLVM_VERSION \
                 --slave /usr/bin/wasm-ld wasm-ld /usr/bin/wasm-ld-$LLVM_VERSION
             ;;
         skipruntime-deps)

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -19,7 +19,8 @@ RUN wget https://apt.llvm.org/llvm.sh && \
       --slave /usr/bin/llc llc /usr/bin/llc-${LLVM_VERSION} \
       --slave /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-${LLVM_VERSION} \
       --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${LLVM_VERSION} \
-      --slave /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-${LLVM_VERSION}
+      --slave /usr/bin/llvm-link llvm-link /usr/bin/llvm-link-${LLVM_VERSION} \
+      --slave /usr/bin/opt opt /usr/bin/opt-${LLVM_VERSION}
 
 ENV CC=clang
 ENV CXX=clang++

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -63,6 +63,11 @@ fun link(
       Array["llvm-link", llFile].concat(Array["-o", bcFile]),
       config.verbose,
     );
+    bcOptFile = output + ".opt.bc";
+    runShell(
+      Array["opt", `-O${config.optLevel}`, bcFile, "-o", bcOptFile],
+      config.verbose,
+    );
     oFile = output + ".o";
     runShell(
       Array[
@@ -70,7 +75,7 @@ fun link(
         "-mtriple=wasm32-unknown-unknown",
         `-O${config.optLevel}`,
         "-filetype=obj",
-        bcFile,
+        bcOptFile,
         "-o",
         oFile,
       ],


### PR DESCRIPTION
Calling `llc -O2` (used for compiling to wasm) only applies codegen optimizations.

For instance, when compiling the following skip code:
```
fun sumsquares(n: Int): Int {
  res = 0;
  for (i in Range(0, n)) {
    !res = res + i * i;
  };
  res
}
```

Before this commit, :
```
  (func $sumsquares (type 18) (param i64) (result i64)
    (local i64 i32 i64 i32 i64)
    i64.const 0
    local.set 1
    i32.const 1
    local.set 2
    i64.const 0
    local.set 3
    loop  ;; label = @1
      block  ;; label = @2
        block  ;; label = @3
          local.get 0
          local.get 3
          i64.gt_s
          br_if 0 (;@3;)
          i32.const 0
          local.set 4
          i64.const 0
          local.set 5
          br 1 (;@2;)
        end
        i32.const 1
        local.set 4
        local.get 3
        local.set 5
        local.get 3
        i64.const 1
        i64.add
        local.set 3
      end
      block  ;; label = @2
        block  ;; label = @3
          local.get 4
          br_if 0 (;@3;)
          i32.const 0
          local.set 2
          br 1 (;@2;)
        end
        local.get 5
        local.get 5
        i64.mul
        local.get 1
        i64.add
        local.set 1
      end
      local.get 2
      i32.const 1
      i32.and
      br_if 0 (;@1;)
    end
    local.get 1)
```

After this commit:
```
  (func $sumsquares (type 26) (param i64) (result i64)
    (local i32 i64 i64)
    global.get $__stack_pointer
    i32.const 32
    i32.sub
    local.tee 1
    global.set $__stack_pointer
    local.get 1
    i32.const 16
    i32.add
    local.get 0
    i64.const 0
    local.get 0
    i64.const 0
    i64.gt_s
    select
    local.tee 0
    i64.const 0
    local.get 0
    i64.const -1
    i64.add
    i64.const 0
    call $__multi3
    local.get 1
    local.get 1
    i64.load offset=16
    local.tee 2
    local.get 1
    i64.load offset=24
    local.tee 3
    local.get 0
    i64.const -2
    i64.add
    local.get 0
    call $__multi3
    local.get 1
    i64.load
    local.set 0
    local.get 1
    i32.const 32
    i32.add
    global.set $__stack_pointer
    local.get 0
    i64.const 1
    i64.shr_u
    i64.const 6148914691236517206
    i64.mul
    local.get 2
    i64.const 1
    i64.shr_u
    local.get 3
    i64.const 63
    i64.shl
    i64.or
    i64.add)
```