### PR TITLE
AIGEN: Add -y flag to npx prettier for non-interactive CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ fmt-c: # Keep in sync with bin/git_hooks/check_format.sh
 
 .PHONY: fmt-js
 fmt-js: # Keep in sync with bin/git_hooks/check_format.sh
-	npx prettier@$(PRETTIER_VERSION) --log-level $(PRETTIER_LOG_LEVEL) --write .
-	npx prettier@$(PRETTIER_VERSION) --log-level $(PRETTIER_LOG_LEVEL) --write --parser=json skipruntime-ts/addon/binding.gyp
+	npx -y prettier@$(PRETTIER_VERSION) --log-level $(PRETTIER_LOG_LEVEL) --write .
+	npx -y prettier@$(PRETTIER_VERSION) --log-level $(PRETTIER_LOG_LEVEL) --write --parser=json skipruntime-ts/addon/binding.gyp
 
 
 .PHONY: fmt-py

--- a/bin/git_hooks/check_format.sh
+++ b/bin/git_hooks/check_format.sh
@@ -15,7 +15,7 @@ check-file () {
     elif [[ "$file" =~ .*\.(c|cc|cpp|h|hh|hpp)$ ]]; then # keep in sync with fmt-c in Makefile
         fmt="clang-format --assume-filename=$file"
     elif [[ "$file" =~ .*\.(css|html|js|json|mjs|ts|tsx)$ ]]; then # keep in sync with .prettierignore
-        fmt="npx prettier@$PRETTIER_VERSION --stdin-filepath $file --loglevel debug"
+        fmt="npx -y prettier@$PRETTIER_VERSION --stdin-filepath $file --loglevel debug"
     elif [[ "$file" == *.py ]]; then # keep in sync with fmt-py in Makefile
         fmt="black - --quiet --line-length 80 --stdin-filename $file"
     else


### PR DESCRIPTION
Without -y, npx prompts for confirmation when installing a package
not in node_modules, which can hang in CI environments.