### PR TITLE
Docker build: simplify args and integrate build_runtime

### DIFF
--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Build all Docker images locally
-# Usage: build_docker_images.sh [--prod]
+# Usage: build_docker_images.sh [--arch PLATFORMS]
 
 set -euo pipefail
 

--- a/bin/build_prod_skdb_images.sh
+++ b/bin/build_prod_skdb_images.sh
@@ -4,4 +4,4 @@
 
 set -euo pipefail
 
-exec "$(dirname -- "${BASH_SOURCE[0]}")"/docker_build.sh --prod
+exec "$(dirname -- "${BASH_SOURCE[0]}")"/docker_build.sh --arch amd64

--- a/bin/build_runtime.sh
+++ b/bin/build_runtime.sh
@@ -1,48 +1,21 @@
-#! /bin/bash
+#!/bin/bash
 
-# Script to build skipruntime binary release
+# Build skipruntime binary release (libskipruntime.so)
 # Usage: build_runtime.sh [arch]
 # Example: build_runtime.sh arm64
 # Default: arm64,amd64
 
-set -xeuo pipefail
+set -euo pipefail
 
-if [ $# -gt 0 ]; then
-    ARCH="$1"
-else
-    ARCH="arm64,amd64"
-fi
-
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_DIR="$SCRIPT_DIR/../"
-cd "$REPO_DIR" || exit
-
-git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
-echo ".git" >> .dockerignore
-
-builder=$(docker buildx create --use)
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+ARCH="${1:-arm64,amd64}"
 
 for arch in ${ARCH//,/ }; do
-    {
-        docker buildx build \
-            --progress=plain \
-            --platform="linux/$arch" \
-            --file=skipruntime-ts/Dockerfile \
-            --output=type=local,dest=build/linux_"$arch" \
-            .
-    } > "build_$arch.log" 2>&1 &
+    "$SCRIPT_DIR"/docker_build.sh --arch "$arch" skipruntime \
+        -- --set "skipruntime.output=type=local,dest=build/linux_$arch"
 done
-wait
-
-docker buildx stop "$builder"
-docker buildx rm "$builder"
-
-git restore .dockerignore
 
 for arch in ${ARCH//,/ }; do
-    echo "=== Build log for linux/$arch ==="
-    cat "build_$arch.log"
-    rm "build_$arch.log"
     mv "build/linux_$arch/libskipruntime.so" "build/libskipruntime.so-linux-$arch"
     rmdir "build/linux_$arch"
 done

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -19,8 +19,10 @@
 #                Comma-separated for multiple. Default: native architecture.
 #
 # Environment variables:
-#   STAGE        Compiler bootstrap stage (default: 0). Passed as STAGE build
-#                arg to the root Dockerfile (skiplang/skip targets).
+#   STAGE              Compiler bootstrap stage (default: 0). Passed as STAGE
+#                      build arg to the root Dockerfile (skiplang/skip targets).
+#   DOCKER_DEFAULT_ARCH  Default platform(s) when --arch is not given.
+#                        Supports same shorthands as --arch.
 #
 # Images (if none specified, builds all applicable images):
 #   skiplang             Dockerfile --target skiplang
@@ -57,6 +59,11 @@ while [[ $# -gt 0 ]]; do
         *) IMAGES+=("$1"); shift ;;
     esac
 done
+
+# Apply default arch from environment if no --arch was given
+if [[ -z "$ARCH" && -n "${DOCKER_DEFAULT_ARCH:-}" ]]; then
+    ARCH="$DOCKER_DEFAULT_ARCH"
+fi
 
 # Normalize --arch shorthands
 if [[ -n "$ARCH" ]]; then

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -80,10 +80,9 @@ if [[ -n "$ARCH" ]]; then
     ARCH=$(IFS=,; echo "${normalized[*]}")
 fi
 
-# Validate flag combinations
-if $PUSH_ONLY && $PUSH; then
-    echo "Error: --push-only and --push are mutually exclusive" >&2
-    exit 1
+# Validate flag combinations (--push-only overrides --push for caller convenience)
+if $PUSH_ONLY; then
+    PUSH=false
 fi
 if $PUSH_ONLY && $DRY_RUN; then
     echo "Error: --push-only and --dry-run are mutually exclusive" >&2

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -7,14 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(dirname -- "${BASH_SOURCE[0]}")
 
-# Default to both architectures (override with --arch)
-has_arch=false
-for arg in "$@"; do
-    [[ "$arg" = "--arch" || "$arg" == --arch=* ]] && has_arch=true
-done
-if ! $has_arch; then
-    set -- --arch amd64,arm64 "$@"
-fi
+export DOCKER_DEFAULT_ARCH="${DOCKER_DEFAULT_ARCH:-amd64,arm64}"
 
 # --push-only replaces --push (they are mutually exclusive in docker_build.sh)
 for arg in "$@"; do

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -7,6 +7,15 @@ set -euo pipefail
 
 SCRIPT_DIR=$(dirname -- "${BASH_SOURCE[0]}")
 
+# Default to both architectures (override with --arch)
+has_arch=false
+for arg in "$@"; do
+    [[ "$arg" = "--arch" || "$arg" == --arch=* ]] && has_arch=true
+done
+if ! $has_arch; then
+    set -- --arch amd64,arm64 "$@"
+fi
+
 # --push-only replaces --push (they are mutually exclusive in docker_build.sh)
 for arg in "$@"; do
     if [[ "$arg" = "--push-only" ]]; then

--- a/bin/release_docker.sh
+++ b/bin/release_docker.sh
@@ -9,11 +9,4 @@ SCRIPT_DIR=$(dirname -- "${BASH_SOURCE[0]}")
 
 export DOCKER_DEFAULT_ARCH="${DOCKER_DEFAULT_ARCH:-amd64,arm64}"
 
-# --push-only replaces --push (they are mutually exclusive in docker_build.sh)
-for arg in "$@"; do
-    if [[ "$arg" = "--push-only" ]]; then
-        exec "$SCRIPT_DIR"/docker_build.sh "$@"
-    fi
-done
-
 exec "$SCRIPT_DIR"/docker_build.sh --push "$@"

--- a/bin/release_docker_ci_images.sh
+++ b/bin/release_docker_ci_images.sh
@@ -10,14 +10,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPO="$SCRIPT_DIR/.."
 
-# Default to amd64 for CI images (override with --arch)
-has_arch=false
-for arg in "$@"; do
-    [[ "$arg" = "--arch" || "$arg" == --arch=* ]] && has_arch=true
-done
-if ! $has_arch; then
-    set -- --arch amd64 "$@"
-fi
+export DOCKER_DEFAULT_ARCH="${DOCKER_DEFAULT_ARCH:-amd64}"
 
 # Extract unique skiplabs/ image names from CI config
 mapfile -t images < <(

--- a/bin/release_docker_ci_images.sh
+++ b/bin/release_docker_ci_images.sh
@@ -2,12 +2,22 @@
 
 # Build and push Docker images used in CI.
 # Image names are extracted from .circleci/base.yml so the two stay in sync.
-# Usage: release_docker_ci_images.sh [--dry-run]
+# Defaults to amd64 only; use --arch to override (e.g. --arch amd64,arm64).
+# Usage: release_docker_ci_images.sh [--dry-run] [--arch PLATFORMS]
 
 set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPO="$SCRIPT_DIR/.."
+
+# Default to amd64 for CI images (override with --arch)
+has_arch=false
+for arg in "$@"; do
+    [[ "$arg" = "--arch" || "$arg" == --arch=* ]] && has_arch=true
+done
+if ! $has_arch; then
+    set -- --arch amd64 "$@"
+fi
 
 # Extract unique skiplabs/ image names from CI config
 mapfile -t images < <(

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -78,3 +78,9 @@ target "skdb-dev-server" {
   tags       = ["skiplabs/skdb-dev-server:latest"]
   contexts   = { "skiplabs/skdb" = "target:skdb" }
 }
+
+# Native shared library for Skip runtime (opt-in, not in any group)
+target "skipruntime" {
+  dockerfile = "skipruntime-ts/Dockerfile"
+  contexts   = { "skiplabs/skiplang-bin-builder" = "target:skiplang-bin-builder" }
+}


### PR DESCRIPTION
## Summary

- Remove `--prod` flag from `docker_build.sh`, replaced by `--arch amd64`
- Default CI image builds to amd64 only (via `DOCKER_DEFAULT_ARCH` env var)
- Decouple `--push` from platform selection — platform is now controlled exclusively by `--arch`
- Add `DOCKER_DEFAULT_ARCH` env var to replace duplicated arch-detection loops in wrapper scripts
- Make `--push-only` override `--push` instead of erroring, simplifying `release_docker.sh` to a single `exec` line
- Integrate `build_runtime.sh` into the bake system: new `skipruntime` target in `docker-bake.hcl`, `--` passthrough for extra bake args

## Test plan

- [ ] `bin/build_docker_images.sh` builds all images locally (native arch)
- [ ] `bin/build_docker_images.sh --arch amd64` builds amd64 only
- [ ] `bin/release_docker.sh --dry-run skiplang` builds amd64+arm64
- [ ] `bin/release_docker_ci_images.sh --dry-run` builds amd64 only
- [ ] `bin/build_runtime.sh amd64` produces `build/libskipruntime.so-linux-amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)