### PR TITLE
AIGEN docker: pin base image versions for reproducibility

### DIFF
--- a/examples/blogger/reactive_service/Dockerfile
+++ b/examples/blogger/reactive_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19
+FROM node:22.13.1-alpine3.21
 WORKDIR /app
 COPY package.json package.json
 RUN npm install

--- a/examples/blogger/web_service/Dockerfile
+++ b/examples/blogger/web_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.16-bookworm
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/examples/blogger/www/Dockerfile
+++ b/examples/blogger/www/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:1.27.3-alpine
 WORKDIR /app
 COPY --from=build /build/dist /usr/share/nginx/html
 

--- a/examples/blogger/www/Dockerfile
+++ b/examples/blogger/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19 AS build
+FROM node:22.13.1-alpine3.21 AS build
 WORKDIR /build
 COPY package.json package.json
 RUN npm install

--- a/examples/cache_invalidation/edge_service/Dockerfile
+++ b/examples/cache_invalidation/edge_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19
+FROM node:22.13.1-alpine3.21
 WORKDIR /app
 COPY package.json package.json
 RUN npm install

--- a/examples/cache_invalidation/web_service/Dockerfile
+++ b/examples/cache_invalidation/web_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.16-bookworm
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/examples/cache_invalidation/www/Dockerfile
+++ b/examples/cache_invalidation/www/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:1.27.3-alpine
 WORKDIR /app
 COPY --from=build /build/dist /usr/share/nginx/html
 

--- a/examples/cache_invalidation/www/Dockerfile
+++ b/examples/cache_invalidation/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19 AS build
+FROM node:22.13.1-alpine3.21 AS build
 WORKDIR /build
 COPY package.json package.json
 RUN npm install

--- a/examples/chatroom/reactive_service/Dockerfile
+++ b/examples/chatroom/reactive_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19
+FROM node:22.13.1-alpine3.21
 WORKDIR /app
 COPY package.json package.json
 RUN npm install

--- a/examples/chatroom/web_service/Dockerfile
+++ b/examples/chatroom/web_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19
+FROM node:22.13.1-alpine3.21
 
 WORKDIR /app
 

--- a/examples/chatroom/www/Dockerfile
+++ b/examples/chatroom/www/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:1.27.3-alpine
 WORKDIR /app
 COPY --from=build /build/dist /usr/share/nginx/html
 

--- a/examples/chatroom/www/Dockerfile
+++ b/examples/chatroom/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19 AS build
+FROM node:22.13.1-alpine3.21 AS build
 WORKDIR /build
 COPY package.json package.json
 RUN npm install

--- a/examples/hackernews/reactive_service/Dockerfile
+++ b/examples/hackernews/reactive_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19
+FROM node:22.13.1-alpine3.21
 WORKDIR /app
 RUN apk add --no-cache bash
 RUN apk add --no-cache socat

--- a/examples/hackernews/web_service/Dockerfile
+++ b/examples/hackernews/web_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10.16-bookworm
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/examples/hackernews/www/Dockerfile
+++ b/examples/hackernews/www/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:1.27.3-alpine
 WORKDIR /app
 COPY --from=build /build/dist /usr/share/nginx/html
 

--- a/examples/hackernews/www/Dockerfile
+++ b/examples/hackernews/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.19 AS build
+FROM node:22.13.1-alpine3.21 AS build
 WORKDIR /build
 COPY package.json package.json
 RUN npm install

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -3,7 +3,7 @@
 
 # aim to start from an image with a version of glibc that is as widely
 # compatible as possible while still receiving security updates
-FROM debian:stable-slim AS base
+FROM debian:bookworm-20250113-slim AS base
 
 ARG LLVM_VERSION=20
 


### PR DESCRIPTION
## Summary
- Pin floating Docker base image tags to specific versions for reproducible builds
- Affects example Dockerfiles and skiplang/Dockerfile

## Changes
| Image | Before | After |
|-------|--------|-------|
| Python | `python:3.10` | `python:3.10.16-bookworm` |
| Node.js | `node:lts-alpine3.19` | `node:22.13.1-alpine3.21` |
| Nginx | `nginx:alpine` | `nginx:1.27.3-alpine` |
| Debian | `debian:stable-slim` | `debian:bookworm-20250113-slim` |

## Test plan
- [x] Verified all pinned image tags exist on Docker Hub
- [x] Tested representative builds for each image type

🤖 Generated with [Claude Code](https://claude.ai/code)