### PR TITLE
apt-install: add openssh-client for git SSH operations

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -38,7 +38,7 @@ for step in "${steps[@]}"; do
             wget -qO /etc/apt/keyrings/llvm.asc https://apt.llvm.org/llvm-snapshot.gpg.key
             echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
             apt-get update
-            apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION make
+            apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION make openssh-client
 
             update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$LLVM_VERSION $PRIORITY \
                 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-$LLVM_VERSION \


### PR DESCRIPTION
## Summary
- Add `openssh-client` to `skiplang-build-deps` in `bin/apt-install.sh`
- The `--no-install-recommends` flag (added in #1094) stopped `git` from pulling in `openssh-client` as a recommended dependency, breaking CircleCI checkout which uses SSH

## Test plan
- [x] Verified `fast-checks` job passes with rebuilt `skip` image
- [x] Verified `compiler` job gets past checkout with rebuilt `skiplang` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)