### PR TITLE
Fix lint errors in preparation for ESLint 10

### DIFF
--- a/skiplang/prelude/ts/wasm/src/sk_types.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_types.ts
@@ -86,7 +86,7 @@ export class Options {
   }
 
   toFlags() {
-    let res = 0;
+    let res: number;
     if (this.read && this.write) {
       res = O_RDWR;
     } else if (this.read) {
@@ -251,7 +251,7 @@ export class Utils {
     this.mainFn = mainFn;
   }
   log = (str: string, kind?: Stream, newLine: boolean = false) => {
-    kind = kind ? kind : Stream.OUT;
+    kind = kind ?? Stream.OUT;
     str += newLine ? "\n" : "";
     if (kind == Stream.DEBUG) {
       // Flush buffered this.stddebug output at newlines

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -92,7 +92,7 @@ export interface Values<T> extends Iterable<T & DepSafe> {
    * Return the first value, if there is exactly one.
    * @param _default
    * @param _default.ifMany - Default value to use instead of throwing if there are multiple values.
-   * @throws {@link SkipNonUniqueValueError} if this iterable contains multiple values.
+   * @throws {SkipNonUniqueValueError} if this iterable contains multiple values.
    */
   getUnique(_default?: { ifMany?: T }): T & DepSafe;
 
@@ -130,7 +130,7 @@ export interface LazyCollection<K extends Json, V extends Json>
    * @param _default.ifNone - Default value for the case where **zero** values are associated to the given key
    * @param _default.ifMany - Default value for the case where **multiple** values are associated to the given key
    * @returns The value associated to `key`.
-   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
+   * @throws {SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
    */
   getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe;
 }
@@ -163,7 +163,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    * @param _default.ifNone - Default value for the case where **zero** values are associated to the given key
    * @param _default.ifMany - Default value for the case where **multiple** values are associated to the given key
    * @returns The value associated to `key`.
-   * @throws {@link SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
+   * @throws {SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
    */
   getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe;
 

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * The @skipruntime/core package contains internal implementation detail for the Skip Framework and should not need to be used directly. See the public API exposed by the @skipruntime/helpers package.
+ * The `@skipruntime/core` package contains internal implementation detail for the Skip Framework and should not need to be used directly. See the public API exposed by the `@skipruntime/helpers` package.
  *
  * @packageDocumentation
  */
@@ -1377,9 +1377,7 @@ export class ToBinding {
 
   //
   public getJsonConverter() {
-    if (this.skjson == undefined) {
-      this.skjson = this.getConverter();
-    }
+    this.skjson ??= this.getConverter();
     return this.skjson;
   }
 

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -160,7 +160,7 @@ export class SkipServiceBroker {
    * @param params - Resource instance parameters.
    * @param key - Key to read.
    * @returns The value associated to the key.
-   * @throws `SkipNonUniqueValueError` when the key is associated to either zero or multiple values.
+   * @throws {SkipNonUniqueValueError} when the key is associated to either zero or multiple values.
    */
   async getUnique<K extends Json, V extends Json>(
     resource: string,


### PR DESCRIPTION
## Summary
- Fix `no-useless-assignment` in `sk_types.ts` (use `let res: number` instead of `let res = 0`)
- Fix `prefer-nullish-coalescing` in `sk_types.ts` and `index.ts` (use `??` and `??=`)
- Fix `jsdoc/require-throws-type` in `api.ts` and `rest.ts` (use `{Type}` syntax)
- Fix `jsdoc/escape-inline-tags` in `index.ts` (backtick-escape package names in JSDoc)

These are valid lint improvements that pass with current ESLint 9 and unblock the ESLint 10 upgrade (#1101).

## Test plan
- [x] `make check-ts` passes (all build + lint) — only pre-existing `skc` wasm build failure remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)