### PR TITLE
Add FileSystem.stat: single-call POSIX stat with FileKind ADT

### DIFF
--- a/skiplang/prelude/runtime/runtime64_specific.cpp
+++ b/skiplang/prelude/runtime/runtime64_specific.cpp
@@ -514,6 +514,29 @@ bool SKIP_is_directory(char* path) {
   return st.st_mode & S_IFDIR;
 }
 
+// Must match FileStat field layout: mode, size, mtime, atime, ctime
+typedef struct {
+  int64_t mode;
+  int64_t size;
+  int64_t mtime;
+  int64_t atime;
+  int64_t ctime;
+} sk_file_stat_t;
+
+int64_t SKIP_file_stat(sk_file_stat_t* result, char* path) {
+  struct stat st;
+  int rc = stat(path, &st);
+  if (rc < 0) {
+    return rc;
+  }
+  result->mode = st.st_mode;
+  result->size = st.st_size;
+  result->mtime = st.st_mtime;
+  result->atime = st.st_atime;
+  result->ctime = st.st_ctime;
+  return 0;
+}
+
 int64_t SKIP_system(char* cmd) {
   sk_string_check_c_safe(cmd);
   int64_t res = system(cmd);

--- a/skiplang/prelude/src/stdlib/filesystem/FileSystem.sk
+++ b/skiplang/prelude/src/stdlib/filesystem/FileSystem.sk
@@ -12,6 +12,48 @@
 @may_alloc
 native fun getcwd(): String;
 
+base class FileKind uses Orderable {
+  children =
+  | FKRegular()
+  | FKDirectory()
+  | FKSymlink()
+  | FKCharDevice()
+  | FKBlockDevice()
+  | FKFifo()
+  | FKSocket()
+  | FKUnknown()
+}
+
+// Layout must match sk_file_stat_t in runtime64_specific.cpp.
+// mode is the full st_mode (file type + permissions).
+// Could be extended with: dev, ino, nlink, uid, gid, rdev, blksize, blocks.
+mutable class FileStat(
+  mutable mode: Int,
+  mutable size: Int,
+  mutable mtime: Int,
+  mutable atime: Int,
+  mutable ctime: Int,
+) {
+  // Extract file type from mode.
+  fun kind(): FileKind {
+    this.mode.and(0o170000) match {
+    | 0o140000 -> FKSocket()
+    | 0o120000 -> FKSymlink()
+    | 0o100000 -> FKRegular()
+    | 0o060000 -> FKBlockDevice()
+    | 0o040000 -> FKDirectory()
+    | 0o020000 -> FKCharDevice()
+    | 0o010000 -> FKFifo()
+    | _ -> FKUnknown()
+    }
+  }
+
+  // Extract permission bits (lower 9 bits of mode).
+  fun permissions(): Int {
+    this.mode.and(0o777)
+  }
+}
+
 module FileSystem;
 
 // This is really broken - you can't read a file into a String without an
@@ -99,6 +141,15 @@ fun readFilesRecursive(
 
   result.chill();
 }
+
+fun stat(path: String): ?FileStat {
+  result = mutable FileStat(0, 0, 0, 0, 0);
+  rc = fillStat(result, path);
+  if (rc < 0) None() else Some(unsafe_chill_trust_me(result))
+}
+
+@cpp_extern("SKIP_file_stat")
+private native fun fillStat(result: mutable FileStat, path: String): Int;
 
 // TODO: Rename the C++ entrypoints and merge these into the
 // public API above.


### PR DESCRIPTION
## Summary
- Add `FileSystem.stat(path)` that calls POSIX `stat()` once and returns all fields (mode, size, mtime, atime, ctime) as a `FileStat` object, or `None()` if the path doesn't exist
- Add `FileKind` ADT (FKRegular, FKDirectory, FKSymlink, etc.) with `kind()` and `permissions()` methods for interpreting the mode field
- Add C runtime function `SKIP_file_stat` backing the native call

## Test plan
- [ ] Verify `FileSystem.stat` returns correct metadata for files, directories, and symlinks
- [ ] Verify `None()` is returned for non-existent paths
- [ ] Verify `kind()` correctly classifies file types
- [ ] Verify `permissions()` extracts the expected permission bits

🤖 Generated with [Claude Code](https://claude.com/claude-code)