### PR TITLE
build: improve error when libbacktrace submodule is not initialized

### DIFF
--- a/skiplang/prelude/build.sk
+++ b/skiplang/prelude/build.sk
@@ -93,6 +93,13 @@ fun build_libbacktrace(
   };
 
   // Resort to building libbacktrace from source.
+  if (!FileSystem.exists("./libbacktrace/configure")) {
+    print_error(
+      "Error: libbacktrace submodule is not initialized.\n" +
+        "Run: git submodule update --init skiplang/prelude/libbacktrace\n",
+    );
+    skipExit(1)
+  };
   p = System.popen{
     args => Array["./configure", "--prefix", out_dir].concat(
       if (pic) Array["--with-pic"] else Array[],


### PR DESCRIPTION
## Summary
- Adds a check in the prelude build script for the `libbacktrace/configure` file before attempting to run it
- When the libbacktrace submodule is not initialized, prints a clear error with the exact `git submodule update` command instead of the cryptic `env: './configure': No such file or directory`

## Test plan
- [x] `skargo test` passes with submodule initialized
- [ ] Without submodule: verify error message shows `git submodule update --init skiplang/prelude/libbacktrace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)