### PR TITLE
Add InclusiveOr type and use it for zipSorted

### DIFF
--- a/skiplang/prelude/src/core/InclusiveOr.sk
+++ b/skiplang/prelude/src/core/InclusiveOr.sk
@@ -1,0 +1,106 @@
+// Represents a value that is either A, B, or both (inclusive or).
+// Left(A) contains only the first value.
+// Right(B) contains only the second value.
+// Both(A, B) contains both values.
+//
+base class InclusiveOr<+A, +B> {
+  children =
+  | Left(value: A)
+  | Right(value: B)
+  | Both(left: A, right: B)
+
+  // # Introspection
+
+  // true iff this is a Left()
+  fun isLeft(): Bool
+  | Left _ -> true
+  | _ -> false
+
+  // true iff this is a Right()
+  fun isRight(): Bool
+  | Right _ -> true
+  | _ -> false
+
+  // true iff this is a Both()
+  fun isBoth(): Bool
+  | Both _ -> true
+  | _ -> false
+
+  // # Extraction
+
+  // The value if this is a Left(), otherwise throws.
+  fun fromLeft(message: String = "fromLeft() called on non-Left"): A
+  | Left(value) -> value
+  | _ -> invariant_violation(message)
+
+  // The value if this is a Right(), otherwise throws.
+  fun fromRight(message: String = "fromRight() called on non-Right"): B
+  | Right(value) -> value
+  | _ -> invariant_violation(message)
+
+  // Both values if this is a Both(), otherwise throws.
+  fun fromBoth(message: String = "fromBoth() called on non-Both"): (A, B)
+  | Both(l, r) -> (l, r)
+  | _ -> invariant_violation(message)
+
+  // # Transforming to Different Types
+
+  // Some(value) if this is a Left(), otherwise None()
+  fun maybeLeft(): ?A
+  | Left(value) -> Some(value)
+  | _ -> None()
+
+  // Some(value) if this is a Right(), otherwise None()
+  fun maybeRight(): ?B
+  | Right(value) -> Some(value)
+  | _ -> None()
+
+  // Some((left, right)) if this is a Both(), otherwise None()
+  fun maybeBoth(): ?(A, B)
+  | Both(l, r) -> Some((l, r))
+  | _ -> None()
+
+  // # Trait Implementations
+
+  fun ==<A2: Equality, B2: Equality>[A: A2, B: B2](
+    that: InclusiveOr<A2, B2>,
+  ): Bool {
+    (this, that) match {
+    | (Left(v1), Left(v2)) -> v1 == v2
+    | (Right(v1), Right(v2)) -> v1 == v2
+    | (Both(a1, b1), Both(a2, b2)) -> a1 == a2 && b1 == b2
+    | _ -> false
+    }
+  }
+
+  fun !=<A2: Equality, B2: Equality>[A: A2, B: B2](
+    that: InclusiveOr<A2, B2>,
+  ): Bool {
+    !(this == that)
+  }
+
+  // Left() < Right() < Both()
+  fun compare<A2: Orderable, B2: Orderable>[A: A2, B: B2](
+    that: InclusiveOr<A2, B2>,
+  ): Order
+  | Left(v1) ->
+    that match {
+    | Left(v2) -> compare(v1, v2)
+    | _ -> LT()
+    }
+  | Right(v1) ->
+    that match {
+    | Left _ -> GT()
+    | Right(v2) -> compare(v1, v2)
+    | Both _ -> LT()
+    }
+  | Both(a1, b1) ->
+    that match {
+    | Both(a2, b2) ->
+      compare(a1, a2) match {
+      | EQ() -> compare(b1, b2)
+      | ord -> ord
+      }
+    | _ -> GT()
+    }
+}

--- a/skiplang/prelude/src/core/language/Iterator.sk
+++ b/skiplang/prelude/src/core/language/Iterator.sk
@@ -164,20 +164,20 @@ mutable base class .Iterator<+T> {
   }
 
   // Merges two iterators assumed to be sorted.
-  // Yields (Some(x), None) for left-only, (None, Some(y)) for right-only,
-  // and (Some(x), Some(y)) for elements present in both.
+  // Yields Left(x) for left-only, Right(y) for right-only, and Both(x, y)
+  // for elements present in both.
   overridable mutable fun zipSorted[T: Orderable](
     other: mutable Iterator<T>,
-  ): mutable Iterator<(?T, ?T)> {
+  ): mutable Iterator<InclusiveOr<T, T>> {
     ZipSortedIterator::create(this, other, id)
   }
 
   // Merges two iterators assumed to be sorted by their `project`ed keys.
