### PR TITLE
build_runtime: cd to repo root before mv

### DIFF
--- a/bin/build_runtime.sh
+++ b/bin/build_runtime.sh
@@ -8,6 +8,9 @@
 set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO="$SCRIPT_DIR/.."
+cd "$REPO"
+
 ARCH="${1:-arm64,amd64}"
 
 for arch in ${ARCH//,/ }; do


### PR DESCRIPTION
## Summary

- Fix CI failure in `skipruntime` job introduced by #1110
- `docker_build.sh` does `cd "$REPO"` so bake output (`dest=build/linux_amd64`) lands in the repo root, but `build_runtime.sh`'s `mv` was running from the caller's directory (in CI: `skipruntime-ts/tests/native_addon_unreleased/`)

## Test plan

- [x] CI `skipruntime` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)