### PR TITLE
AIGEN: Fix CLI env tests crashing with SIGSEGV

### DIFF
--- a/skiplang/cli/tests/tests.sk
+++ b/skiplang/cli/tests/tests.sk
@@ -318,7 +318,9 @@ fun boolArgsFromEnv(): void {
   cmd = Cli.Command("foo")
     .arg(Cli.Arg::bool("bar").negatable().env("BAR"))
     .arg(Cli.Arg::bool("baz").env("BAZ"));
-  Environ.vars().each(v -> Environ.remove_var(v.i0));
+  // Snapshot names before removing: vars() caches the count upfront,
+  // so calling remove_var() during iteration shrinks environ and SIGSEGVs.
+  Environ.vars().map(v -> v.i0).collect(Array).each(Environ.remove_var);
   Environ.set_var("BAR", "y");
   Environ.set_var("BAZ", "1");
   args = Cli.parseArgsFrom(cmd, Array["--no-bar"]);
@@ -333,7 +335,9 @@ fun intArgsFromEnv(): void {
     .arg(Cli.Arg::int("foo").env("FOO"))
     .arg(Cli.Arg::int("bar").default(123).env("BAR"))
     .arg(Cli.Arg::int("baz").env("BAZ"));
-  Environ.vars().each(v -> Environ.remove_var(v.i0));
+  // Snapshot names before removing: vars() caches the count upfront,
+  // so calling remove_var() during iteration shrinks environ and SIGSEGVs.
+  Environ.vars().map(v -> v.i0).collect(Array).each(Environ.remove_var);
   Environ.set_var("BAR", "456");
   Environ.set_var("BAZ", "42");
   args = Cli.parseArgsFrom(cmd, Array["--foo=1"]);


### PR DESCRIPTION
## Summary
- `boolArgsFromEnv` and `intArgsFromEnv` tests crash with SIGSEGV because they call `Environ.remove_var()` while iterating `Environ.vars()`
- `vars()` caches the `environ` array length upfront, but `remove_var()` (via `unsetenv`) shrinks the array in-place, causing an out-of-bounds read → `strlen(NULL)` → SIGSEGV
- Fix: snapshot env var names into an `Array` before removing them
- This bug has existed since the env tests were introduced (Jul 2023, commit 0e76c884) but was only exposed by the new sktest crash detection (#1088). The crash also kills the worker subprocess, taking out all 30+ co-located tests as collateral (appearing as 32/36 failures in CI)

## Test plan
- [x] `skargo test --jobs 2` in `skiplang/cli/`: 36/36 pass (was 4/36)
- [x] `--jobs 36` (1 test per worker): confirms only the 2 env tests were truly crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)