-  // Yields (Some(x), None) for left-only, (None, Some(y)) for right-only,
-  // and (Some(x), Some(y)) for elements present in both.
+  // Yields Left(x) for left-only, Right(y) for right-only, and Both(x, y)
+  // for elements present in both.
   overridable mutable fun zipSortedBy<K: Orderable>[T: Projectable<K>](
     other: mutable Iterator<T>,
-  ): mutable Iterator<(?T, ?T)> {
+  ): mutable Iterator<InclusiveOr<T, T>> {
     ZipSortedIterator::create(this, other, x ~> x.project())
   }
 
@@ -432,20 +432,20 @@ mutable class ZipWithIterator<T, U, +V>(
 
 // See Iterator#zipSorted() and Iterator#zipSortedBy()
 // Merges two sorted iterators, comparing elements via a projection function.
-// Yields (Some(x), None) for left-only, (None, Some(y)) for right-only,
-// and (Some(x), Some(y)) for elements present in both.
+// Yields Left(x) for left-only, Right(y) for right-only, and Both(x, y) for
+// elements present in both.
 private mutable class ZipSortedIterator<K: Orderable, T> private (
   private mutable head1: ?T,
   private tail1: mutable Iterator<T>,
   private mutable head2: ?T,
   private tail2: mutable Iterator<T>,
   private project: T ~> K,
-) extends Iterator<(?T, ?T)> {
+) extends Iterator<InclusiveOr<T, T>> {
   static fun create(
     iter1: mutable Iterator<T>,
     iter2: mutable Iterator<T>,
     project: T ~> K,
-  ): mutable Iterator<(?T, ?T)> {
+  ): mutable Iterator<InclusiveOr<T, T>> {
     head1 = iter1.next();
     head2 = iter2.next();
     mutable static(head1, iter1, head2, iter2, project)
@@ -459,34 +459,39 @@ private mutable class ZipSortedIterator<K: Orderable, T> private (
     }
   }
 
-  mutable fun next(): ?(?T, ?T) {
-    none: ?T = None();
-    advance = (curr, tail, setHead) -> {
-      curr.each(old -> {
-        newHead = tail.next();
-        newHead.each(new ->
-          invariant(
-            this.project(old) < this.project(new),
-            "Iterator#zipSorted(): iterator not sorted",
-          )
-        );
-        setHead(newHead);
-      });
+  mutable fun next(): ?InclusiveOr<T, T> {
+    advance = (old, tail) -> {
+      newHead = tail.next();
+      newHead.each(new ->
+        invariant(
+          this.project(old) < this.project(new),
+          "Iterator#zipSorted(): iterator not sorted",
+        )
+      );
+      newHead;
     };
-    go = (x, y) -> {
-      advance(x, this.tail1, h -> this.!head1 = h);
-      advance(y, this.tail2, h -> this.!head2 = h);
-      Some((x, y))
-    };
+    advanceLeft = (x) -> this.!head1 = advance(x, this.tail1);
+    advanceRight = (y) -> this.!head2 = advance(y, this.tail2);
     (this.head1, this.head2) match {
     | (None(), None()) -> None()
-    | (None(), Some(_)) -> go(none, this.head2)
-    | (Some(_), None()) -> go(this.head1, none)
+    | (None(), Some(y)) ->
+      advanceRight(y);
+      Some(Right(y))
+    | (Some(x), None()) ->
+      advanceLeft(x);
+      Some(Left(x))
     | (Some(x), Some(y)) ->
       this.project(x).compare(this.project(y)) match {
-      | LT() -> go(this.head1, none)
-      | EQ() -> go(this.head1, this.head2)
-      | GT() -> go(none, this.head2)
+      | LT() ->
+        advanceLeft(x);
+        Some(Left(x))
+      | EQ() ->
+        advanceLeft(x);
+        advanceRight(y);
+        Some(Both(x, y))
+      | GT() ->
+        advanceRight(y);
+        Some(Right(y))
       }
     }
   }


### PR DESCRIPTION
Add an `InclusiveOr<+A, +B>` type to represent either an `A`, or a `B`, or
both. This is a standard generalization of the usual `Either` type.

Then refactor `zipSorted` to use it, for code clarity, and also to remove the bogus case corresponding to an element being in neither input iterator.