### PR TITLE
[skipruntime-ts/server] Send an empty update every 30 seconds on SSE streams

### DIFF
--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -135,7 +135,12 @@ export function streamingService(service: ServiceInstance): express.Express {
           res.end();
         },
       });
+      const heartbeat = setInterval(() => {
+        res.write("event: update\ndata:[]\n\n");
+      }, 30000);
+
       req.on("close", () => {
+        clearInterval(heartbeat);
         service.unsubscribe(subscriptionID);
       });
     } catch (e: unknown) {


### PR DESCRIPTION
This should help with some timeout issues. I'll also cut an NPM release to get this over into the skipper repo once it lands.

@skiplabsdaniel seem okay to you?

I looked into doing it at different points, but didn't want to mess with watermarks, so this seemed best.