### PR TITLE
fix(core): treat reducer remove() null as recompute signal

### DIFF
--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -1318,12 +1318,12 @@ export class ToBinding {
   ): Nullable<Pointer<Internal.CJSON>> {
     const skjson = this.getJsonConverter();
     const reducer = this.handles.get(skreducer);
-    return skjson.exportJSON(
-      reducer.object.remove(
-        skjson.importJSON(skacc) as Json,
-        skjson.importJSON(skvalue) as Json & DepSafe,
-      ),
+    const result = reducer.object.remove(
+      skjson.importJSON(skacc) as Json,
+      skjson.importJSON(skvalue) as Json & DepSafe,
     );
+    if (result === null) return null;
+    return skjson.exportJSON(result);
   }
 
   SkipRuntime_Reducer__isEquals(


### PR DESCRIPTION
Problem
-------
The Reducer interface (skipruntime-ts/core/src/api.ts, lines 72-84) documents that remove() may return null to request a full recompute of the accumulator. Native Skip reducers rely on this: they return None() and the engine calls init() over all current values instead of continuing the incremental update.

JS reducers could not trigger this path. The bridge function SkipRuntime_Reducer__remove always called skjson.exportJSON(result), which converted JS null into a CJNull heap object—a valid JSON value meaning "the accumulator is JSON null". The engine therefore received Some(CJNull), not None(), and kept walking old/new arrays incrementally.

Fix
---
Short-circuit in SkipRuntime_Reducer__remove: when the JS reducer returns null, return a literal null pointer instead of exporting. The FFI then yields None() to BaseTypes.Reducer.update, which aborts the incremental loop and tells writeEntry to rebuild the accumulator via init().