### PR TITLE
[skip/server] Update healthcheck routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Update healthcheck routes from `/v1/healthcheck` to `/healthz`
+
 ## [0.0.18] - 2025-11-14
 
 ### Added

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -97,7 +97,7 @@ export function controlService(service: ServiceInstance): express.Express {
       });
   });
 
-  app.get("/v1/healthcheck", (_, res) => {
+  app.get("/healthz", (_, res) => {
     res.sendStatus(200);
   });
 
@@ -155,7 +155,7 @@ export function streamingService(service: ServiceInstance): express.Express {
     }
   });
 
-  app.get("/v1/healthcheck", (_, res) => {
+  app.get("/healthz", (_, res) => {
     res.sendStatus(200);
   });
 

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -66,7 +66,7 @@ export type SkipServer = {
  *   Destroys the resource instance identified by `uuid`.
  *   Under normal circumstances, resource instances are deleted automatically after some period of inactivity; this interface enables immediately deleting live streams under exceptional circumstances.
  *
- * - `GET /v1/healthcheck
+ * - `GET /healthz
  *   Check that the Skip service is running normally.
  *   Returns HTTP 200 if the service is healthy, for use in monitoring, deployments, and the like.
  *
@@ -84,6 +84,10 @@ export type SkipServer = {
  *     id: <watermark>\n
  *     data: <values>\n\n
  * ```
+ *
+ * - `GET /healthz
+ *   Check that the Skip service is running normally.
+ *   Returns HTTP 200 if the service is healthy, for use in monitoring, deployments, and the like.
  *
  * @typeParam Inputs - Named collections from which the service computes.
  * @typeParam ResourceInputs - Named collections provided to resource computations.


### PR DESCRIPTION
The `/healthz` route name is in line with Kubernetes conventions.