### PR TITLE
Prepare reuse with external mappers and lazy computes

### DIFF
--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -38,6 +38,14 @@ mutable class Writer{
 }
 
 /*****************************************************************************/
+/* The class handed a function used by apply. */
+/*****************************************************************************/
+
+base class Mapper<K: frozen, F: frozen> uses Unsafe.Downcastable, Equality {
+  fun map(mutable Context, mutable Writer, K, mutable Iterator<F>): void;
+}
+
+/*****************************************************************************/
 /* The signature of a function used by apply. */
 /*****************************************************************************/
 
@@ -47,6 +55,61 @@ type MapFun<K, F> = (
   K,
   mutable Iterator<F>,
 ) ~> void;
+
+class Parent(
+  mapper: Mapper<Key, File>,
+  ranges: ?Array<KeyRange<Key>>,
+  onUpdate: ?((mutable Context, SortedSet<Key>) ~> void),
+) uses Equality {
+  fun ==(other: Parent): Bool {
+    this.mapper == other.mapper &&
+      this.ranges == other.ranges &&
+      (this.onUpdate, other.onUpdate) match {
+      | (None(), None()) -> true
+      | (Some(f1), Some(f2)) -> native_eq(f1, f2) == 0
+      | _ -> false
+      }
+  }
+}
+
+/*****************************************************************************/
+/* A Mapper that used Lambda. */
+/*****************************************************************************/
+
+class LambdaMapper<K: frozen, F: frozen>(
+  lambda: MapFun<K, F>,
+) extends Mapper<K, F> {
+  fun map(
+    context: mutable Context,
+    writer: mutable Writer,
+    key: K,
+    values: mutable Iterator<F>,
+  ): void {
+    this.lambda(context, writer, key, values)
+  }
+
+  fun ==(other: Mapper<K, F>): Bool {
+    Unsafe.maybeCast(other, LambdaMapper<K, F>) match {
+    | Some(o) -> native_eq(this.lambda, o.lambda) == 0
+    | _ -> false
+    }
+  }
+}
+
+/*****************************************************************************/
+/* A no op Mapper. */
+/*****************************************************************************/
+
+class NoopMapper<K: frozen, F: frozen>() extends Mapper<K, F> {
+  fun map(
+    _context: mutable Context,
+    _writer: mutable Writer,
+    _key: K,
+    _values: mutable Iterator<F>,
+  ): void {
+    void
+  }
+}
 
 /*****************************************************************************/
 /* Compaction types and helpers. */
