### PR TITLE
AIGEN: Pin exact prettier version in package.json

### DIFF
--- a/bin/git_hooks/check_format.sh
+++ b/bin/git_hooks/check_format.sh
@@ -4,6 +4,8 @@
 
 exec 1>&2
 
+PRETTIER_VERSION=$(jq -r '.devDependencies.prettier' package.json)
+
 # check that a single staged file is well-formatted
 check-file () {
     file=$1
@@ -13,7 +15,7 @@ check-file () {
     elif [[ "$file" =~ .*\.(c|cc|cpp|h|hh|hpp)$ ]]; then # keep in sync with fmt-c in Makefile
         fmt="clang-format --assume-filename=$file"
     elif [[ "$file" =~ .*\.(css|html|js|json|mjs|ts|tsx)$ ]]; then # keep in sync with .prettierignore
-        fmt="npx prettier --stdin-filepath $file --loglevel debug"
+        fmt="npx prettier@$PRETTIER_VERSION --stdin-filepath $file --loglevel debug"
     elif [[ "$file" == *.py ]]; then # keep in sync with fmt-py in Makefile
         fmt="black - --quiet --line-length 80 --stdin-filename $file"
     else

--- a/examples/blogger/www/package.json
+++ b/examples/blogger/www/package.json
@@ -26,7 +26,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.0.3",
-    "prettier": "^2.4.1",
+    "prettier": "3.4.1",
     "typescript": "~4.5.5"
   }
 }

--- a/examples/cache_invalidation/www/package.json
+++ b/examples/cache_invalidation/www/package.json
@@ -26,7 +26,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.0.3",
-    "prettier": "^2.4.1",
+    "prettier": "3.4.1",
     "typescript": "~4.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@skiplabs/eslint-config": "^0.0.1",
     "@skiplabs/tsconfig": "^0.0.1",
     "eslint": "9.15.0",
-    "prettier": "^3.4.1",
+    "prettier": "3.4.1",
     "typescript": "^5.7.2"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Remove caret from version specifier so the Makefile uses an exact version (3.4.1) rather than a compatible range (^3.4.1)
- Update example package.json files to use the same version
- Update the git hook to use the version from package.json