### PR TITLE
AIGEN Bump Skargo package versions to reflect accumulated changes

### DIFF
--- a/skiplang/arparser/Skargo.toml
+++ b/skiplang/arparser/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arparser"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/cc/Skargo.toml
+++ b/skiplang/cc/Skargo.toml
@@ -1,3 +1,3 @@
 [package]
 name = "cc"
-version = "0.1.0"
+version = "0.1.1"

--- a/skiplang/cli/Skargo.toml
+++ b/skiplang/cli/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/compiler/Skargo.toml
+++ b/skiplang/compiler/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skc"
-version = "0.1.0"
+version = "0.2.0"
 tests = ["tests/tests.sk"]
 test-harness = "SkcTests.main"
 

--- a/skiplang/prelude/Skargo.toml
+++ b/skiplang/prelude/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "std"
-version = "0.1.0"
+version = "0.2.0"
 
 [dev-dependencies]
 sktest = { path = "../sktest" }

--- a/skiplang/semver/Skargo.toml
+++ b/skiplang/semver/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semver"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skargo"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/skdate/Skargo.toml
+++ b/skiplang/skdate/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skdate"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/skjson/Skargo.toml
+++ b/skiplang/skjson/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skjson"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/sktest/Skargo.toml
+++ b/skiplang/sktest/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sktest"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skipruntime-ts/skiplang/core/Skargo.toml
+++ b/skipruntime-ts/skiplang/core/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skipruntime-core"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 std = { path = "../../../skiplang/prelude" }

--- a/skipruntime-ts/skiplang/ffi/Skargo.toml
+++ b/skipruntime-ts/skiplang/ffi/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skipruntime"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 skipruntime-core = { path = "../core" }

--- a/sql/Skargo.toml
+++ b/sql/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skdb"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 std = { path = "../skiplang/prelude" }


### PR DESCRIPTION
## Summary

Bump version fields in 13 Skargo.toml files to reflect code changes accumulated since the initial version was set in Oct 2024 (`65c1d494a`). Three packages (pkg-config, toml, sqlparser) are unchanged — they had no source changes beyond a directory move.

## Minor bumps (API/feature changes)

| Package | Version | Key changes |
|---------|---------|-------------|
| **std** | 0.1.0 → 0.2.0 | 531 commits: iterator additions (zipSorted, InclusiveOr), collection enhancements, type system updates |
| **skc** | 0.1.0 → 0.2.0 | 112 commits: LLVM 20 upgrade, opaque pointer transition, binding pattern changes |
| **skjson** | 0.1.0 → 0.2.0 | 75 commits: readonly arrays/objects, API refactoring, JSON ordering improvements |
| **skargo** | 0.2.0 → 0.3.0 | 29 commits: package version embedding, env var support, build script improvements |
| **skdate** | 0.1.0 → 0.2.0 | 24 commits: build system rework (cc integration), stdlib function additions |
| **skdb** | 0.1.0 → 0.2.0 | 20+ commits since Jan 2023: fork management, transaction redesign |
| **skipruntime-core** | 0.1.0 → 0.2.0 | 26 commits: service reload, Mapper/LazyCompute/Reducer classes |
| **skipruntime** | 0.1.0 → 0.2.0 | 11 commits: service reload FFI, fork management |

## Patch bumps (bugfixes, no API break)

| Package | Version | Key changes |
|---------|---------|-------------|
| **sktest** | 0.1.0 → 0.1.1 | 9 commits: crash detection, test assignment helper |
| **cc** | 0.1.0 → 0.1.1 | 4 commits: stricter flexible array checks, C flag changes |
| **cli** | 0.1.0 → 0.1.1 | 3 commits: binding pattern fix, SIGSEGV fix |
| **arparser** | 0.1.0 → 0.1.1 | 2 commits: test fixes |
| **semver** | 0.1.0 → 0.1.1 | 2 commits: test fixes |

## Unchanged (no source changes)

- **pkg-config** (0.1.0) — directory move only
- **toml** (0.1.0) — directory move only
- **sqlparser** (0.1.0) — directory move only

## Test plan
- [ ] CI passes — versions are metadata embedded by skargo, no build logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)