### PR TITLE
fix: use explicit --format table in GROUP PERMISSIONS tests

### DIFF
--- a/sql/test_privacy.sh
+++ b/sql/test_privacy.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # Let's check that user2 can read
-if $SKDB tail "$subt1" --user ID2 2>&1 | grep -q "238|\"ID22\""; then
+if $SKDB tail "$subt1" --format=table --user ID2 2>&1 | grep -q "238|\"ID22\""; then
     pass "GROUP PERMISSIONS4"
 else
     fail "GROUP PERMISSIONS4"
@@ -121,7 +121,7 @@ fi
 echo "insert into skdb_user_permissions values ('ID2', skdb_permission(''), 'root')" | $SKDB
 
 # Let's check that user2 cannot read
-if $SKDB tail "$subt1" --user ID2 2>&1 | grep -q "238|\"ID22\""; then
+if $SKDB tail "$subt1" --format=table --user ID2 2>&1 | grep -q "238|\"ID22\""; then
     fail "GROUP PERMISSIONS6"
 else
     pass "GROUP PERMISSIONS6"
@@ -130,7 +130,7 @@ fi
 echo "delete from skdb_user_permissions where userID='ID2';" | $SKDB
 
 # Let's check that user2 can read again
-if $SKDB tail "$subt1" --user ID2 2>&1 | grep -q "238|\"ID22\""; then
+if $SKDB tail "$subt1" --format=table --user ID2 2>&1 | grep -q "238|\"ID22\""; then
     pass "GROUP PERMISSIONS7"
 else
     fail "GROUP PERMISSIONS7"
@@ -140,7 +140,7 @@ fi
 echo "delete from skdb_group_permissions where groupID='ID22' and userID='ID2';" | $SKDB
 
 # Let's check that user2 cannot read (after being kicked out)
-if $SKDB tail "$subt1" --user ID2 2>&1 | grep -q "238|\"ID22\""; then
+if $SKDB tail "$subt1" --format=table --user ID2 2>&1 | grep -q "238|\"ID22\""; then
     fail "GROUP PERMISSIONS8"
 else
     pass "GROUP PERMISSIONS8"
@@ -172,7 +172,7 @@ else
 fi
 
 # Let's check that user1 can read
-if $SKDB tail "$subt1" --user ID1 2>&1 | grep -q "240|\"ID23\""; then
+if $SKDB tail "$subt1" --format=table --user ID1 2>&1 | grep -q "240|\"ID23\""; then
     pass "GROUP PERMISSIONS11"
 else
     fail "GROUP PERMISSIONS11"


### PR DESCRIPTION
## Summary
- GROUP PERMISSIONS 4, 7, and 11 tests fail when run locally in Docker but pass in CircleCI
- Root cause: the default output format for `skdb` depends on `isatty(stdin)` — `"table"` when interactive, `"sql"` otherwise. CircleCI [allocates a pseudo-tty](https://github.com/pantsbuild/pants/issues/9924) so tests get `"table"` format (strings double-quoted), but local `docker run` without `-t` has no tty so tests get `"sql"` format (strings bare), causing grep patterns like `238|"ID22"` to not match
- Fix: add `--format=table` explicitly on `tail` calls that don't already specify a format

## Test plan
- [x] `make test-native` passes in local Docker container (all GROUP PERMISSIONS tests now pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)