### PR TITLE
[skip-wasm] Fix sk-types annotations for typescript 5.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,11 +55,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.17",
-        "@skipruntime/core": "0.0.17",
-        "@skipruntime/helpers": "0.0.17",
-        "@skipruntime/server": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
+        "@skip-adapter/postgres": "0.0.18",
+        "@skipruntime/core": "0.0.18",
+        "@skipruntime/helpers": "0.0.18",
+        "@skipruntime/server": "0.0.18",
+        "@skipruntime/wasm": "0.0.18"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
@@ -101,70 +101,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skip-adapter/postgres": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.17.tgz",
-      "integrity": "sha512-kPfNn/me6ybTKxbVti1psTLQcwDjxU7WaNaQHKANvffNIP3a/DOVuuFz+3WA5sshmEAqQ9ePlxWhOiV4bpBksA==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "pg": "^8.13.1",
-        "pg-format": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skipruntime/core": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.17.tgz",
-      "integrity": "sha512-E+Szf5VAcSmaHeRyfSiX9LgVkulskRVu6OSAHD+ukqEcpcC1BOZkby5xMA7Z8BhWRcjBt8MLOE5uxp6gmmM8KA=="
-    },
-    "examples/blogger/reactive_service/node_modules/@skipruntime/helpers": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.17.tgz",
-      "integrity": "sha512-a2GtVGo3N1UvO6r+KgYR2Vn+QPKurWe4cguWbGzi+chJ9+b6CJoGiZOjbnCdQ4Vm5UZx0rP/xSxrHTPOixcYDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "eventsource": "^2.0.2",
-        "express": "^4.21.1"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.17.tgz",
-      "integrity": "sha512-2iQioME6ckw1K2uU1TPTrAySgroLDsdPPrDLtmzYWGO0OCOqB2eZCDXDRzIicVX+SDKzQEK4hQ9UBbNk6tJ7bA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skipruntime/server": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.17.tgz",
-      "integrity": "sha512-Ojl51NUYdGt7Xg6P6WHfuonhUqFHRp2MEhM0S01aXb+DEV3IFhL8ZLF6euYVNpuqZiZt6XvP4ql6j2ly9e3fEw==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "express": "^4.21.1"
-      },
-      "optionalDependencies": {
-        "@skipruntime/native": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skipruntime/wasm": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.17.tgz",
-      "integrity": "sha512-gV7xrpueKgFjaK1/2F/d+4Wy+z/z/PHOyvLd3NvQ3CXVPy7Y4XGVaBP3CpGU3jdaWjSHc/zXizW1YYEvNnrFaA==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
       }
     },
     "examples/blogger/reactive_service/node_modules/@types/node": {
@@ -361,11 +297,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.17",
-        "@skipruntime/core": "0.0.17",
-        "@skipruntime/helpers": "0.0.17",
-        "@skipruntime/server": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
+        "@skip-adapter/postgres": "0.0.18",
+        "@skipruntime/core": "0.0.18",
+        "@skipruntime/helpers": "0.0.18",
+        "@skipruntime/server": "0.0.18",
+        "@skipruntime/wasm": "0.0.18"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
@@ -407,70 +343,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skip-adapter/postgres": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.17.tgz",
-      "integrity": "sha512-kPfNn/me6ybTKxbVti1psTLQcwDjxU7WaNaQHKANvffNIP3a/DOVuuFz+3WA5sshmEAqQ9ePlxWhOiV4bpBksA==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "pg": "^8.13.1",
-        "pg-format": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/core": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.17.tgz",
-      "integrity": "sha512-E+Szf5VAcSmaHeRyfSiX9LgVkulskRVu6OSAHD+ukqEcpcC1BOZkby5xMA7Z8BhWRcjBt8MLOE5uxp6gmmM8KA=="
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/helpers": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.17.tgz",
-      "integrity": "sha512-a2GtVGo3N1UvO6r+KgYR2Vn+QPKurWe4cguWbGzi+chJ9+b6CJoGiZOjbnCdQ4Vm5UZx0rP/xSxrHTPOixcYDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "eventsource": "^2.0.2",
-        "express": "^4.21.1"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/native": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.17.tgz",
-      "integrity": "sha512-2iQioME6ckw1K2uU1TPTrAySgroLDsdPPrDLtmzYWGO0OCOqB2eZCDXDRzIicVX+SDKzQEK4hQ9UBbNk6tJ7bA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/server": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.17.tgz",
-      "integrity": "sha512-Ojl51NUYdGt7Xg6P6WHfuonhUqFHRp2MEhM0S01aXb+DEV3IFhL8ZLF6euYVNpuqZiZt6XvP4ql6j2ly9e3fEw==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "express": "^4.21.1"
-      },
-      "optionalDependencies": {
-        "@skipruntime/native": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/wasm": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.17.tgz",
-      "integrity": "sha512-gV7xrpueKgFjaK1/2F/d+4Wy+z/z/PHOyvLd3NvQ3CXVPy7Y4XGVaBP3CpGU3jdaWjSHc/zXizW1YYEvNnrFaA==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/@types/node": {
@@ -667,11 +539,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/kafka": "0.0.17",
-        "@skipruntime/core": "0.0.17",
-        "@skipruntime/helpers": "0.0.17",
-        "@skipruntime/server": "0.0.17",
-        "@skipruntime/wasm": "0.0.17",
+        "@skip-adapter/kafka": "0.0.18",
+        "@skipruntime/core": "0.0.18",
+        "@skipruntime/helpers": "0.0.18",
+        "@skipruntime/server": "0.0.18",
+        "@skipruntime/wasm": "0.0.18",
         "kafkajs": "^2.2.4"
       },
       "devDependencies": {
@@ -679,148 +551,21 @@
         "@skiplabs/tsconfig": "^0.0.1"
       }
     },
