### PR TITLE
Use https for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "skiplang-bootstrap"]
 	path = skiplang/compiler/bootstrap
-	url = git@github.com:SkipLabs/skiplang-bootstrap.git
+	url = https://github.com/SkipLabs/skiplang-bootstrap.git
 	shallow = true
 
 [submodule "compiler/runtime/libbacktrace"]
@@ -9,4 +9,4 @@
     ignore = dirty
 [submodule "www/docs_site"]
 	path = www/docs_site
-	url = git@github.com:SkipLabs/docs_site.git
+	url = https://github.com/SkipLabs/docs_site.git


### PR DESCRIPTION
One can use
`git config url."git@github.com:".insteadOf "https://github.com/"` to prefer ssh over https