### PR TITLE
Add Claude Code format hook for auto-formatting edited files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/bin/claude_hooks/format_file.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/bin/claude_hooks/format_file.sh
+++ b/bin/claude_hooks/format_file.sh
@@ -11,7 +11,6 @@ if [ -z "$file_path" ]; then
 fi
 
 PRETTIER_VERSION=$(jq -r '.devDependencies.prettier' "$CLAUDE_PROJECT_DIR/package.json")
-BLACK_VERSION=$(grep '^black==' "$CLAUDE_PROJECT_DIR/requirements-dev.txt" | cut -d'=' -f3)
 
 case "$file_path" in
     *.sk)

--- a/bin/claude_hooks/format_file.sh
+++ b/bin/claude_hooks/format_file.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Format a single file based on its extension.
+# Called by Claude Code PostToolUse hook with JSON on stdin.
+# Keep in sync with bin/git_hooks/check_format.sh
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+
+if [ -z "$file_path" ]; then
+    exit 0
+fi
+
+PRETTIER_VERSION=$(jq -r '.devDependencies.prettier' "$CLAUDE_PROJECT_DIR/package.json")
+BLACK_VERSION=$(grep '^black==' "$CLAUDE_PROJECT_DIR/requirements-dev.txt" | cut -d'=' -f3)
+
+case "$file_path" in
+    *.sk)
+        if command -v skfmt &>/dev/null; then
+            skfmt -i "$file_path"
+        else
+            DOCKER_IMAGE="${DOCKER_IMAGE:-skiplabs/skip:latest}"
+            REL_PATH="${file_path#"$CLAUDE_PROJECT_DIR"/}"
+            docker run --rm \
+                -v "$CLAUDE_PROJECT_DIR:/work/skip" \
+                -w /work/skip \
+                "$DOCKER_IMAGE" \
+                skfmt -i "$REL_PATH"
+        fi
+        ;;
+    *.c|*.cc|*.cpp|*.h|*.hh|*.hpp)
+        if command -v clang-format &>/dev/null; then
+            clang-format -i "$file_path"
+        fi
+        ;;
+    *.css|*.html|*.js|*.json|*.mjs|*.ts|*.tsx)
+        npx -y prettier@"$PRETTIER_VERSION" --write "$file_path"
+        ;;
+    *.py)
+        black --quiet --line-length 80 "$file_path"
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds a PostToolUse hook that auto-formats files after Edit/Write tool use in Claude Code
- Supports skfmt (.sk), clang-format (C/C++), prettier (JS/TS/CSS/HTML/JSON), and black (Python)
- Keeps formatting rules in sync with `bin/git_hooks/check_format.sh`

## Test plan
- [x] Tested with `.sk` file — skfmt formats correctly
- [x] Tested with `.cpp` file — clang-format formats correctly
- [x] Tested with `.ts` file — prettier formats correctly
- [x] Tested with `.py` file — black formats correctly
- [x] Tested with unmatched extension (`.rs`) — no-op as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)