### PR TITLE
AIGEN: Docker build efficiency improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,8 @@ node_modules/
 /skiplang/prelude/runtime/*.o
 /skiplang/prelude/runtime/magic.c
 /skiplang/compiler/stage*
+examples/
+.circleci/
+.claude/
+.vscode/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN make clean && make STAGE=0
 
 FROM skiplang-base AS skiplang
 
-COPY --from=bootstrap /work/compiler/stage0/bin/ /usr/bin/
-COPY --from=bootstrap /work/compiler/stage0/lib/ /usr/lib/
+COPY --link --from=bootstrap /work/compiler/stage0/bin/ /usr/bin/
+COPY --link --from=bootstrap /work/compiler/stage0/lib/ /usr/lib/
 
 FROM skiplang AS skip
 

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -42,5 +42,5 @@ RUN make clean && make STAGE=0
 
 FROM base AS final
 
-COPY --from=skiplang /work/skiplang/compiler/stage0/bin/ /usr/bin/
-COPY --from=skiplang /work/skiplang/compiler/stage0/lib/ /usr/lib/
+COPY --link --from=skiplang /work/skiplang/compiler/stage0/bin/ /usr/bin/
+COPY --link --from=skiplang /work/skiplang/compiler/stage0/lib/ /usr/lib/

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -9,8 +9,8 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
     npm install -g bun && \
     npx playwright install-deps
 
-RUN sh -c 'curl -s "https://get.sdkman.io?rcupdate=false" | bash'
 RUN --mount=type=cache,id=sdkman-$TARGETARCH,target=/root/.sdkman/archives,sharing=locked \
+    sh -c 'curl -s "https://get.sdkman.io?rcupdate=false" | bash' && \
     bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     sdk install gradle && \
     sdk install java 20.0.2-tem"

--- a/sql/server/core/Dockerfile
+++ b/sql/server/core/Dockerfile
@@ -1,6 +1,22 @@
 FROM eclipse-temurin:20
 
-COPY . /skdb
+# Copy Gradle wrapper and build configs first (changes rarely)
+COPY sql/server/gradlew sql/server/gradle.properties /skdb/sql/server/
+COPY sql/server/gradle/ /skdb/sql/server/gradle/
+COPY sql/server/build.gradle.kts sql/server/settings.gradle.kts /skdb/sql/server/
+COPY sql/server/core/build.gradle.kts /skdb/sql/server/core/
+COPY sql/server/dev/build.gradle.kts /skdb/sql/server/dev/
+COPY sql/server/pg/build.gradle.kts /skdb/sql/server/pg/
+
 WORKDIR /skdb/sql/server/core
+
+# Download dependencies (cached unless build.gradle.kts changes)
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
+    ../gradlew dependencies --no-daemon --console plain
+
+# Copy remaining source
+COPY . /skdb
+
+# Build
 RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
     ../gradlew build --no-daemon --console plain

--- a/sql/server/dev/Dockerfile
+++ b/sql/server/dev/Dockerfile
@@ -1,9 +1,24 @@
 FROM skiplabs/skdb AS skdb
 FROM eclipse-temurin:20 AS skgw
 
-COPY . /skdb
+# Copy Gradle wrapper and build configs first (changes rarely)
+COPY sql/server/gradlew sql/server/gradle.properties /skdb/sql/server/
+COPY sql/server/gradle/ /skdb/sql/server/gradle/
+COPY sql/server/build.gradle.kts sql/server/settings.gradle.kts /skdb/sql/server/
+COPY sql/server/core/build.gradle.kts /skdb/sql/server/core/
+COPY sql/server/dev/build.gradle.kts /skdb/sql/server/dev/
+COPY sql/server/pg/build.gradle.kts /skdb/sql/server/pg/
 
 WORKDIR /skdb/sql/server/dev
+
+# Download dependencies (cached unless build.gradle.kts changes)
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
+    ../gradlew dependencies --no-daemon --console plain
+
+# Copy remaining source
+COPY . /skdb
+
+# Build
 RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
     ../gradlew jar --no-daemon --console plain
 

--- a/sql/server/dev/Dockerfile
+++ b/sql/server/dev/Dockerfile
@@ -30,8 +30,8 @@ FROM eclipse-temurin:20 AS dev
 
 WORKDIR /skdb
 
-COPY --from=skdb /skdb/build ./build
-COPY --from=skgw /skdb/sql/server/dev/build/libs/dev.jar /skdb/build/server.jar
-COPY --from=skgw /skdb/sql/server/dev/start_dev.sh /skdb/build/start.sh
+COPY --link --from=skdb /skdb/build ./build
+COPY --link --from=skgw /skdb/sql/server/dev/build/libs/dev.jar /skdb/build/server.jar
+COPY --link --from=skgw /skdb/sql/server/dev/start_dev.sh /skdb/build/start.sh
 
 ENTRYPOINT ["/skdb/build/start.sh"]


### PR DESCRIPTION
> Stacked on #1087 (`docker-buildkit-cache`)

## Summary

Build efficiency improvements for Docker images:

- **COPY ordering for Gradle builds** (`sql/server/core/Dockerfile`, `sql/server/dev/Dockerfile`): Copy Gradle wrapper and build configs before source code so dependency resolution layers survive source-only changes
- **`.dockerignore` expansion**: Exclude `examples/`, `.circleci/`, `.claude/`, `.vscode/`, `*.md` and other directories unused by any Docker build, reducing build context size
- **`COPY --link`** for multi-stage `COPY --from=` instructions (`Dockerfile`, `skiplang/Dockerfile`, `sql/server/dev/Dockerfile`): Makes COPY layers independent of parent layers, improving cache reuse
- **SDKMAN RUN consolidation** (`sql/Dockerfile`): Merge two separate RUN instructions (curl install + sdk install) into one, saving an intermediate layer

## Test plan

- [ ] `docker_build.sh skdb-base` — SDKMAN + Gradle + Java install correctly in single RUN
- [ ] `docker_build.sh server-core` — Gradle dependency cache survives source-only changes
- [ ] `docker_build.sh skiplang` — COPY --link builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)