### PR TITLE
AIGEN Pin black version to 26.1.0 and reformat Python code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ COPY --from=bootstrap /work/compiler/stage0/lib/ /usr/lib/
 FROM skiplang AS skip
 
 RUN --mount=type=bind,source=./bin/apt-install.sh,target=/tmp/apt-install.sh \
+    --mount=type=bind,source=./requirements-dev.txt,target=/tmp/requirements-dev.txt \
     /tmp/apt-install.sh skipruntime-deps other-CI-tools other-dev-tools

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ default: check check-ts
 
 PRETTIER_LOG_LEVEL?=warn
 PRETTIER_VERSION:=$(shell jq -r '.devDependencies.prettier' package.json)
+BLACK_VERSION:=$(shell grep '^black==' requirements-dev.txt | cut -d'=' -f3)
 
 PLAYWRIGHT_REPORTER?="line"
 SKARGO_PROFILE?=release
@@ -113,7 +114,7 @@ fmt-js: # Keep in sync with bin/git_hooks/check_format.sh
 
 .PHONY: fmt-py
 fmt-py: # Keep in sync with bin/git_hooks/check_format.sh
-	black --quiet --line-length 80 .
+	pip install -q black==$(BLACK_VERSION) && black --quiet --line-length 80 .
 
 .PHONY: fmt
 fmt: fmt-sk fmt-c fmt-js fmt-py # Keep in sync with bin/git_hooks/check_format.sh

--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -51,7 +51,9 @@ for step in "${steps[@]}"; do
         other-CI-tools)
             # Assumes other steps have been run before
             apt-get install -q -y clang-format-$LLVM_VERSION docker.io docker-buildx parallel pip shellcheck
-            pip install black==26.1.0
+            # Version from requirements-dev.txt (check repo root, then /tmp for docker builds)
+            BLACK_VERSION=$(grep '^black==' requirements-dev.txt /tmp/requirements-dev.txt 2>/dev/null | head -1 | cut -d'=' -f3)
+            pip install black==${BLACK_VERSION:-26.1.0}
             update-alternatives --auto clang
             ;;
         other-dev-tools)

--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -53,7 +53,7 @@ for step in "${steps[@]}"; do
             apt-get install -q -y clang-format-$LLVM_VERSION docker.io docker-buildx parallel pip shellcheck
             # Version from requirements-dev.txt (check repo root, then /tmp for docker builds)
             BLACK_VERSION=$(grep '^black==' requirements-dev.txt /tmp/requirements-dev.txt 2>/dev/null | head -1 | cut -d'=' -f3)
-            pip install black==${BLACK_VERSION:-26.1.0}
+            pip install black=="${BLACK_VERSION:-26.1.0}"
             update-alternatives --auto clang
             ;;
         other-dev-tools)

--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -51,7 +51,7 @@ for step in "${steps[@]}"; do
         other-CI-tools)
             # Assumes other steps have been run before
             apt-get install -q -y clang-format-$LLVM_VERSION docker.io docker-buildx parallel pip shellcheck
-            pip install black
+            pip install black==26.1.0
             update-alternatives --auto clang
             ;;
         other-dev-tools)

--- a/bin/build_runtime.sh
+++ b/bin/build_runtime.sh
@@ -28,7 +28,7 @@ for arch in ${ARCH//,/ }; do
             --progress=plain \
             --platform="linux/$arch" \
             --file=skipruntime-ts/Dockerfile \
-            --output=type=local,dest=build/linux_$arch \
+            --output=type=local,dest=build/linux_"$arch" \
             .
     } > "build_$arch.log" 2>&1 &
 done

--- a/bin/git_hooks/check_format.sh
+++ b/bin/git_hooks/check_format.sh
@@ -5,6 +5,13 @@
 exec 1>&2
 
 PRETTIER_VERSION=$(jq -r '.devDependencies.prettier' package.json)
+BLACK_VERSION=$(grep '^black==' requirements-dev.txt | cut -d'=' -f3)
+
+# Check black version (run `pip install -r requirements-dev.txt` if wrong version)
+if ! black --version 2>/dev/null | grep -q "$BLACK_VERSION"; then
+    echo "Error: black==$BLACK_VERSION required. Run: pip install -r requirements-dev.txt"
+    exit 1
+fi
 
 # check that a single staged file is well-formatted
 check-file () {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development dependencies
+black==26.1.0

--- a/sql/test/replication/model.py
+++ b/sql/test/replication/model.py
@@ -90,7 +90,7 @@ def runQuery(dbkey, query):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
         )
-        (out, _) = await proc.communicate(query.encode())
+        out, _ = await proc.communicate(query.encode())
         if proc.returncode is None or proc.returncode > 0:
             raise RuntimeError(f"running '{query}' exited non-zero")
 
@@ -114,7 +114,7 @@ def compact(dbkey):
             "--sync",
             stderr=asyncio.subprocess.PIPE,
         )
-        (_, err) = await proc.communicate()
+        _, err = await proc.communicate()
         schedule.debug(err.decode().rstrip())
         if proc.returncode is None or proc.returncode > 0:
             raise RuntimeError(f"running 'compact' exited non-zero")
@@ -141,7 +141,7 @@ def subscribe(dbkey, subkey, table, user, dest, peerId):
             # "--peer-id", peerId,  # for multi-peer
             stdout=asyncio.subprocess.PIPE,
         )
-        (out, _) = await proc.communicate()
+        out, _ = await proc.communicate()
         session = out.decode().rstrip()
         schedule.storeScheduleLocal(subkey, session)
         return session
@@ -163,7 +163,7 @@ async def tail(db, session, peerId, spec):
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    (out, err) = await proc.communicate(json.dumps(spec).encode())
+    out, err = await proc.communicate(json.dumps(spec).encode())
     return out, err, proc.returncode
 
 


### PR DESCRIPTION
## Summary
- Pin black to version 26.1.0 in apt-install.sh to prevent future formatting drift
- Reformat sql/test/replication/model.py with the pinned version

This fixes the CI fast-checks failure caused by unpinned black version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)