### PR TITLE
AIGEN apt-install.sh, skiplang/Dockerfile: use signed-by for apt repos

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -25,10 +25,10 @@ for step in "${steps[@]}"; do
     case "$step" in
         skiplang-build-deps)
             apt-get update
-            apt-get install -q -y --no-install-recommends wget gnupg
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-            echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
-            echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
+            apt-get install -q -y --no-install-recommends ca-certificates wget
+            mkdir -p /etc/apt/keyrings
+            wget -qO /etc/apt/keyrings/llvm.asc https://apt.llvm.org/llvm-snapshot.gpg.key
+            echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
             apt-get update
             apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION make
 
@@ -43,10 +43,13 @@ for step in "${steps[@]}"; do
                 --slave /usr/bin/wasm-ld wasm-ld /usr/bin/wasm-ld-$LLVM_VERSION
             ;;
         skipruntime-deps)
-            wget -O - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add -
-            echo "deb https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodejs.list
             apt-get update
-            apt-get install -q -y --no-install-recommends nodejs npm jq
+            apt-get install -q -y --no-install-recommends ca-certificates wget
+            mkdir -p /etc/apt/keyrings
+            wget -qO /etc/apt/keyrings/nodesource.asc https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+            echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodejs.list
+            apt-get update
+            apt-get install -q -y --no-install-recommends nodejs jq
             ;;
         other-CI-tools)
             # Assumes other steps have been run before

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -8,14 +8,14 @@ FROM debian:bookworm-20250113-slim AS base
 ARG LLVM_VERSION=20
 ARG TARGETARCH
 
-# Install LLVM via apt repository directly
-# Note: [trusted=yes] is needed because apt.llvm.org's GPG key uses SHA1 signatures
-# which modern Debian rejects since Feb 2026. This is an upstream LLVM issue.
+# Install LLVM via apt repository with signed GPG key
 RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
     apt-get update --quiet && \
     apt-get install --quiet --yes --no-install-recommends ca-certificates make wget && \
-    echo "deb [trusted=yes] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/llvm.asc https://apt.llvm.org/llvm-snapshot.gpg.key && \
+    echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update --quiet && \
     apt-get install --quiet --yes --no-install-recommends \
         clang-${LLVM_VERSION} \


### PR DESCRIPTION
## Summary
- Replace `[trusted=yes]` (disables all signature verification) with `[signed-by=...]` using downloaded GPG keys in `/etc/apt/keyrings/`
- Replace deprecated `wget | apt-key add` pattern in `apt-install.sh`
- Make `skipruntime-deps` step self-contained by installing `ca-certificates` and `wget` before downloading the Nodesource key
- Drop unused `gnupg` and `deb-src` line from `skiplang-build-deps`

## Test plan
- [ ] `docker buildx build .` — exercises both `skiplang-build-deps` and `skipruntime-deps` via `apt-install.sh`
- [ ] `docker buildx build -f skiplang/Dockerfile .` — exercises the standalone Dockerfile LLVM setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)