-    "examples/chatroom/reactive_service/node_modules/@skip-adapter/kafka": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skip-adapter/kafka/-/kafka-0.0.17.tgz",
-      "integrity": "sha512-YnBGxl8GgVnWOVMxTp05/NCri5UGEsCeVZDOEx9Z4MrZor+pxaqzrk80YUujYMGg7VMkQgKOJm/wB5KCPo/2Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "kafkajs": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=22.6.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@skipruntime/core": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.17.tgz",
-      "integrity": "sha512-E+Szf5VAcSmaHeRyfSiX9LgVkulskRVu6OSAHD+ukqEcpcC1BOZkby5xMA7Z8BhWRcjBt8MLOE5uxp6gmmM8KA=="
-    },
-    "examples/chatroom/reactive_service/node_modules/@skipruntime/helpers": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.17.tgz",
-      "integrity": "sha512-a2GtVGo3N1UvO6r+KgYR2Vn+QPKurWe4cguWbGzi+chJ9+b6CJoGiZOjbnCdQ4Vm5UZx0rP/xSxrHTPOixcYDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "eventsource": "^2.0.2",
-        "express": "^4.21.1"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.17.tgz",
-      "integrity": "sha512-2iQioME6ckw1K2uU1TPTrAySgroLDsdPPrDLtmzYWGO0OCOqB2eZCDXDRzIicVX+SDKzQEK4hQ9UBbNk6tJ7bA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@skipruntime/server": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.17.tgz",
-      "integrity": "sha512-Ojl51NUYdGt7Xg6P6WHfuonhUqFHRp2MEhM0S01aXb+DEV3IFhL8ZLF6euYVNpuqZiZt6XvP4ql6j2ly9e3fEw==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "express": "^4.21.1"
-      },
-      "optionalDependencies": {
-        "@skipruntime/native": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@skipruntime/wasm": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.17.tgz",
-      "integrity": "sha512-gV7xrpueKgFjaK1/2F/d+4Wy+z/z/PHOyvLd3NvQ3CXVPy7Y4XGVaBP3CpGU3jdaWjSHc/zXizW1YYEvNnrFaA==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
-      }
-    },
     "examples/hackernews/reactive_service": {
       "name": "reactive-hackernews-leader",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.17",
-        "@skipruntime/core": "0.0.17",
-        "@skipruntime/helpers": "0.0.17",
-        "@skipruntime/server": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
+        "@skip-adapter/postgres": "0.0.18",
+        "@skipruntime/core": "0.0.18",
+        "@skipruntime/helpers": "0.0.18",
+        "@skipruntime/server": "0.0.18",
+        "@skipruntime/wasm": "0.0.18"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.1",
         "@types/node": "^22.10.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skip-adapter/postgres": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.17.tgz",
-      "integrity": "sha512-kPfNn/me6ybTKxbVti1psTLQcwDjxU7WaNaQHKANvffNIP3a/DOVuuFz+3WA5sshmEAqQ9ePlxWhOiV4bpBksA==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "pg": "^8.13.1",
-        "pg-format": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/core": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.17.tgz",
-      "integrity": "sha512-E+Szf5VAcSmaHeRyfSiX9LgVkulskRVu6OSAHD+ukqEcpcC1BOZkby5xMA7Z8BhWRcjBt8MLOE5uxp6gmmM8KA=="
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/helpers": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.17.tgz",
-      "integrity": "sha512-a2GtVGo3N1UvO6r+KgYR2Vn+QPKurWe4cguWbGzi+chJ9+b6CJoGiZOjbnCdQ4Vm5UZx0rP/xSxrHTPOixcYDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "eventsource": "^2.0.2",
-        "express": "^4.21.1"
-      },
-      "engines": {
-        "node": ">=22.6.0 <23.0.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.17.tgz",
-      "integrity": "sha512-2iQioME6ckw1K2uU1TPTrAySgroLDsdPPrDLtmzYWGO0OCOqB2eZCDXDRzIicVX+SDKzQEK4hQ9UBbNk6tJ7bA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/server": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.17.tgz",
-      "integrity": "sha512-Ojl51NUYdGt7Xg6P6WHfuonhUqFHRp2MEhM0S01aXb+DEV3IFhL8ZLF6euYVNpuqZiZt6XvP4ql6j2ly9e3fEw==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17",
-        "express": "^4.21.1"
-      },
-      "optionalDependencies": {
-        "@skipruntime/native": "0.0.17",
-        "@skipruntime/wasm": "0.0.17"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/wasm": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.17.tgz",
-      "integrity": "sha512-gV7xrpueKgFjaK1/2F/d+4Wy+z/z/PHOyvLd3NvQ3CXVPy7Y4XGVaBP3CpGU3jdaWjSHc/zXizW1YYEvNnrFaA==",
-      "dependencies": {
-        "@skipruntime/core": "0.0.17"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {

--- a/skiplang/prelude/ts/wasm/src/sk_browser.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_browser.ts
@@ -8,7 +8,7 @@ class Env implements Environment {
   fileSystem: MemFS;
   system: MemSys;
   timestamp: () => float;
-  decodeUTF8: (utf8: ArrayBuffer) => string;
+  decodeUTF8: (utf8: ArrayBuffer | Uint8Array) => string;
   encodeUTF8: (str: string) => Uint8Array;
   storage: () => Storage;
   onException: () => void;

--- a/skiplang/prelude/ts/wasm/src/sk_node.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_node.ts
@@ -17,7 +17,7 @@ class Env implements Environment {
   disableWarnings: boolean = false;
   system: MemSys;
   timestamp: () => float;
-  decodeUTF8: (utf8: ArrayBuffer) => string;
+  decodeUTF8: (utf8: ArrayBuffer | Uint8Array) => string;
   encodeUTF8: (str: string) => Uint8Array;
   base64Decode: (base64: string) => Uint8Array;
   base64Encode: (toEncode: string, url?: boolean) => string;

--- a/skiplang/prelude/ts/wasm/src/sk_types.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_types.ts
@@ -372,7 +372,6 @@ export class Utils {
   importString = (strPtr: ptr<Internal.String>) => {
     const size = this.exports.SKIP_String_byteSize(strPtr);
     const utf8 = new Uint8Array(this.exports.memory.buffer, strPtr, size);
-
     return this.env.decodeUTF8(utf8);
   };
   exportString = (s: string): ptr<Internal.String> => {

--- a/skiplang/prelude/ts/wasm/src/sk_types.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_types.ts
@@ -150,7 +150,7 @@ export interface Environment {
   disableWarnings: boolean;
   environment: string[];
   timestamp: () => float;
-  decodeUTF8: (utf8: ArrayBuffer) => string;
+  decodeUTF8: (utf8: ArrayBuffer | Uint8Array) => string;
   encodeUTF8: (str: string) => Uint8Array;
   onException: () => void;
   base64Decode: (base64: string) => Uint8Array;
@@ -372,6 +372,7 @@ export class Utils {
   importString = (strPtr: ptr<Internal.String>) => {
     const size = this.exports.SKIP_String_byteSize(strPtr);
     const utf8 = new Uint8Array(this.exports.memory.buffer, strPtr, size);
+
     return this.env.decodeUTF8(utf8);
   };
   exportString = (s: string): ptr<Internal.String> => {
@@ -734,7 +735,7 @@ export function humanSize(bytes: int) {
 }
 
 export function loadWasm(
-  buffer: ArrayBuffer,
+  buffer: ArrayBuffer | Uint8Array,
   managers: ToWasmManager[],
   environment: Environment,
   main?: string,


### PR DESCRIPTION
Some changes required to get things typechecking at the latest TSC version; should be no functional change.