### PR TITLE
AIGEN Docker: add --push-only flag for pushing pre-built images

### DIFF
--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
 # Build and push Docker images to Docker Hub (multi-arch)
-# Usage: release_docker.sh IMAGE [IMAGE...]
+# Usage: release_docker.sh [--push-only] [--dry-run] IMAGE [IMAGE...]
 
 set -euo pipefail
 
-exec "$(dirname -- "${BASH_SOURCE[0]}")"/docker_build.sh --push "$@"
+SCRIPT_DIR=$(dirname -- "${BASH_SOURCE[0]}")
+
+# --push-only replaces --push (they are mutually exclusive in docker_build.sh)
+for arg in "$@"; do
+    if [[ "$arg" = "--push-only" ]]; then
+        exec "$SCRIPT_DIR"/docker_build.sh "$@"
+    fi
+done
+
+exec "$SCRIPT_DIR"/docker_build.sh --push "$@"


### PR DESCRIPTION
## Summary

- Add `--push-only` flag to `docker_build.sh` that pushes previously built images without rebuilding
- Switch `--push` flows from anonymous buildx builders to a named builder (`skip-builder`) that persists between runs
- Update `release_docker.sh` to pass `--push-only` through correctly

## Motivation

A `--push --dry-run` build takes ~1h (multi-arch amd64+arm64). Previously there was no way to push those images afterward — the anonymous builder was destroyed on exit, so `--push` would rebuild everything from scratch. Now a two-step workflow is possible:

```bash
# Step 1: build without pushing (~1h)
./bin/release_docker_ci_images.sh --dry-run

# Step 2: push already-built images (~instant)
./bin/release_docker_ci_images.sh --push-only
```

## How it works

| Mode | Builder | `--no-cache` | Pushes | Builder cleanup |
|------|---------|-------------|--------|-----------------|
| `--push --dry-run` | named, created | yes | no | kept for `--push-only` |
| `--push-only` | named, reused | no | yes | cleaned up |
| `--push` | named, created | yes | yes | cleaned up |
| local builds | none | yes | no | n/a |

## Test plan

- [ ] `./bin/docker_build.sh --push-only` without prior build → error about missing builder
- [ ] `./bin/docker_build.sh --push-only --push img` → error about mutually exclusive flags
- [ ] `./bin/docker_build.sh --push-only --dry-run img` → error about mutually exclusive flags
- [ ] `./bin/release_docker_ci_images.sh --dry-run` → builds multi-arch, `docker buildx ls` shows `skip-builder`
- [ ] `./bin/release_docker_ci_images.sh --push-only` → pushes without rebuilding, builder cleaned up
- [ ] Local builds unchanged (no named builder involved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)