### PR TITLE
docker: add STAGE build arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,17 @@ ENV CXX=clang++
 
 FROM skiplang-base AS bootstrap
 
+ARG STAGE=0
 COPY ./skiplang /work
 
 WORKDIR /work/compiler
-RUN make clean && make STAGE=0
+RUN make clean && make STAGE=$STAGE
 
 FROM skiplang-base AS skiplang
 
-COPY --link --from=bootstrap /work/compiler/stage0/bin/ /usr/bin/
-COPY --link --from=bootstrap /work/compiler/stage0/lib/ /usr/lib/
+ARG STAGE=0
+COPY --link --from=bootstrap /work/compiler/stage${STAGE}/bin/ /usr/bin/
+COPY --link --from=bootstrap /work/compiler/stage${STAGE}/lib/ /usr/lib/
 
 FROM skiplang AS skip
 

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -19,6 +19,10 @@
 #   --arch PLAT  Override platform(s). Shorthands: amd, amd64, arm, arm64.
 #                Comma-separated for multiple. Default depends on mode.
 #
+# Environment variables:
+#   STAGE        Compiler bootstrap stage (default: 0). Passed as STAGE build
+#                arg to the root Dockerfile (skiplang/skip targets).
+#
 # Images (if none specified, builds all applicable images):
 #   skiplang             Dockerfile --target skiplang
 #   skiplang-bin-builder skiplang/Dockerfile
@@ -187,6 +191,11 @@ else
     if ! $DRY_RUN; then
         BAKE_ARGS+=(--load)
     fi
+fi
+
+# Pass STAGE build arg to targets using the root Dockerfile
+if [[ -n "${STAGE:-}" ]]; then
+    BAKE_ARGS+=(--set "skiplang.args.STAGE=$STAGE" --set "skip.args.STAGE=$STAGE")
 fi
 
 # Determine which bake targets to build


### PR DESCRIPTION
## Summary
- Add `STAGE` build arg to the root Dockerfile so the compiler bootstrap stage is configurable (default: 0)
- Forward `STAGE` env var from `docker_build.sh` to the `skiplang` and `skip` bake targets
- Usage: `STAGE=1 bin/docker_build.sh skiplang`

## Test plan
- [x] Verified `STAGE=1 bin/docker_build.sh --dry-run skiplang` passes `--set skiplang.args.STAGE=1` to bake
- [x] Verified default (no STAGE) doesn't add any extra args
- [x] Verified full build succeeds with default STAGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)