### PR TITLE
compiler: improve error message for deferred calls on base classes

### DIFF
--- a/skiplang/compiler/src/skipTyping.sk
+++ b/skiplang/compiler/src/skipTyping.sk
@@ -6158,11 +6158,21 @@ fun check_deferred_call(
       // abstract method on concrete
       void
     | (_, Some(deferred_pos), _) ->
+      context_hint = tobject match {
+      | "Base" ->
+        ". Note: deferred methods cannot be called on base classes" +
+          " — use a concrete subclass instead, or provide a manual" +
+          " implementation"
+      | _ -> ""
+      };
       msg2 =
         "'" +
         field_str +
         "' was declared as 'deferred'. It can" +
-        " be used only from 'static', in instance methods or deferred static methods. Or from a Concrete<_> object in a 'deferred' method";
+        " be used only from 'static', in instance methods or" +
+        " deferred static methods. Or from a Concrete<_> object" +
+        " in a 'deferred' method" +
+        context_hint;
       SkipError.errorl(
         List[(pos, "Invalid deferred call"), (deferred_pos, msg2)],
       )

--- a/skiplang/compiler/tests/typechecking/invalid/deferred_base_class_call.exp_err
+++ b/skiplang/compiler/tests/typechecking/invalid/deferred_base_class_call.exp_err
@@ -1,0 +1,14 @@
+File "tests/typechecking/invalid/deferred_base_class_call.sk", line 18, characters 3-13:
+Invalid deferred call
+16 |
+17 | fun test(): B {
+18 |   B::create()
+   |   ^^^^^^^^^^^
+19 | }
+
+File "tests/typechecking/invalid/deferred_base_class_call.sk", line 2, characters 3-10:
+'create' was declared as 'deferred'. It can be used only from 'static', in instance methods or deferred static methods. Or from a Concrete<_> object in a 'deferred' method. Note: deferred methods cannot be called on base classes — use a concrete subclass instead, or provide a manual implementation
+1 | base class B {
+2 |   deferred static fun create(): this;
+  |   ^^^^^^^^
+3 | }

--- a/skiplang/compiler/tests/typechecking/invalid/deferred_base_class_call.sk
+++ b/skiplang/compiler/tests/typechecking/invalid/deferred_base_class_call.sk
@@ -1,0 +1,19 @@
+base class B {
+  deferred static fun create(): this;
+}
+
+class C1() extends B {
+  static fun create(): this {
+    C1()
+  }
+}
+
+class C2() extends B {
+  static fun create(): this {
+    C2()
+  }
+}
+
+fun test(): B {
+  B::create()
+}

--- a/skiplang/compiler/tests/typechecking/invalid/late_static3.exp_err
+++ b/skiplang/compiler/tests/typechecking/invalid/late_static3.exp_err
@@ -7,7 +7,7 @@ Invalid deferred call
 10 |   print_raw("Fail")
 
 File "tests/typechecking/invalid/late_static3.sk", line 3, characters 3-10:
-'bad' was declared as 'deferred'. It can be used only from 'static', in instance methods or deferred static methods. Or from a Concrete<_> object in a 'deferred' method
+'bad' was declared as 'deferred'. It can be used only from 'static', in instance methods or deferred static methods. Or from a Concrete<_> object in a 'deferred' method. Note: deferred methods cannot be called on base classes — use a concrete subclass instead, or provide a manual implementation
 1 | base class Foo {
 2 |   static fun abs(): void;
 3 |   deferred static fun bad(): void {

--- a/skiplang/compiler/tests/typechecking/invalid/late_static7.exp_err
+++ b/skiplang/compiler/tests/typechecking/invalid/late_static7.exp_err
@@ -7,7 +7,7 @@ Invalid deferred call
 12 | }
 
 File "tests/typechecking/invalid/late_static7.sk", line 3, characters 3-10:
-'foo' was declared as 'deferred'. It can be used only from 'static', in instance methods or deferred static methods. Or from a Concrete<_> object in a 'deferred' method
+'foo' was declared as 'deferred'. It can be used only from 'static', in instance methods or deferred static methods. Or from a Concrete<_> object in a 'deferred' method. Note: deferred methods cannot be called on base classes — use a concrete subclass instead, or provide a manual implementation
 1 | base class Foo {
 2 |   static fun abs(): void;
 3 |   deferred static fun foo(): void {


### PR DESCRIPTION
## Summary
- When calling a deferred method on a base class, the error now includes a hint explaining that deferred methods cannot be called on base classes and suggests using a concrete subclass or providing a manual implementation
- Previously, the error just said "Invalid deferred call" with no guidance on how to fix it when the issue is using a base class

### Example

Given a base class with a deferred method:

```skip
base class B {
  deferred static fun create(): this;
}

class C1() extends B {
  static fun create(): this { C1() }
}

fun test(): B {
  B::create()  // Error: calling deferred method on base class
}
```

**Before:**
```
Invalid deferred call

'create' was declared as 'deferred'. It can be used only from 'static',
in instance methods or deferred static methods. Or from a Concrete<_>
object in a 'deferred' method
```

**After:**
```
Invalid deferred call

'create' was declared as 'deferred'. It can be used only from 'static',
in instance methods or deferred static methods. Or from a Concrete<_>
object in a 'deferred' method. Note: deferred methods cannot be called
on base classes — use a concrete subclass instead, or provide a manual
implementation
```

## Test plan
- [x] `skargo check` passes on the compiler
- [x] Added typechecking test: `tests/typechecking/invalid/deferred_base_class_call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)