@@ -675,16 +738,7 @@ base class EagerDir protected {
   protected fixedOld: FixedSourceMap = FixedSourceMap::empty(),
   data: DataMap<Key>,
   protected old: SortedMap<Path, MInfo> = SortedMap[],
-  parents: FixedSingle<
-    DirName,
-    Array<
-      (
-        MapFun<Key, File>,
-        ?Array<KeyRange<Key>>,
-        ?((mutable Context, SortedSet<Key>) ~> void),
-      ),
-    >,
-  > = FixedSingle::empty(),
+  parents: FixedSingle<DirName, Array<Parent>> = FixedSingle::empty(),
   childDirs: SortedSet<DirName> = SortedSet[],
   protected slices: RangeMapList<Key, DirName> = RangeMapList[],
   protected reducer: ?Reducer<Key, File> = None(),
@@ -937,7 +991,7 @@ base class EagerDir protected {
     parent: EagerDir,
     childName: DirName,
     timeStack: TimeStack,
-    f: MapFun<Key, File>,
+    f: Mapper<Key, File>,
     acc: mutable Vector<FixedRow<Key, Array<File>>>,
     current: mutable IntRef,
   ): void {
@@ -997,7 +1051,7 @@ base class EagerDir protected {
     parent: EagerDir,
     childName: DirName,
     timeStack: TimeStack,
-    f: MapFun<Key, File>,
+    f: Mapper<Key, File>,
     currentStart: Int,
     currentEnd: Int,
     start: ?Boundary<Key>,
@@ -1088,7 +1142,7 @@ base class EagerDir protected {
     parent: EagerDir,
     childName: DirName,
     timeStack: TimeStack,
-    f: MapFun<Key, File>,
+    f: Mapper<Key, File>,
     acc: mutable Vector<FixedRow<Key, Array<File>>>,
     rangeOpt: ?KeyRange<Key>,
   ): void {
@@ -1152,7 +1206,7 @@ base class EagerDir protected {
     timeStack: TimeStack,
     key: Key,
     valueIter: mutable Iterator<File>,
-    f: MapFun<Key, File>,
+    mapper: Mapper<Key, File>,
   ): void {
     arrow = TArrowKey::create{parentName, childName, key};
     context.enter(arrow, timeStack);
@@ -1168,7 +1222,7 @@ base class EagerDir protected {
     context.!reads = SortedSet[];
 
     writer = mutable Writer{};
-    f(context, writer, key, valueIter);
+    mapper.map(context, writer, key, valueIter);
 
     kvArray = writer.getWrites();
     newDirs = context.newDirs;
@@ -1204,16 +1258,7 @@ base class EagerDir protected {
   protected static fun isReusable(
     context: mutable Context,
     child: EagerDir,
-    parents: FixedSingle<
-      DirName,
-      Array<
-        (
-          MapFun<Key, File>,
-          ?Array<KeyRange<Key>>,
-          ?((mutable Context, SortedSet<Key>) ~> void),
-        ),
-      >,
-    >,
+    parents: FixedSingle<DirName, Array<Parent>>,
     reducerOpt: ?IReducer<File>,
   ): Bool {
     context.canReuse match {
@@ -1231,7 +1276,7 @@ base class EagerDir protected {
     | CRNever() -> false
     | CRIfMatch() ->
       same =
-        (native_eq(parents, child.parents) == 0) &&
+        fsEquals(parents, child.parents) &&
         (native_eq(reducerOpt, child.reducer.map(r -> r.reducer)) == 0);
       parentItems = parents.items();
       tick = context.getTick();
@@ -1314,11 +1359,33 @@ base class EagerDir protected {
     onUpdate: ?((mutable Context, SortedSet<Key>) ~> void) = None(),
     unsafeSkipInit: Bool = false,
   ): void {
+    static::applyFor(
+      context,
+      parentName,
+      childName,
+      LambdaMapper(f),
+      reducerOpt,
+      rangeOpt,
+      onUpdate,
+      unsafeSkipInit,
+    )
+  }
+
+  static fun applyFor(
+    context: mutable Context,
+    parentName: DirName,
+    childName: DirName,
+    mapper: Mapper<Key, File>,
+    reducerOpt: ?IReducer<File> = None(),
+    rangeOpt: ?Array<KeyRange<Key>> = None(),
+    onUpdate: ?((mutable Context, SortedSet<Key>) ~> void) = None(),
+    unsafeSkipInit: Bool = false,
+  ): void {
     parents = FixedSingle::singleton(
       parentName,
-      Array[(f, rangeOpt, onUpdate)],
+      Array[Parent(mapper, rangeOpt, onUpdate)],
     );
-    TEagerDir::applyMany(
+    TEagerDir::applyManyFor(
       context,
       parents,
       childName,
@@ -1467,13 +1534,7 @@ base class EagerDir protected {
     context: mutable Context,
     parentDirtyOpt: ?KeySet,
     contextDirtyReadersOpt: ?SortedMap<DirName, KeySet>,
-    parentMaps: Array<
-      (
-        MapFun<Key, File>,
-        ?Array<KeyRange<Key>>,
-        ?((mutable Context, SortedSet<Key>) ~> void),
-      ),
-    >,
+    parentMaps: Array<Parent>,
     childRef: EagerDir,
   ): void {
     parent = this;
@@ -1491,8 +1552,7 @@ base class EagerDir protected {
         keys = parent.typed().castKeySet(dirtyKeys).values();
         !dirty = withRegionFold(None(), keys, dirty, (_, key, dirtyInRegion) ~> {
           for (p in parentMaps) {
-            (_, rangeOpt, _) = p;
-            rangeOpt match {
+            p.ranges match {
             | Some(
               ranges,
             ) if (
@@ -1512,8 +1572,7 @@ base class EagerDir protected {
       keys = parent.typed().castKeySet(dirtyKeys).values();
       !dirty = withRegionFold(None(), keys, dirty, (_, key, dirtyInRegion) ~> {
         for (p in parentMaps) {
-          (_, rangeOpt, _) = p;
-          rangeOpt match {
+          p.ranges match {
           | Some(
             ranges,
           ) if (!ranges.any(range -> range.start <= key && key <= range.end)) ->
@@ -1547,8 +1606,7 @@ base class EagerDir protected {
 
         for (p in parentMaps) {
           writer = mutable Writer{};
-          (mapFun, _, _) = p;
-          mapFun(ctx, writer, key, parent.getIterRaw(key));
+          p.mapper.map(ctx, writer, key, parent.getIterRaw(key));
           mapped = writer.getWrites();
           for (kv in mapped) {
             (k, rvalues) = kv;
@@ -1608,8 +1666,7 @@ base class EagerDir protected {
     context.setDir(childRef);
 
     for (p in parentMaps) {
-      (_, _, onUpdate) = p;
-      onUpdate match {
+      p.onUpdate match {
       | None() -> void
       | Some(f) -> f(context, dirty)
       }
@@ -1780,7 +1837,7 @@ base class EagerDir protected {
         for (parent in childDir.parents.items()) {
           if (parent.i0 != this.dirName) continue;
           for (p in parent.i1) {
-            p.i1 match {
+            p.ranges match {
             | None() -> continue
             | Some(ranges) ->
               for (range in ranges) {
@@ -2210,6 +2267,22 @@ class TEagerDir extends EagerDir, TDir {
     reducerOpt: ?IReducer<File> = None(),
     unsafeSkipInit: Bool = false,
   ): void {
+    static::applyManyFor(
+      context,
+      parents.map(arr ~> arr.map(t -> Parent(LambdaMapper(t.i0), t.i1, t.i2))),
+      childName,
+      reducerOpt,
+      unsafeSkipInit,
+    )
+  }
+
+  static fun applyManyFor(
+    context: mutable Context,
+    parents: FixedSingle<DirName, Array<Parent>>,
+    childName: DirName,
+    reducerOpt: ?IReducer<File> = None(),
+    unsafeSkipInit: Bool = false,
+  ): void {
     (context.fromContext.flatMap(ctx ->
       ctx.unsafeMaybeGetEagerDir(childName)
     ) match {
@@ -2259,9 +2332,8 @@ class TEagerDir extends EagerDir, TDir {
       if (!unsafeSkipInit) {
         for (parentName => parentData in parents) {
           for (p in parentData) {
-            (f, rangeOpt, _) = p;
             parent = context.unsafeGetEagerDir(parentName);
-            rangeOpt match {
+            p.ranges match {
             | None() ->
               static::mapData(
                 context,
@@ -2269,7 +2341,7 @@ class TEagerDir extends EagerDir, TDir {
                 parent,
                 childName,
                 timeStack,
-                f,
+                p.mapper,
                 acc,
                 None(),
               )
@@ -2281,7 +2353,7 @@ class TEagerDir extends EagerDir, TDir {
                   parent,
                   childName,
                   timeStack,
-                  f,
+                  p.mapper,
                   acc,
                   Some(range),
                 );
@@ -2300,7 +2372,7 @@ class TEagerDir extends EagerDir, TDir {
       if (context.debugMode) {
         parentNames = parents
           .items()
-          .map(x -> (x.i0, x.i1.map(p -> p.i1)))
+          .map(x -> (x.i0, x.i1.map(p -> p.ranges)))
           .collect(Array);
         print_string(
           `CREATED:  ${childName} (time: ${time}, parents: ${parentNames})`,
@@ -2329,8 +2401,7 @@ class TEagerDir extends EagerDir, TDir {
     context.setDir(dir);
     for (parentName => parentData in parents) {
       for (p in parentData) {
-        (_, rangeOpt, _) = p;
-        static::addChildToParent(context, parentName, childName, rangeOpt);
+        static::addChildToParent(context, parentName, childName, p.ranges);
       }
     };
   }

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -218,9 +218,9 @@ class Reducer<K: Orderable, F: frozen>{
   }
 }
 
-class IReducer<F>{
-  init: (mutable Iterator<F> ~> Array<F>),
-  update: (Array<F>, Array<F>, Array<F>) ~> ?Array<F>,
+base class IReducer<F> uses Unsafe.Downcastable, Equality {
+  fun init(mutable Iterator<F>): Array<F>;
+  fun update(Array<F>, Array<F>, Array<F>): ?Array<F>;
 }
 
 mutable class IntRef(mutable value: Int) {
@@ -1277,7 +1277,7 @@ base class EagerDir protected {
     | CRIfMatch() ->
       same =
         fsEquals(parents, child.parents) &&
-        (native_eq(reducerOpt, child.reducer.map(r -> r.reducer)) == 0);
+        (reducerOpt == child.reducer.map(r -> r.reducer));
       parentItems = parents.items();
       tick = context.getTick();
       while (same) {

--- a/skiplang/prelude/src/skstore/EagerFilter.sk
+++ b/skiplang/prelude/src/skstore/EagerFilter.sk
@@ -89,13 +89,11 @@ class EagerFilter<K: Key, F: File> private {
     rangesOpt: ?FilterRange<K>,
   ): void {
     sinkName = this.childName.sub("filter-sink").sub(genSym(0).toString());
-    EagerDir::apply(
+    EagerDir::applyFor(
       context,
       this.parentName,
       sinkName,
-      (_context, _writer, _key, _fileIter) ~> {
-        void
-      },
+      NoopMapper(),
       None(),
       None(),
       Some((context, keys) ~> this.syncData(context, Some(keys), rangesOpt)),

--- a/skiplang/prelude/src/skstore/FixedDir.sk
+++ b/skiplang/prelude/src/skstore/FixedDir.sk
@@ -486,6 +486,17 @@ class FixedSingle<K: Orderable, +V: frozen> private (
     if (elt.i0 != key) return None();
     Some(elt.i1);
   }
+
+  fun map<U: frozen>(f: V ~> U): FixedSingle<K, U> {
+    FixedSingle(this.data.map(kv -> (kv.i0, f(kv.i1))))
+  }
+}
+
+fun fsEquals<K: Orderable, V: Equality>(
+  first: FixedSingle<K, V>,
+  second: FixedSingle<K, V>,
+): Bool {
+  first.data == second.data
 }
 
 // Mapping from source paths to MInfo

--- a/skiplang/prelude/src/skstore/Handle.sk
+++ b/skiplang/prelude/src/skstore/Handle.sk
@@ -167,18 +167,69 @@ mutable class TWriter<K: Key, V: File> private {
 /* Typed version of the Reducer. */
 /*****************************************************************************/
 
-class EReducer<V2, V3: File>{
+base class ReducerBase<V2: frozen, V3: File>{
   type: File ~> V3,
+} uses Unsafe.Downcastable, Equality {
+  fun doinit(mutable Iterator<V2>): Array<V3>;
+  fun doupdate(Array<V3>, Array<V2>, Array<V2>): ?Array<V3>;
+}
+
+class EReducer<V2: frozen, V3: File>{
   canReset: Bool,
   init: (mutable Iterator<V2> ~> Array<V3>),
   update: (Array<V3>, Array<V2>, Array<V2>) ~> ?Array<V3>,
+} extends ReducerBase<V2, V3> {
+  fun doinit(values: mutable Iterator<V2>): Array<V3> {
+    this.init(values)
+  }
+
+  fun doupdate(state: Array<V3>, old: Array<V2>, new: Array<V2>): ?Array<V3> {
+    this.update(state, old, new)
+  }
+
+  fun ==(other: ReducerBase<V2, V3>): Bool {
+    Unsafe.maybeCast(other, EReducer<V2, V3>) match {
+    | Some(o) ->
+      native_eq(this.init, o.init) == 0 && native_eq(this.update, o.update) == 0
+    | _ -> false
+    }
+  }
+}
+
+class IReducerBase<V2: frozen, V3: File>(
+  reducer: ReducerBase<V2, V3>,
+  valueType: File ~> V2,
+) extends IReducer<File> {
+  //
+  fun init(values: mutable Iterator<File>): Array<File> {
+    this.reducer.doinit(values.map(this.valueType));
+  }
+
+  fun update(
+    state: Array<File>,
+    old: Array<File>,
+    new: Array<File>,
+  ): ?Array<File> {
+    this.reducer.doupdate(
+      state.map(this.reducer.type),
+      old.map(this.valueType),
+      new.map(this.valueType),
+    )
+  }
+
+  fun ==(other: IReducer<File>): Bool {
+    Unsafe.maybeCast(other, IReducerBase<V2, V3>) match {
+    | Some(o) -> this.reducer == o.reducer
+    | _ -> false
+    }
+  }
 }
 
 /*****************************************************************************/
 /* A few predefined Reducers. */
 /*****************************************************************************/
 
-fun countReducer(): EReducer<_, IntFile> {
+fun countReducer<V: frozen>(): EReducer<V, IntFile> {
   EReducer{
     type => IntFile::type,
     canReset => false,
@@ -444,7 +495,7 @@ class EHandle<K: Key, V: File> extends Handle<K, V> {
       (EHandle<K, V>, (TMapFun<K, V, K2, V2>, ?Array<KeyRange<K>>)),
     >,
     dirName: DirName,
-    reducer: EReducer<V2, V3>,
+    reducer: ReducerBase<V2, V3>,
   ): EHandle<K2, V3> {
     static::genMultiMapReduce(
       typeOutputKey,
@@ -452,17 +503,7 @@ class EHandle<K: Key, V: File> extends Handle<K, V> {
       context,
       parents,
       dirName,
-      Some(
-        IReducer{
-          init => files ~> reducer.init(files.map(typeOutput)),
-          update => (state, old, new) ~>
-            reducer.update(
-              state.map(reducer.type),
-              old.map(typeOutput),
-              new.map(typeOutput),
-            ),
-        },
-      ),
+      Some(IReducerBase(reducer, typeOutput)),
     )
   }
 
@@ -489,7 +530,7 @@ class EHandle<K: Key, V: File> extends Handle<K, V> {
     context: mutable Context,
     dirName: DirName,
     f: TMapFun<K, V, K2, V2>,
-    reducer: EReducer<V2, V3>,
+    reducer: ReducerBase<V2, V3>,
     rangeOpt: ?Array<KeyRange<K>> = None(),
   ): EHandle<K2, V3> {
     static::multiMapReduce(

--- a/skiplang/prelude/src/skstore/LazyDir.sk
+++ b/skiplang/prelude/src/skstore/LazyDir.sk
@@ -17,6 +17,25 @@ base class LazyResult<F> {
   | LAbsent()
 }
 
+base class LazyCompute<K: frozen, F: frozen> uses Unsafe.Downcastable, Equality{
+  fun compute(mutable Context, DirName, K): ?Array<F>;
+}
+
+class LambdaLazyCompute<K: frozen, F: frozen>(
+  lambda: (mutable Context, DirName, K) ~> ?Array<F>,
+) extends LazyCompute<K, F> {
+  fun compute(context: mutable Context, dirname: DirName, key: K): ?Array<F> {
+    this.lambda(context, dirname, key)
+  }
+
+  fun ==(other: LazyCompute<K, F>): Bool {
+    Unsafe.maybeCast(other, LambdaLazyCompute<K, F>) match {
+    | Some(o) -> native_eq(this.lambda, o.lambda) == 0
+    | _ -> false
+    }
+  }
+}
+
 base class LazyDir protected {protected collect: Bool} extends Dir {
   /* Updates the lazyGets ref counts and return as well a potentially updated
     LazyDir in which dead keys have been removed. */
@@ -36,7 +55,7 @@ base class LazyDir protected {protected collect: Bool} extends Dir {
 
 class TLazyDir{
   protected data: SortedMap<Key, LazyResult<File>> = SortedMap[],
-  protected lazyFun: (mutable Context, DirName, Key) ~> ?Array<File>,
+  protected compute: LazyCompute<Key, File>,
 } extends LazyDir, TDir {
   fun updateLazyGets(
     refCountsOpt: ?KeyMap<Int>,
@@ -147,7 +166,7 @@ class TLazyDir{
     context.!reads = SortedSet[];
 
     resultOpt = try {
-      this.lazyFun(context, dirName, key)
+      this.compute.compute(context, dirName, key)
     } catch {
     | exn ->
       !dir = context.unsafeGetLazyDir(dirName).typed();
@@ -229,6 +248,15 @@ class TLazyDir{
     lazyFun: (mutable Context, DirName, Key) ~> ?Array<File>,
     collect: Bool = true,
   ): Dir {
+    static::createFor(context, dirName, LambdaLazyCompute(lazyFun), collect)
+  }
+
+  static fun createFor(
+    context: mutable Context,
+    dirName: DirName,
+    compute: LazyCompute<Key, File>,
+    collect: Bool = true,
+  ): Dir {
     context.addRead(Path::dirTag(dirName));
     (context.fromContext.flatMap(ctx ->
       ctx.unsafeMaybeGetLazyDir(dirName)
@@ -236,7 +264,7 @@ class TLazyDir{
     | d @ Some _ -> d
     | _ -> context.unsafeMaybeGetLazyDir(dirName)
     }) match {
-    | Some(ldir) if (native_eq(ldir.typed().lazyFun, lazyFun) == 0) ->
+    | Some(ldir) if (ldir.typed().compute == compute) ->
       if (context.debugMode) {
         print_string(`REUSING: ${dirName}`);
       };
@@ -247,7 +275,7 @@ class TLazyDir{
       newDir = static{
         timeStack => TimeStack::create(context, time),
         dirName,
-        lazyFun,
+        compute,
         collect,
       };
       context.updateDirtyReaders(Path::dirTag(dirName));


### PR DESCRIPTION
Use classes rather than Lambdas to define mappers and lazy compute functions, which allows to redefine equality when using external definitions. This also allows to add user data that may be useful for debugging.