### PR TITLE
Make sizeHint a non-exact capacity hint

### DIFF
--- a/skiplang/prelude/src/core/language/Iterator.sk
+++ b/skiplang/prelude/src/core/language/Iterator.sk
@@ -12,12 +12,12 @@ module Iterator;
 // more items or None() when there are no more items. An iterator cannot be
 // reset: mutable methods will, in general, advance the iterator.
 mutable base class .Iterator<+T> {
-  // Returns a hint of the number of items that this Iterator may yield:
-  // - Returns Some(n) if the exact number of items is known. Examples:
-  //   iterators over concrete collections, 1:1 transform operations
-  //   (e.g. map()).
-  // - Otherwise returns None(). Examples: transform operations that may
-  //   not be 1:1, such as filter(), flatMap(), takeWhile(), etc.
+  // Returns a hint of the number of items that this Iterator may yield.
+  // This is used for capacity pre-allocation and is not guaranteed to be exact.
+  // - Returns Some(n) as an estimate. For concrete collections this is exact;
+  //   for transforms like filter() it may be an upper bound.
+  // - Returns None() if no useful estimate is available.
+  // Consumers must handle cases where the actual count differs from the hint.
   overridable readonly fun sizeHint(): ?Int {
     None()
   }
@@ -397,7 +397,9 @@ mutable class ZipIterator<+T, +U>(
   readonly fun sizeHint(): ?Int {
     (this.left.sizeHint(), this.right.sizeHint()) match {
     | (Some(left), Some(right)) -> Some(min(left, right))
-    | _ -> None()
+    | (Some(left), None()) -> Some(left)
+    | (None(), Some(right)) -> Some(right)
+    | (None(), None()) -> None()
     }
   }
 
@@ -418,7 +420,9 @@ mutable class ZipWithIterator<T, U, +V>(
   readonly fun sizeHint(): ?Int {
     (this.left.sizeHint(), this.right.sizeHint()) match {
     | (Some(left), Some(right)) -> Some(min(left, right))
-    | _ -> None()
+    | (Some(left), None()) -> Some(left)
+    | (None(), Some(right)) -> Some(right)
+    | (None(), None()) -> None()
     }
   }
 
@@ -452,10 +456,18 @@ private mutable class ZipSortedIterator<K: Orderable, T> private (
   }
 
   readonly fun sizeHint(): ?Int {
-    (this.head1, this.head2) match {
-    | (Some(_), None()) -> this.tail1.sizeHint().map(n -> n + 1)
-    | (None(), Some(_)) -> this.tail2.sizeHint().map(n -> n + 1)
-    | _ -> None()
+    size1 = this.tail1.sizeHint().map(n ->
+      if (this.head1.isSome()) n + 1 else n
+    );
+    size2 = this.tail2.sizeHint().map(n ->
+      if (this.head2.isSome()) n + 1 else n
+    );
+    (size1, size2) match {
+    | (Some(s1), Some(s2)) -> Some(s1 + s2)
+    | (Some(s), None())
+    | (None(), Some(s)) ->
+      Some(s)
+    | (None(), None()) -> None()
     }
   }
 

--- a/skiplang/prelude/src/stdlib/collections/mutable/Vector.sk
+++ b/skiplang/prelude/src/stdlib/collections/mutable/Vector.sk
@@ -99,32 +99,51 @@ mutable class .Vector<+T> private (
   static fun mreverseFromIterator<I: mutable Iterator<T>>(
     items: I,
   ): mutable this {
-    items.sizeHint() match {
-    | Some(size) ->
-      invariant(
-        size >= 0,
-        "Vector::mreverseFromIterator(): Expected items sizeHint() to be nonnegative.",
-      );
-      inner = unsafeMake(size);
-      index = size;
+    hint = items.sizeHint().default(0);
+    if (hint > 0) {
+      // Optimistically try fast path using hint
+      inner = unsafeMake(hint);
+      index = hint;
+      overflow = mutable Vector[];
       items.each(value -> {
-        !index = index - 1;
-        invariant(
-          index.uge(0),
-          "Vector::mreverseFromIterator(): Invalid iterator, expected each() to yield sizeHint() items.",
-        );
-        unsafeSet(inner, index, value);
+        if (index > 0) {
+          !index = index - 1;
+          unsafeSet(inner, index, value);
+        } else {
+          // More items than hint - collect overflow
+          overflow.push(value);
+        }
       });
-      invariant(
-        index == 0,
-        "Vector::mreverseFromIterator(): Invalid iterator, expected each() to yield sizeHint() items.",
-      );
-      mutable Vector(inner, size)
-    | None() ->
-      result = Vector::mcreateFromIterator(items);
+      overflowSize = overflow.size();
+      filledStart = index;
+      if (overflowSize == 0) {
+        if (filledStart == 0) {
+          // Hint was exact
+          mutable Vector(inner, hint)
+        } else {
+          // Hint was too large: extract only the filled portion
+          filledSize = hint - index;
+          result = unsafeMake(filledSize);
+          unsafeMoveSlice(inner, filledStart, hint, result, 0);
+          mutable Vector(result, filledSize)
+        }
+      } else {
+        // Hint was too small: combine reverse(overflow) + inner
+        totalSize = hint + overflowSize;
+        result = unsafeMake(totalSize);
+        // Copy overflow in reverse order
+        for (i in Range(0, overflowSize)) {
+          unsafeSet(result, i, overflow[overflowSize - 1 - i]);
+        };
+        // Copy inner (already in reversed order)
+        unsafeMoveSlice(inner, 0, hint, result, overflowSize);
+        mutable Vector(result, totalSize)
+      };
+    } else {
+      result = static::mcreateFromIterator(items);
       result.reverse();
-      result
-    }
+      result;
+    };
   }
 
   // Create a vector of the given size with all indices set to the given value.


### PR DESCRIPTION
Update Iterator.sizeHint() documentation to clarify it returns a hint
for capacity pre-allocation rather than an exact count. This allows
consumers to handle cases where the actual count differs.

- Update mreverseFromIterator to gracefully handle inexact hints by
  collecting overflow items when hint is too small, or extracting
  the filled portion when hint is too large
- Improve ZipIterator and ZipWithIterator to return a hint when at
  least one side has a hint
- Improve ZipSortedIterator to return sum of both sizes as upper bound