### PR TITLE
Add persistence layer

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -2303,11 +2303,18 @@ class ConcurrentFork() extends .Exception {
   }
 }
 
-fun mergeForkNoGc(
+class MergeState(
+  settings: ForkSettings,
+  start: Tick,
+  contexts: ContextsWithActions,
+  fork: ?String,
+)
+
+fun startMergeForkNoGc(
   name: String,
   settings: ForkSettings = ForkSettings::keepall(),
   synchronizer: ?ForkSynchronizer = None(),
-): void {
+): MergeState {
   SKStore.gGlobalLock();
   contexts = SKStore.gContextsGetNoLock();
   if (!contexts.has(Some(name))) {
@@ -2340,16 +2347,36 @@ fun mergeForkNoGc(
     new = contexts.check(fork.fork, new_context.clone(), fork.postponables);
     !new.contexts = new.contexts.remove(name);
     SKStore.gUnsafeFree(contexts);
-    sync = UInt32::truncate(if (settings.isSync) 1 else 0);
-    SKStore.gContextsReplaceNoLock(new.contexts, sync);
-    SKStore.gGlobalUnlock();
-    new.contexts.get(fork.fork).notifyAll(start, settings.ignoredSessions);
-    new.actions.each(fn -> fn())
+    MergeState(settings, start, new, fork.fork)
   | Failure(ex) ->
     SKStore.gUnsafeFree(contexts);
     SKStore.gGlobalUnlock();
     throw ex
   }
+}
+
+fun endMergeForkNoGc(state: MergeState): void {
+  new = state.contexts;
+  sync = UInt32::truncate(if (state.settings.isSync) 1 else 0);
+  SKStore.gContextsReplaceNoLock(new.contexts, sync);
+  SKStore.gGlobalUnlock();
+  new.contexts
+    .get(state.fork)
+    .notifyAll(state.start, state.settings.ignoredSessions);
+  new.actions.each(fn -> fn())
+}
+
+fun abortMergeForkNoGc(_state: MergeState): void {
+  // The unused parameter is here the be call in merge context
+  SKStore.gGlobalUnlock();
+}
+
+fun mergeForkNoGc(
+  name: String,
+  settings: ForkSettings = ForkSettings::keepall(),
+  synchronizer: ?ForkSynchronizer = None(),
+): void {
+  endMergeForkNoGc(startMergeForkNoGc(name, settings, synchronizer))
 }
 
 fun removeForkNoGc(name: String, isSync: Bool = false): void {

--- a/skipruntime-ts/addon/src/common.h
+++ b/skipruntime-ts/addon/src/common.h
@@ -35,6 +35,7 @@ char* CallJSNullableStringFunction(v8::Isolate*, v8::Local<v8::Object>,
                                    const char*, int, v8::Local<v8::Value>[]);
 void NatTryCatch(v8::Isolate*, std::function<void(v8::Isolate*)>);
 void RunWithGC(const v8::FunctionCallbackInfo<v8::Value>&);
+void UnsafeAsyncRunWithGC(const v8::FunctionCallbackInfo<v8::Value>&);
 void GetErrorObject(const v8::FunctionCallbackInfo<v8::Value>&);
 char* ToSKString(v8::Isolate*, v8::Local<v8::Value>);
 void Print(v8::Isolate*, const char*, v8::Local<v8::Value>);
@@ -70,5 +71,6 @@ struct SkipException : std::exception {
 #define SKNotifier void*
 #define SKReducer void*
 #define SKMapper void*
+#define SKMergeState void*
 
 #endif  // SKCOMMON_H

--- a/skipruntime-ts/addon/src/index.ts
+++ b/skipruntime-ts/addon/src/index.ts
@@ -14,6 +14,7 @@ type AddOn = {
   getSkipRuntimeFromBinding: () => SkipRuntimeFromBinding;
   initSkipRuntimeToBinding: (binding: ToBinding) => void;
   runWithGC: <T>(fn: () => T) => T;
+  unsafeAsyncRunWithGC: <T>(fn: () => Promise<T>) => Promise<T>;
   getErrorObject: (skExc: Pointer<IException>) => Error;
 };
 
@@ -27,6 +28,7 @@ const fromBinding = skip_runtime.getSkipRuntimeFromBinding();
 const tobinding = new ToBinding(
   fromBinding,
   skip_runtime.runWithGC,
+  skip_runtime.unsafeAsyncRunWithGC,
   () => jsonConverter,
   skip_runtime.getErrorObject,
 );

--- a/skipruntime-ts/addon/src/main.cc
+++ b/skipruntime-ts/addon/src/main.cc
@@ -26,6 +26,8 @@ void InitToBinding(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void Initialize(v8::Local<v8::Object> exports, v8::Local<v8::Value> module,
                 void* context) {
   NODE_SET_METHOD(exports, "runWithGC", skbinding::RunWithGC);
+  NODE_SET_METHOD(exports, "unsafeAsyncRunWithGC",
+                  skbinding::UnsafeAsyncRunWithGC);
   NODE_SET_METHOD(exports, "getErrorObject", skbinding::GetErrorObject);
   NODE_SET_METHOD(exports, "getJsonBinding", skjson::GetBinding);
   NODE_SET_METHOD(exports, "getSkipRuntimeFromBinding",

--- a/skipruntime-ts/addon/src/tojs.cc
+++ b/skipruntime-ts/addon/src/tojs.cc
@@ -56,6 +56,10 @@ CJSON SkipRuntime_Runtime__getForKey(char* resource, CJObject jsonParams,
 CJSON SkipRuntime_Runtime__update(char* input, CJSON values);
 double SkipRuntime_Runtime__fork(char* input);
 double SkipRuntime_Runtime__merge(CJArray);
+SKMergeState SkipRuntime_Runtime__startMerge(CJArray);
+double SkipRuntime_Runtime__endMerge(SKMergeState);
+double SkipRuntime_Runtime__abortMerge(SKMergeState);
+
 double SkipRuntime_Runtime__abortFork();
 uint32_t SkipRuntime_Runtime__forkExists(char* input);
 CJSON SkipRuntime_Runtime__reload(SKService service);
@@ -902,6 +906,72 @@ void MergeOfRuntime(const FunctionCallbackInfo<Value>& args) {
   });
 }
 
+void StartMergeOfRuntime(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  HandleScope scope(isolate);
+  if (args.Length() != 1) {
+    // Throw an Error that is passed back to JavaScript
+    isolate->ThrowException(
+        Exception::TypeError(FromUtf8(isolate, "Must have one parameter.")));
+    return;
+  };
+  if (!args[0]->IsExternal()) {
+    // Throw an Error that is passed back to JavaScript
+    isolate->ThrowException(Exception::TypeError(
+        FromUtf8(isolate, "The parameter must be a pointer.")));
+    return;
+  };
+  NatTryCatch(isolate, [&args](Isolate* isolate) {
+    SKMergeState skstate =
+        SkipRuntime_Runtime__startMerge(args[0].As<External>()->Value());
+    args.GetReturnValue().Set(External::New(isolate, skstate));
+  });
+}
+
+void EndMergeOfRuntime(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  HandleScope scope(isolate);
+  if (args.Length() != 1) {
+    // Throw an Error that is passed back to JavaScript
+    isolate->ThrowException(
+        Exception::TypeError(FromUtf8(isolate, "Must have one parameter.")));
+    return;
+  };
+  if (!args[0]->IsExternal()) {
+    // Throw an Error that is passed back to JavaScript
+    isolate->ThrowException(Exception::TypeError(
+        FromUtf8(isolate, "The parameter must be a pointer.")));
+    return;
+  };
+  NatTryCatch(isolate, [&args](Isolate* isolate) {
+    double skerror =
+        SkipRuntime_Runtime__endMerge(args[0].As<External>()->Value());
+    args.GetReturnValue().Set(Number::New(isolate, skerror));
+  });
+}
+
+void AbortMergeOfRuntime(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  HandleScope scope(isolate);
+  if (args.Length() != 1) {
+    // Throw an Error that is passed back to JavaScript
+    isolate->ThrowException(
+        Exception::TypeError(FromUtf8(isolate, "Must have one parameter.")));
+    return;
+  };
+  if (!args[0]->IsExternal()) {
+    // Throw an Error that is passed back to JavaScript
+    isolate->ThrowException(Exception::TypeError(
+        FromUtf8(isolate, "The parameter must be a pointer.")));
+    return;
+  };
+  NatTryCatch(isolate, [&args](Isolate* isolate) {
+    double skerror =
+        SkipRuntime_Runtime__abortMerge(args[0].As<External>()->Value());
+    args.GetReturnValue().Set(Number::New(isolate, skerror));
+  });
+}
+
 void AbortForkOfRuntime(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   HandleScope scope(isolate);
@@ -1043,6 +1113,12 @@ void GetToJSBinding(const FunctionCallbackInfo<Value>& args) {
   AddFunction(isolate, binding, "SkipRuntime_Runtime__update", UpdateOfRuntime);
   AddFunction(isolate, binding, "SkipRuntime_Runtime__fork", ForkOfRuntime);
   AddFunction(isolate, binding, "SkipRuntime_Runtime__merge", MergeOfRuntime);
+  AddFunction(isolate, binding, "SkipRuntime_Runtime__startMerge",
+              StartMergeOfRuntime);
+  AddFunction(isolate, binding, "SkipRuntime_Runtime__endMerge",
+              EndMergeOfRuntime);
+  AddFunction(isolate, binding, "SkipRuntime_Runtime__abortMerge",
+              AbortMergeOfRuntime);
   AddFunction(isolate, binding, "SkipRuntime_Runtime__abortFork",
               AbortForkOfRuntime);
   AddFunction(isolate, binding, "SkipRuntime_Runtime__forkExists",

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -483,6 +483,11 @@ export interface Resource<
   ): EagerCollection<Json, Json>;
 }
 
+export interface Store<K extends Json, V extends Json> {
+  load(): Promise<Entry<K, V>[]>;
+  save(data: Entry<K, V>[]): Promise<void>;
+}
+
 /**
  * Initial data for a service's input collections.
  *
@@ -492,8 +497,8 @@ export interface Resource<
  */
 export type InitialData<Inputs extends NamedCollections> = {
   [Name in keyof Inputs]: Inputs[Name] extends EagerCollection<infer K, infer V>
-    ? Entry<K, V>[]
-    : Entry<Json, Json>[];
+    ? Entry<K, V>[] | Store<K, V>
+    : Entry<Json, Json>[] | Store<Json, Json>;
 };
 
 /**

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -175,6 +175,15 @@ export interface FromBinding {
   SkipRuntime_Runtime__merge(
     ignore: Pointer<Internal.CJArray<Internal.CJString>>,
   ): Handle<Error>;
+  SkipRuntime_Runtime__startMerge(
+    ignore: Pointer<Internal.CJArray<Internal.CJString>>,
+  ): Pointer<Internal.MergeState>;
+  SkipRuntime_Runtime__endMerge(
+    state: Pointer<Internal.MergeState>,
+  ): Handle<Error>;
+  SkipRuntime_Runtime__abortMerge(
+    state: Pointer<Internal.MergeState>,
+  ): Handle<Error>;
   SkipRuntime_Runtime__abortFork(): Handle<Error>;
   SkipRuntime_Runtime__forkExists(name: string): boolean;
 

--- a/skipruntime-ts/core/src/internal.ts
+++ b/skipruntime-ts/core/src/internal.ts
@@ -50,3 +50,6 @@ export type Reducer = T<typeof reducer>;
 
 declare const notifier: unique symbol;
 export type Notifier = T<typeof notifier>;
+
+declare const mergestate: unique symbol;
+export type MergeState = T<typeof mergestate>;

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -727,6 +727,39 @@ fun mergeForkForOfRuntime(streamsToIgnore: SKJSON.CJArray): Float {
   }
 }
 
+@export("SkipRuntime_Runtime__startMerge")
+fun startMergeForOfRuntime(
+  streamsToIgnore: SKJSON.CJArray,
+): ?SKStore.MergeState {
+  streamsToIgnore match {
+  | SKJSON.CJArray(values) ->
+    ignore = values.iterator().map(SKJSON.asString).collect(Set);
+    getFork().map(f ->
+      SKStore.startMergeForkNoGc(f, SKStore.ForkSettings::keepall(ignore))
+    )
+  }
+}
+
+@export("SkipRuntime_Runtime__endMerge")
+fun endMergeForOfRuntime(state: ?SKStore.MergeState): Float {
+  try {
+    state.each(s -> SKStore.endMergeForkNoGc(s));
+    0.0
+  } catch {
+  | err -> getErrorHdl(err)
+  }
+}
+
+@export("SkipRuntime_Runtime__abortMerge")
+fun abortMergeForOfRuntime(state: ?SKStore.MergeState): Float {
+  try {
+    state.each(s -> SKStore.abortMergeForkNoGc(s));
+    0.0
+  } catch {
+  | err -> getErrorHdl(err)
+  }
+}
+
 @export("SkipRuntime_Runtime__abortFork")
 fun abortForkOfRuntime(): Float {
   try {

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -190,6 +190,13 @@ export interface FromWasm {
   SkipRuntime_Runtime__merge(
     ignore: ptr<Internal.CJArray<Internal.CJString>>,
   ): Handle<Error>;
+  SkipRuntime_Runtime__startMerge(
+    ignore: ptr<Internal.CJArray<Internal.CJString>>,
+  ): ptr<Internal.MergeState>;
+  SkipRuntime_Runtime__endMerge(state: ptr<Internal.MergeState>): Handle<Error>;
+  SkipRuntime_Runtime__abortMerge(
+    state: ptr<Internal.MergeState>,
+  ): Handle<Error>;
   SkipRuntime_Runtime__abortFork(): Handle<Error>;
   SkipRuntime_Runtime__forkExists(name: ptr<Internal.String>): number;
   SkipRuntime_Runtime__reload(
@@ -684,6 +691,24 @@ export class WasmFromBinding implements FromBinding {
     return this.fromWasm.SkipRuntime_Runtime__merge(toPtr(ignore));
   }
 
+  SkipRuntime_Runtime__startMerge(
+    ignore: ptr<Internal.CJArray<Internal.CJString>>,
+  ): ptr<Internal.MergeState> {
+    return this.fromWasm.SkipRuntime_Runtime__startMerge(toPtr(ignore));
+  }
+
+  SkipRuntime_Runtime__endMerge(
+    state: ptr<Internal.MergeState>,
+  ): Handle<Error> {
+    return this.fromWasm.SkipRuntime_Runtime__endMerge(toPtr(state));
+  }
+
+  SkipRuntime_Runtime__abortMerge(
+    state: ptr<Internal.MergeState>,
+  ): Handle<Error> {
+    return this.fromWasm.SkipRuntime_Runtime__abortMerge(toPtr(state));
+  }
+
   SkipRuntime_Runtime__abortFork(): Handle<Error> {
     return this.fromWasm.SkipRuntime_Runtime__abortFork();
   }
@@ -763,6 +788,7 @@ class LinksImpl implements Links {
     this.tobinding = new ToBinding(
       fromBinding,
       utils.runWithGc.bind(utils),
+      utils.unsafeAsyncWithGc.bind(utils),
       () => (this.env.shared.get("SKJSON")! as SKJSONShared).converter,
       (skExc: Pointer<Internal.Exception>) =>
         this.utils.getErrorObject(toPtr(skExc)),


### PR DESCRIPTION
The purpose of the persistence layer is to enable the Skip runtime to become the sole point of entry for data:
- Ensuring that only data in the Skip runtime is stored.
- Should speed up the loading of input values

A Store concept has been added, so that a service's "InitialData" elements can be an input array as it is today, or a Store (this allows mixing requirements, with different stores for different needs depending on the nature of the data, while still having the possibility of volatile data).
A store is a class that implements the interface:

```
export interface Store<K extends Json, V extends Json> {
  load(): Promise<Entry<K, V>[]>;
  save(data: Entry<K, V>[]): Promise<void>;
}
``` 
If the write in SKIP runtime fails the data is not stored, and if saving to a store fails, the corresponding write in the SKIP runtime will also fail.