### PR TITLE
AIGEN Docker: add --arch flag, fix --push-only cache reuse

### DIFF
--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -51,8 +51,8 @@ while [[ $# -gt 0 ]]; do
         --push-only) PUSH_ONLY=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         --prod) PROD=true; shift ;;
-        --arch) ARCH="$2"; shift 2 ;;
-        --arch=*) ARCH="${1#--arch=}"; shift ;;
+        --arch) ARCH="${ARCH:+$ARCH,}$2"; shift 2 ;;
+        --arch=*) ARCH="${ARCH:+$ARCH,}${1#--arch=}"; shift ;;
         *) IMAGES+=("$1"); shift ;;
     esac
 done


### PR DESCRIPTION
## Summary
- Add `--arch` flag to `docker_build.sh` to override target platforms (e.g. `--arch amd64` for fast single-arch builds)
- Fix `--push-only` not reusing cached layers from `--push --dry-run`

## Details

### `--arch` flag
- Supports shorthands: `amd`, `amd64`, `arm`, `arm64` (normalized to `linux/amd64`, `linux/arm64`)
- Comma-separated for multiple: `--arch amd64,arm64`
- Mode-dependent defaults: `--push` defaults to both, `--prod` defaults to amd64, local uses native
- Multiple `--arch` flags accumulate: `--arch amd --arch arm`

### `--push-only` cache fix
Root cause: `.dockerignore` preparation was skipped for `--push-only`, so the build context differed from the dry-run, causing all BuildKit cache keys to miss. Fix: always prepare `.dockerignore`, only skip submodule validation for `--push-only`.

## Test plan
- [x] `--push --dry-run --arch amd64` builds successfully
- [x] `--push-only --arch amd64` shows CACHED for all steps (no rebuild)
- [x] `bash -n` syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)