### PR TITLE
Allow undefined fields on JsonObject

### DIFF
--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -167,7 +167,7 @@ export type Json =
 /**
  * Objects containing `Json` values.
  */
-export type JsonObject = { readonly [key: string]: Json | null };
+export type JsonObject = { readonly [key: string]: Json | null | undefined };
 
 export type Exportable =
   | null

--- a/skipruntime-ts/helpers/src/external.ts
+++ b/skipruntime-ts/helpers/src/external.ts
@@ -16,6 +16,7 @@ export function defaultParamEncoder(params: Json): string {
   if (typeof params == "object") {
     const queryParams: { [param: string]: string } = {};
     for (const [key, value] of Object.entries(params)) {
+      if (value === undefined) continue;
       if (typeof value == "object") queryParams[key] = JSON.stringify(value);
       else queryParams[key] = value.toString();
     }


### PR DESCRIPTION
Today, defining an object with optional values involves the systematic use of the null value or defining the union of all versions of the type.