### PR TITLE
fix: decouple `make check-ts` from wasm builds

### DIFF
--- a/bin/check-ts.sh
+++ b/bin/check-ts.sh
@@ -12,5 +12,9 @@ DIRS=$( jq --raw-output ".workspaces[]" package.json )
 
 for dir in $DIRS
 do
-    "$SCRIPT_DIR"/cd_sh "$dir" "npm run build --if-present && npm run lint --if-present"
+    if jq -e '.scripts.typecheck' "$dir/package.json" > /dev/null 2>&1; then
+        "$SCRIPT_DIR"/cd_sh "$dir" "npm run typecheck && npm run lint --if-present"
+    else
+        "$SCRIPT_DIR"/cd_sh "$dir" "npm run build --if-present && npm run lint --if-present"
+    fi
 done

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -9,7 +9,8 @@
     }
   },
   "scripts": {
-    "build": "node ../../prebuild.mjs skipwasm-std skipwasm-json && tsc && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=./dist/src/",
+    "build": "npm run typecheck && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=./dist/src/",
+    "typecheck": "node ../../prebuild.mjs skipwasm-std skipwasm-json && tsc",
     "clean": "rm -rf dist skipwasm-std skipwasm-json",
     "lint": "eslint"
   },

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -10,7 +10,8 @@
     "./orchestration.js": "./dist/src/skdb_orchestration.js"
   },
   "scripts": {
-    "build": "node ../../prebuild.mjs skiplang-std skiplang-json skipwasm-std skipwasm-json skipwasm-date skipwasm-worker && tsc && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../Skargo.toml --out-dir=./dist/src/",
+    "build": "npm run typecheck && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../Skargo.toml --out-dir=./dist/src/",
+    "typecheck": "node ../../prebuild.mjs skiplang-std skiplang-json skipwasm-std skipwasm-json skipwasm-date skipwasm-worker && tsc",
     "clean": "rm -rf dist skiplang-std skiplang-json skipwasm-std skipwasm-json skipwasm-date skipwasm-worker",
     "lint": "eslint",
     "cli": "node ./dist/src/skdb-cli.js"


### PR DESCRIPTION
## Summary
- Extract a `typecheck` script (prebuild + tsc) in `skipruntime-ts/wasm` and `sql/ts`, whose `build` scripts bundle `skargo build --target wasm32-unknown-unknown`
- Update `check-ts.sh` to prefer `typecheck` over `build` when available, so TS type-checking and linting no longer require the Skip wasm toolchain
- `npm run build` still works unchanged (calls `typecheck` then `skargo`)

## Test plan
- [x] `make check-ts` passes locally without a wasm-capable `skc`
- [x] CI `check-ts` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)