### PR TITLE
AIGEN Docker: add --dry-run, replace SDKMAN with apt

### DIFF
--- a/bin/release_docker_ci_images.sh
+++ b/bin/release_docker_ci_images.sh
@@ -2,6 +2,7 @@
 
 # Build and push Docker images used in CI.
 # Image names are extracted from .circleci/base.yml so the two stay in sync.
+# Usage: release_docker_ci_images.sh [--dry-run]
 
 set -euo pipefail
 
@@ -19,4 +20,4 @@ if [[ ${#images[@]} -eq 0 ]]; then
 fi
 
 set -x
-"$SCRIPT_DIR"/release_docker.sh "${images[@]}"
+"$SCRIPT_DIR"/release_docker.sh "$@" "${images[@]}"

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -2,22 +2,18 @@ FROM skiplabs/skip AS base
 
 ARG TARGETARCH
 
+# Install system deps, Java 20 (Adoptium Temurin), and Gradle 9.3.1
 RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/root/.npm,sharing=locked \
-    apt-get update && apt-get install -q -y --no-install-recommends curl sqlite3 unzip zip && \
-    npm install -g bun && \
-    npx playwright install-deps
-
-# Install Java 20 (Adoptium Temurin) and Gradle 9.3.1
-RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
     mkdir -p /etc/apt/keyrings && \
     wget -qO /etc/apt/keyrings/adoptium.asc https://packages.adoptium.net/artifactory/api/gpg/key/public && \
     echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" \
       > /etc/apt/sources.list.d/adoptium.list && \
     apt-get update && \
-    apt-get install -q -y --no-install-recommends temurin-20-jdk && \
+    apt-get install -q -y --no-install-recommends curl sqlite3 unzip zip temurin-20-jdk && \
+    npm install -g bun && \
+    npx playwright install-deps && \
     curl -sL https://services.gradle.org/distributions/gradle-9.3.1-bin.zip -o /tmp/gradle.zip && \
     unzip -q /tmp/gradle.zip -d /opt && \
     rm /tmp/gradle.zip && \

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -9,8 +9,10 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
     npm install -g bun && \
     npx playwright install-deps
 
-RUN --mount=type=cache,id=sdkman-$TARGETARCH,target=/root/.sdkman/archives,sharing=locked \
+# Cache mount at /tmp to avoid creating /root/.sdkman/ before the installer runs
+RUN --mount=type=cache,id=sdkman-$TARGETARCH,target=/tmp/sdkman-archives,sharing=locked \
     sh -c 'curl -s "https://get.sdkman.io?rcupdate=false" | bash' && \
+    ln -snf /tmp/sdkman-archives /root/.sdkman/archives && \
     bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     sdk install gradle && \
     sdk install java 20.0.2-tem"

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -9,13 +9,25 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
     npm install -g bun && \
     npx playwright install-deps
 
-# Cache mount at /tmp to avoid creating /root/.sdkman/ before the installer runs
-RUN --mount=type=cache,id=sdkman-$TARGETARCH,target=/tmp/sdkman-archives,sharing=locked \
-    sh -c 'curl -s "https://get.sdkman.io?rcupdate=false" | bash' && \
-    ln -snf /tmp/sdkman-archives /root/.sdkman/archives && \
-    bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
-    sdk install gradle && \
-    sdk install java 20.0.2-tem"
+# Install Java 20 (Adoptium Temurin) and Gradle 9.3.1
+RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/adoptium.asc https://packages.adoptium.net/artifactory/api/gpg/key/public && \
+    echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" \
+      > /etc/apt/sources.list.d/adoptium.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends temurin-20-jdk && \
+    curl -sL https://services.gradle.org/distributions/gradle-9.3.1-bin.zip -o /tmp/gradle.zip && \
+    unzip -q /tmp/gradle.zip -d /opt && \
+    rm /tmp/gradle.zip && \
+    ln -s /opt/gradle-9.3.1/bin/gradle /usr/local/bin/gradle && \
+    mkdir -p /root/.sdkman/bin \
+      /root/.sdkman/candidates/java/20.0.2-tem \
+      /root/.sdkman/candidates/gradle && \
+    touch /root/.sdkman/bin/sdkman-init.sh
+
+ENV JAVA_HOME=/usr/lib/jvm/temurin-20-jdk-${TARGETARCH}
 
 FROM base AS skdb
 


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to `docker_build.sh` and `release_docker_ci_images.sh` for testing multi-arch builds without pushing
- Fix SDKMAN cache mount creating a stale directory that broke reinstalls
- Replace SDKMAN with Adoptium apt repo (Java 20) + direct Gradle 9.3.1 download in `sql/Dockerfile`, cutting the arm64 QEMU build time for that step from **619s to 121s** (5x faster)
- Deduplicate `ca-certificates`/`wget` installs in `apt-install.sh` across steps
- Merge two `RUN` commands in `sql/Dockerfile` into one, saving a redundant `apt-get update`

## Details

### `--dry-run` flag
Allows `release_docker_ci_images.sh --dry-run` to build all CI images for amd64+arm64 without pushing to Docker Hub. Useful for validating Dockerfile changes locally.

### SDKMAN replacement
SDKMAN's curl-based JDK download is extremely slow under QEMU (619s on arm64 vs 36s on amd64). Replaced with:
- **Java**: `temurin-20-jdk` from Adoptium's apt repo, GPG-verified via `signed-by`
- **Gradle 9.3.1**: Direct zip from gradle.org, symlinked to `/usr/local/bin/gradle` (matches the latest version SDKMAN was installing, per PR #1082)
- **SDKMAN compat shim**: Empty `sdkman-init.sh` + directory stubs so CI make targets (`service_common.mk`, `service_server.mk`) continue working

### Deduplicate apt-install.sh
Extract `_ensure_base_deps()` helper that checks if `ca-certificates` and `wget` are already present before running `apt-get update` + install. Avoids redundant work when `skipruntime-deps` runs after `skiplang-build-deps` (e.g. in the `skip` Docker image).

### Merge sql/Dockerfile RUN commands
Combined the two separate `RUN` commands into one: adds Adoptium repo → single `apt-get update` → installs all apt packages → npm/bun/playwright → Gradle download → SDKMAN shim. Saves one `apt-get update` round-trip (slow under QEMU on arm64).

## Test plan
- [x] `release_docker_ci_images.sh --dry-run` builds skiplang, skip, skdb-base for both amd64 and arm64
- [ ] CI passes (test-wasm job exercises the SDKMAN shim via service_common.mk / service_server.mk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)