### PR TITLE
Prepare for TypeScript 6.0 compatibility

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -57,6 +57,21 @@ jobs:
       - run:
           name: Typecheck and lint typescript sources
           command: make check-ts
+      - run:
+          name: Check locked TypeScript version
+          command: |
+            ts_version=$(npx tsc --version | awk '{print $2}')
+            if [[ ! "$ts_version" =~ ^5\.7\. ]]; then
+              echo "ERROR: Locked TypeScript version is $ts_version, expected 5.7.x"
+              echo "Update the additional typecheck steps in this job."
+              exit 1
+            fi
+      - run:
+          name: Typecheck with TypeScript ~5.8.0
+          command: npm install --save-dev typescript@~5.8.0 --ignore-scripts && SKIP_LINT=1 bin/check-ts.sh
+      - run:
+          name: Typecheck with TypeScript ~6.0.0
+          command: npm install --save-dev typescript@~6.0.0 --ignore-scripts && SKIP_LINT=1 bin/check-ts.sh
 
   compiler:
     docker:

--- a/bin/check-ts.sh
+++ b/bin/check-ts.sh
@@ -10,11 +10,16 @@ REPO="$SCRIPT_DIR/.."
 cd "$REPO"
 DIRS=$( jq --raw-output ".workspaces[]" package.json )
 
+LINT=""
+if [ -z "${SKIP_LINT:-}" ]; then
+    LINT=" && npm run lint --if-present"
+fi
+
 for dir in $DIRS
 do
     if jq -e '.scripts.typecheck' "$dir/package.json" > /dev/null 2>&1; then
-        "$SCRIPT_DIR"/cd_sh "$dir" "npm run typecheck && npm run lint --if-present"
+        "$SCRIPT_DIR"/cd_sh "$dir" "npm run typecheck$LINT"
     else
-        "$SCRIPT_DIR"/cd_sh "$dir" "npm run build --if-present && npm run lint --if-present"
+        "$SCRIPT_DIR"/cd_sh "$dir" "npm run build --if-present$LINT"
     fi
 done

--- a/examples/blogger/reactive_service/package.json
+++ b/examples/blogger/reactive_service/package.json
@@ -14,15 +14,15 @@
   "license": "MIT",
   "description": "Reactive blogger service using Skip runtime",
   "dependencies": {
-    "@skipruntime/core": "0.0.19",
-    "@skipruntime/wasm": "0.0.19",
-    "@skipruntime/server": "0.0.19",
-    "@skipruntime/helpers": "0.0.19",
-    "@skip-adapter/postgres": "0.0.19"
+    "@skipruntime/core": "0.0.20",
+    "@skipruntime/wasm": "0.0.21",
+    "@skipruntime/server": "0.0.21",
+    "@skipruntime/helpers": "0.0.21",
+    "@skip-adapter/postgres": "0.0.21"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.1",
+    "@skiplabs/tsconfig": "^0.0.2",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0",
     "eslint": "10.0.0"

--- a/examples/blogger/reactive_service/tsconfig.json
+++ b/examples/blogger/reactive_service/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/examples/cache_invalidation/edge_service/package.json
+++ b/examples/cache_invalidation/edge_service/package.json
@@ -14,15 +14,15 @@
   "license": "MIT",
   "description": "Reactive cache service using Skip runtime",
   "dependencies": {
-    "@skipruntime/core": "0.0.19",
-    "@skipruntime/wasm": "0.0.19",
-    "@skipruntime/server": "0.0.19",
-    "@skipruntime/helpers": "0.0.19",
-    "@skip-adapter/postgres": "0.0.19"
+    "@skipruntime/core": "0.0.20",
+    "@skipruntime/wasm": "0.0.21",
+    "@skipruntime/server": "0.0.21",
+    "@skipruntime/helpers": "0.0.21",
+    "@skip-adapter/postgres": "0.0.21"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.1",
+    "@skiplabs/tsconfig": "^0.0.2",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0",
     "eslint": "10.0.0"

--- a/examples/cache_invalidation/edge_service/tsconfig.json
+++ b/examples/cache_invalidation/edge_service/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/examples/chatroom/reactive_service/package.json
+++ b/examples/chatroom/reactive_service/package.json
@@ -9,15 +9,16 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/core": "0.0.19",
-    "@skipruntime/wasm": "0.0.19",
-    "@skipruntime/server": "0.0.19",
-    "@skipruntime/helpers": "0.0.19",
-    "@skip-adapter/kafka": "0.0.19",
+    "@skipruntime/core": "0.0.20",
+    "@skipruntime/wasm": "0.0.21",
+    "@skipruntime/server": "0.0.21",
+    "@skipruntime/helpers": "0.0.21",
+    "@skip-adapter/kafka": "0.0.21",
     "kafkajs": "^2.2.4"
   },
   "devDependencies": {
+    "@types/node": "^22.10.0",
     "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.1"
+    "@skiplabs/tsconfig": "^0.0.2"
   }
 }

--- a/examples/chatroom/reactive_service/tsconfig.json
+++ b/examples/chatroom/reactive_service/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@skiplabs/tsconfig",
   "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
     "skipLibCheck": true
   }
 }

--- a/examples/chatroom/web_service/package.json
+++ b/examples/chatroom/web_service/package.json
@@ -10,13 +10,14 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/helpers": "0.0.18",
+    "@skipruntime/helpers": "0.0.21",
     "express": "^4.21.1",
     "kafkajs": "^2.2.4"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "@types/node": "^22.10.0",
     "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.1"
+    "@skiplabs/tsconfig": "^0.0.2"
   }
 }

--- a/examples/chatroom/web_service/tsconfig.json
+++ b/examples/chatroom/web_service/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@skiplabs/tsconfig",
   "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
     "skipLibCheck": true
   }
 }

--- a/examples/hackernews/reactive_service/package.json
+++ b/examples/hackernews/reactive_service/package.json
@@ -9,15 +9,15 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/core": "0.0.19",
-    "@skipruntime/wasm": "0.0.19",
-    "@skipruntime/server": "0.0.19",
-    "@skipruntime/helpers": "0.0.19",
-    "@skip-adapter/postgres": "0.0.19"
+    "@skipruntime/core": "0.0.20",
+    "@skipruntime/wasm": "0.0.21",
+    "@skipruntime/server": "0.0.21",
+    "@skipruntime/helpers": "0.0.21",
+    "@skip-adapter/postgres": "0.0.21"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
     "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.1"
+    "@skiplabs/tsconfig": "^0.0.2"
   }
 }

--- a/examples/hackernews/reactive_service/tsconfig.json
+++ b/examples/hackernews/reactive_service/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "@skiplabs/tsconfig",
   "compilerOptions": {
-    "skipLibCheck": true
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "types": ["node"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       ],
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
-        "@skiplabs/tsconfig": "^0.0.1",
+        "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^22.10.0",
         "eslint": "10.0.0",
         "prettier": "3.4.1",
@@ -343,15 +343,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.19",
-        "@skipruntime/core": "0.0.19",
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/server": "0.0.19",
-        "@skipruntime/wasm": "0.0.19"
+        "@skip-adapter/postgres": "0.0.20",
+        "@skipruntime/core": "0.0.20",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/server": "0.0.20",
+        "@skipruntime/wasm": "0.0.20"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
-        "@skiplabs/tsconfig": "^0.0.1",
+        "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^20.0.0",
         "eslint": "10.0.0",
         "typescript": "^5.0.0"
@@ -379,15 +379,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.19",
-        "@skipruntime/core": "0.0.19",
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/server": "0.0.19",
-        "@skipruntime/wasm": "0.0.19"
+        "@skip-adapter/postgres": "0.0.20",
+        "@skipruntime/core": "0.0.20",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/server": "0.0.20",
+        "@skipruntime/wasm": "0.0.20"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
-        "@skiplabs/tsconfig": "^0.0.1",
+        "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^20.0.0",
         "eslint": "10.0.0",
         "typescript": "^5.0.0"
@@ -415,16 +415,16 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/kafka": "0.0.19",
-        "@skipruntime/core": "0.0.19",
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/server": "0.0.19",
-        "@skipruntime/wasm": "0.0.19",
+        "@skip-adapter/kafka": "0.0.20",
+        "@skipruntime/core": "0.0.20",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/server": "0.0.20",
+        "@skipruntime/wasm": "0.0.20",
         "kafkajs": "^2.2.4"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
-        "@skiplabs/tsconfig": "^0.0.1"
+        "@skiplabs/tsconfig": "^0.0.2"
       }
     },
     "examples/hackernews/reactive_service": {
@@ -432,15 +432,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.19",
-        "@skipruntime/core": "0.0.19",
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/server": "0.0.19",
-        "@skipruntime/wasm": "0.0.19"
+        "@skip-adapter/postgres": "0.0.20",
+        "@skipruntime/core": "0.0.20",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/server": "0.0.20",
+        "@skipruntime/wasm": "0.0.20"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
-        "@skiplabs/tsconfig": "^0.0.1",
+        "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^22.10.0"
       }
     },
@@ -5442,17 +5442,17 @@
     },
     "skiplang/prelude/ts/wasm": {
       "name": "@skip-wasm/std",
-      "version": "1.0.6"
+      "version": "1.0.7"
     },
     "skiplang/prelude/ts/worker": {
       "name": "@skip-wasm/worker",
-      "version": "0.0.0"
+      "version": "0.0.1"
     },
     "skiplang/skdate/ts": {
       "name": "@skip-wasm/date",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
-        "@skip-wasm/std": "1.0.6"
+        "@skip-wasm/std": "1.0.7"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -5461,18 +5461,18 @@
     },
     "skiplang/skjson/ts/binding": {
       "name": "@skiplang/json",
-      "version": "0.0.4"
+      "version": "0.0.5"
     },
     "skiplang/skjson/ts/wasm": {
       "name": "@skip-wasm/json",
-      "version": "1.0.7"
+      "version": "1.0.8"
     },
     "skipruntime-ts/adapters/kafka": {
       "name": "@skip-adapter/kafka",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.19",
+        "@skipruntime/core": "0.0.20",
         "kafkajs": "^2.2.4"
       },
       "engines": {
@@ -5481,10 +5481,10 @@
     },
     "skipruntime-ts/adapters/postgres": {
       "name": "@skip-adapter/postgres",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.19",
+        "@skipruntime/core": "0.0.20",
         "pg": "^8.13.1",
         "pg-format": "^1.0.4"
       },
@@ -5498,21 +5498,21 @@
     },
     "skipruntime-ts/addon": {
       "name": "@skipruntime/native",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "hasInstallScript": true,
       "dependencies": {
-        "@skipruntime/core": "0.0.19"
+        "@skipruntime/core": "0.0.20"
       }
     },
     "skipruntime-ts/core": {
       "name": "@skipruntime/core",
-      "version": "0.0.19"
+      "version": "0.0.20"
     },
     "skipruntime-ts/examples": {
       "name": "skipruntime-examples",
       "dependencies": {
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/server": "0.0.19",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/server": "0.0.20",
         "better-sqlite3": "^11.7.2",
         "eventsource": "^2.0.2"
       },
@@ -5523,10 +5523,10 @@
     },
     "skipruntime-ts/helpers": {
       "name": "@skipruntime/helpers",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.19",
+        "@skipruntime/core": "0.0.20",
         "eventsource": "^2.0.2",
         "express": "^4.21.1"
       },
@@ -5539,24 +5539,24 @@
     },
     "skipruntime-ts/metapackage": {
       "name": "@skiplabs/skip",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@skipruntime/core": "0.0.19",
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/server": "0.0.19",
-        "@skipruntime/wasm": "0.0.19"
+        "@skipruntime/core": "0.0.20",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/server": "0.0.20",
+        "@skipruntime/wasm": "0.0.20"
       },
       "optionalDependencies": {
-        "@skip-adapter/kafka": "0.0.19",
-        "@skip-adapter/postgres": "0.0.19",
-        "@skipruntime/native": "0.0.19"
+        "@skip-adapter/kafka": "0.0.20",
+        "@skip-adapter/postgres": "0.0.20",
+        "@skipruntime/native": "0.0.20"
       }
     },
     "skipruntime-ts/server": {
       "name": "@skipruntime/server",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@skipruntime/core": "0.0.19",
+        "@skipruntime/core": "0.0.20",
         "express": "^4.21.1"
       },
       "devDependencies": {
@@ -5567,18 +5567,18 @@
         "tsx": "^4.19.3"
       },
       "optionalDependencies": {
-        "@skipruntime/native": "0.0.19",
-        "@skipruntime/wasm": "0.0.19"
+        "@skipruntime/native": "0.0.20",
+        "@skipruntime/wasm": "0.0.20"
       }
     },
     "skipruntime-ts/tests": {
       "name": "@skipruntime/tests",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.19",
-        "@skipruntime/core": "0.0.19",
-        "@skipruntime/helpers": "0.0.19",
-        "@skipruntime/native": "0.0.19",
-        "@skipruntime/wasm": "0.0.19",
+        "@skip-adapter/postgres": "0.0.20",
+        "@skipruntime/core": "0.0.20",
+        "@skipruntime/helpers": "0.0.20",
+        "@skipruntime/native": "0.0.20",
+        "@skipruntime/wasm": "0.0.20",
         "earl": "^1.3.0",
         "mocha": "^11.0.1",
         "pg": "^8.13.1"
@@ -5590,14 +5590,14 @@
     },
     "skipruntime-ts/wasm": {
       "name": "@skipruntime/wasm",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "dependencies": {
-        "@skipruntime/core": "0.0.19"
+        "@skipruntime/core": "0.0.20"
       }
     },
     "sql/ts": {
       "name": "skdb",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bin": {
         "skdb-cli": "dist/src/skdb-cli.js"
       },
@@ -5611,7 +5611,7 @@
       "name": "skdb-tests",
       "dependencies": {
         "@playwright/test": "^1.47.2",
-        "skdb": "^1.0.0",
+        "skdb": "^1.0.1",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -5622,7 +5622,7 @@
     },
     "tsconfig": {
       "name": "@skiplabs/tsconfig",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/node": "^22.10.0",
     "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.1",
+    "@skiplabs/tsconfig": "^0.0.2",
     "eslint": "10.0.0",
     "prettier": "3.4.1",
     "typescript": "^5.7.2"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p src/tsconfig.json"
   },
   "dependencies": {
-    "skdb": "^1.0.0"
+    "skdb": "^1.0.1"
   },
   "devDependencies": {
     "typescript": "^5.7.2"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "skdb": "^1.0.0"
+    "skdb": "^1.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/skiplang/prelude/ts/wasm/package.json
+++ b/skiplang/prelude/ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/std",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skiplang/prelude/ts/wasm/src/sk_browser.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_browser.ts
@@ -54,7 +54,7 @@ class Env implements Environment {
     const global = typeof window == "undefined" ? self : window;
     this.timestamp = () => global.performance.now();
     const decoder = new TextDecoder("utf8");
-    this.decodeUTF8 = (utf8: ArrayBuffer) => decoder.decode(utf8);
+    this.decodeUTF8 = (utf8: ArrayBuffer | Uint8Array) => decoder.decode(utf8);
     const encoder = new TextEncoder(); // always utf-8
     this.encodeUTF8 = (str: string) => encoder.encode(str);
     this.base64Decode = (base64: string) =>

--- a/skiplang/prelude/ts/wasm/src/sk_types.ts
+++ b/skiplang/prelude/ts/wasm/src/sk_types.ts
@@ -4,6 +4,17 @@ import { cloneIfProxy } from "../skiplang-std/index.js";
 
 export type { float, int, Nullable, Pointer };
 
+// Cast: @types/node types Uint8Array.buffer as ArrayBufferLike (= ArrayBuffer |
+// SharedArrayBuffer), but APIs like WebAssembly.instantiate expect ArrayBuffer.
+// Safe because Node's TextEncoder, Buffer, and Uint8Array constructors never use
+// SharedArrayBuffer. Unsafe if buf was constructed over a SharedArrayBuffer.
+// WARNING: Do NOT use on sliced Uint8Arrays (e.g. new Uint8Array(buf, offset, len))
+// — .buffer returns the full backing ArrayBuffer, not the slice.
+// Remove when @types/node narrows Uint8Array.buffer to ArrayBuffer.
+export function toArrayBuffer(buf: Uint8Array): ArrayBuffer {
+  return buf.buffer as ArrayBuffer;
+}
+
 export type ptr<InternalType extends Internal.T<any>> = Internal.Opaque<
   number,
   InternalType
@@ -741,7 +752,8 @@ export function loadWasm(
 ) {
   const wasm = {};
   const links = managers.map((manager) => manager.prepare(wasm));
-  return WebAssembly.instantiate(buffer, { env: wasm }).then((result) => {
+  const bytes = buffer instanceof ArrayBuffer ? buffer : toArrayBuffer(buffer);
+  return WebAssembly.instantiate(bytes, { env: wasm }).then((result) => {
     const instance = result.instance;
     const exports = instance.exports;
     const utils = new Utils(instance.exports, environment, main);

--- a/skiplang/prelude/ts/wasm/tsconfig.json
+++ b/skiplang/prelude/ts/wasm/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skiplang/prelude/ts/worker/package.json
+++ b/skiplang/prelude/ts/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/worker",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "exports": {
     "browser": "./dist/browser.js",

--- a/skiplang/prelude/ts/worker/tsconfig.json
+++ b/skiplang/prelude/ts/worker/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skiplang/skdate/ts/package.json
+++ b/skiplang/skdate/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/date",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "exports": {
     ".": "./dist/src/sk_date.js"
@@ -15,6 +15,6 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skip-wasm/std": "1.0.6"
+    "@skip-wasm/std": "1.0.7"
   }
 }

--- a/skiplang/skdate/ts/tsconfig.json
+++ b/skiplang/skdate/ts/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skiplang/skjson/ts/binding/package.json
+++ b/skiplang/skjson/ts/binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplang/json",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skiplang/skjson/ts/binding/tsconfig.json
+++ b/skiplang/skjson/ts/binding/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skiplang/skjson/ts/wasm/package.json
+++ b/skiplang/skjson/ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/json",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "exports": {
     ".": "./dist/skjson.js",

--- a/skiplang/skjson/ts/wasm/tsconfig.json
+++ b/skiplang/skjson/ts/wasm/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skipruntime-ts/adapters/kafka/package.json
+++ b/skipruntime-ts/adapters/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/kafka",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "kafkajs": "^2.2.4",
-    "@skipruntime/core": "0.0.19"
+    "@skipruntime/core": "0.0.20"
   }
 }

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/postgres",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "pg": "^8.13.1",
     "pg-format": "^1.0.4",
-    "@skipruntime/core": "0.0.19"
+    "@skipruntime/core": "0.0.20"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/native",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "gypfile": true,
   "type": "module",
   "exports": {
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.19"
+    "@skipruntime/core": "0.0.20"
   }
 }

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/core",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",

--- a/skipruntime-ts/core/tsconfig.json
+++ b/skipruntime-ts/core/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -12,8 +12,8 @@
     "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
-    "@skipruntime/helpers": "0.0.19",
-    "@skipruntime/server": "0.0.19",
+    "@skipruntime/helpers": "0.0.21",
+    "@skipruntime/server": "0.0.21",
     "eventsource": "^2.0.2",
     "better-sqlite3": "^11.7.2"
   }

--- a/skipruntime-ts/examples/tsconfig.json
+++ b/skipruntime-ts/examples/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@skiplabs/tsconfig",
   "compilerOptions": {
+    "rootDir": ".",
     "noUnusedLocals": false
   }
 }

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/helpers",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "eventsource": "^2.0.2",
     "express": "^4.21.1",
-    "@skipruntime/core": "0.0.19"
+    "@skipruntime/core": "0.0.20"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15"

--- a/skipruntime-ts/helpers/tsconfig.json
+++ b/skipruntime-ts/helpers/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@skiplabs/skip",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "dependencies": {
-    "@skipruntime/core": "0.0.19",
-    "@skipruntime/server": "0.0.19",
-    "@skipruntime/helpers": "0.0.19",
-    "@skipruntime/wasm": "0.0.19"
+    "@skipruntime/core": "0.0.20",
+    "@skipruntime/server": "0.0.21",
+    "@skipruntime/helpers": "0.0.21",
+    "@skipruntime/wasm": "0.0.21"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.19",
-    "@skip-adapter/kafka": "0.0.19",
-    "@skip-adapter/postgres": "0.0.19"
+    "@skipruntime/native": "0.0.21",
+    "@skip-adapter/kafka": "0.0.21",
+    "@skip-adapter/postgres": "0.0.21"
   }
 }

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/server",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "type": "module",
   "exports": {
     ".": "./dist/src/server.js"
@@ -19,11 +19,11 @@
     "tsx": "^4.19.3"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.19",
+    "@skipruntime/core": "0.0.20",
     "express": "^4.21.1"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.19",
-    "@skipruntime/wasm": "0.0.19"
+    "@skipruntime/native": "0.0.21",
+    "@skipruntime/wasm": "0.0.21"
   }
 }

--- a/skipruntime-ts/server/tsconfig.json
+++ b/skipruntime-ts/server/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "mocha"]
+  }
 }

--- a/skipruntime-ts/tests/native_addon_unreleased/run.sh
+++ b/skipruntime-ts/tests/native_addon_unreleased/run.sh
@@ -15,7 +15,7 @@ fi
 
 # build and copy the runtime
 ../../../bin/build_runtime.sh "$ARCH"
-VERSION=$(jq --raw-output .version ../../metapackage/package.json)
+VERSION=$(jq --raw-output .version ../../addon/package.json)
 mkdir -p build/v"$VERSION"
 cp ../../../build/libskipruntime.so-* build/v"$VERSION"
 

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -16,10 +16,10 @@
     "earl": "^1.3.0",
     "mocha": "^11.0.1",
     "pg": "^8.13.1",
-    "@skipruntime/core": "0.0.19",
-    "@skipruntime/helpers": "0.0.19",
-    "@skipruntime/native": "0.0.19",
-    "@skipruntime/wasm": "0.0.19",
-    "@skip-adapter/postgres": "0.0.19"
+    "@skipruntime/core": "0.0.20",
+    "@skipruntime/helpers": "0.0.21",
+    "@skipruntime/native": "0.0.21",
+    "@skipruntime/wasm": "0.0.21",
+    "@skip-adapter/postgres": "0.0.21"
   }
 }

--- a/skipruntime-ts/tests/tsconfig.json
+++ b/skipruntime-ts/tests/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/wasm",
-  "version": "0.0.19",
+  "version": "0.0.21",
   "type": "module",
   "exports": {
     ".": {
@@ -15,6 +15,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.19"
+    "@skipruntime/core": "0.0.20"
   }
 }

--- a/skipruntime-ts/wasm/tsconfig.json
+++ b/skipruntime-ts/wasm/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@skiplabs/tsconfig"
+  "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  }
 }

--- a/sql/ts/bun/package.json
+++ b/sql/ts/bun/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
-    "skdb": "^1.0.0",
+    "skdb": "^1.0.1",
     "chalk": "^5.3.0"
   }
 }

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skdb",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "exports": {
     ".": {

--- a/sql/ts/src/skdb_database.ts
+++ b/sql/ts/src/skdb_database.ts
@@ -17,7 +17,10 @@ import type { DBEnvironment } from "./skdb_env.js";
 class SKDBMechanismImpl implements SKDBMechanism {
   writeCsv: (payload: string, source: string) => void;
   watermark: (replicationUid: string, table: string) => bigint;
-  watchFile: (fileName: string, fn: (change: ArrayBuffer) => void) => void;
+  watchFile: (
+    fileName: string,
+    fn: (change: ArrayBuffer | Uint8Array) => void,
+  ) => void;
   getReplicationUid: (deviceUuid: string) => string;
   subscribe: (
     replicationUid: string,
@@ -28,7 +31,7 @@ class SKDBMechanismImpl implements SKDBMechanism {
   diff: (
     session: string,
     watermarks: Map<string, bigint>,
-  ) => ArrayBuffer | null;
+  ) => ArrayBuffer | Uint8Array | null;
   assertCanBeMirrored: (table: string, schema: string) => void;
   tableExists: (tableName: string) => boolean;
   exec: (query: string) => SKDBTable;
@@ -55,7 +58,10 @@ class SKDBMechanismImpl implements SKDBMechanism {
         payload + "\n",
       );
     };
-    this.watchFile = (fileName: string, fn: (change: ArrayBuffer) => void) => {
+    this.watchFile = (
+      fileName: string,
+      fn: (change: ArrayBuffer | Uint8Array) => void,
+    ) => {
       fs.watchFile(fileName, (change) => {
         if (change == "") {
           return;

--- a/sql/ts/src/skdb_orchestration.ts
+++ b/sql/ts/src/skdb_orchestration.ts
@@ -73,7 +73,7 @@ type ProtoCtrlMsg =
 
 type ProtoData = {
   type: "data";
-  payload: ArrayBuffer;
+  payload: ArrayBuffer | Uint8Array;
 };
 
 type ProtoResponse = ProtoResponseCreds | ProtoData;
@@ -249,7 +249,7 @@ class ProtoMsgDecoder {
   private bufs: Uint8Array[] = [];
   private readonly msgs: (ProtoMsg | null)[] = [];
 
-  private popBufs(): ArrayBuffer {
+  private popBufs(): ArrayBuffer | Uint8Array {
     if (this.bufs.length == 1) {
       // avoid copying for the common case of single buffer
       const buf = this.bufs.pop();

--- a/sql/ts/src/skdb_types.ts
+++ b/sql/ts/src/skdb_types.ts
@@ -113,7 +113,10 @@ export interface SKDB {
 export interface SKDBMechanism {
   writeCsv: (payload: string, source: string) => void;
   watermark: (replicationUid: string, table: string) => bigint;
-  watchFile: (fileName: string, fn: (change: ArrayBuffer) => void) => void;
+  watchFile: (
+    fileName: string,
+    fn: (change: ArrayBuffer | Uint8Array) => void,
+  ) => void;
   getReplicationUid: (deviceUuid: string) => string;
   subscribe: (
     replicationUid: string,
@@ -124,7 +127,7 @@ export interface SKDBMechanism {
   diff: (
     session: string,
     watermarks: Map<string, bigint>,
-  ) => ArrayBuffer | null;
+  ) => ArrayBuffer | Uint8Array | null;
   tableExists: (tableName: string) => boolean;
   exec: (query: string) => SKDBTable;
   assertCanBeMirrored: (table: string, schema: string) => void;

--- a/sql/ts/tests/apitests.ts
+++ b/sql/ts/tests/apitests.ts
@@ -85,9 +85,12 @@ export async function setup(
   });
   {
     const keyData = testUserCreds.privateKey;
+    // Cast: Uint8Array is a BufferSource at runtime but @types/node
+    // generics make TS 6.0 reject it. Do NOT use .buffer — it returns the
+    // full backing ArrayBuffer, not the slice.
     const key = await crypto.subtle.importKey(
       "raw",
-      keyData,
+      keyData as BufferSource,
       { name: "HMAC", hash: "SHA-256" },
       false,
       ["sign"],
@@ -103,9 +106,10 @@ export async function setup(
   });
   {
     const keyData2 = testUserCreds2.privateKey;
+    // Cast: same as above — pass Uint8Array directly, not .buffer.
     const key2 = await crypto.subtle.importKey(
       "raw",
-      keyData2,
+      keyData2 as BufferSource,
       { name: "HMAC", hash: "SHA-256" },
       false,
       ["sign"],

--- a/sql/ts/tests/muxed_socket.ts
+++ b/sql/ts/tests/muxed_socket.ts
@@ -284,11 +284,14 @@ export const ms_tests: () => Test[] = () => {
     {
       name: "Auth Short AccessKey",
       fun: async (env: DBEnvironment, mu: Mu) => {
+        // Cast: Uint8Array is a BufferSource at runtime but @types/node
+        // generics make TS 6.0 reject it. Do NOT use .buffer — it may return
+        // a larger backing ArrayBuffer than the typed array view.
         const key = await env
           .crypto()
           .subtle.importKey(
             "raw",
-            env.encodeUTF8("very_secure"),
+            env.encodeUTF8("very_secure") as BufferSource,
             { name: "HMAC", hash: "SHA-256" },
             false,
             ["sign"],
@@ -320,9 +323,10 @@ export const ms_tests: () => Test[] = () => {
     {
       name: "Auth Fail",
       fun: async (env: DBEnvironment, mu: Mu) => {
+        // Cast: same as above — pass Uint8Array directly, not .buffer.
         const key = await env.crypto().subtle.importKey(
           "raw",
-          env.encodeUTF8("this-is-not-correct"), // <--
+          env.encodeUTF8("this-is-not-correct") as BufferSource, // <--
           { name: "HMAC", hash: "SHA-256" },
           false,
           ["sign"],

--- a/sql/ts/tests/muxed_utils.ts
+++ b/sql/ts/tests/muxed_utils.ts
@@ -48,11 +48,14 @@ export function toHex(buf: ArrayBuffer) {
 }
 
 export async function connectAndAuth(env: DBEnvironment) {
+  // Cast: Uint8Array is a BufferSource at runtime but @types/node
+  // generics make TS 6.0 reject it. Do NOT use .buffer — it may return
+  // a larger backing ArrayBuffer than the typed array view.
   const key = await env
     .crypto()
     .subtle.importKey(
       "raw",
-      env.encodeUTF8("test"),
+      env.encodeUTF8("test") as BufferSource,
       { name: "HMAC", hash: "SHA-256" },
       false,
       ["sign"],

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@playwright/test": "^1.47.2",
     "ws": "^8.18.0",
-    "skdb": "^1.0.0"
+    "skdb": "^1.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",

--- a/sql/ts/tests/tsconfig.json
+++ b/sql/ts/tests/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": ".",
+    "skipLibCheck": true
+  },
   "exclude": ["dist/", "build/", "test-results/"]
 }

--- a/sql/ts/tsconfig.json
+++ b/sql/ts/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@skiplabs/tsconfig",
+  "compilerOptions": {
+    "rootDir": "."
+  },
   "exclude": ["dist/", "tests/", "vitejs/", "bun/"]
 }

--- a/sql/ts/vitejs/package.json
+++ b/sql/ts/vitejs/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "skdb": "^1.0.0"
+    "skdb": "^1.0.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplabs/tsconfig",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Shared tsconfig.json config for SkipLabs packages.",
   "author": "SkipLabs",
   "license": "MIT",

--- a/tsconfig/tsconfig.json
+++ b/tsconfig/tsconfig.json
@@ -20,12 +20,14 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "${configDir}/dist",
+    "rootDir": "${configDir}/src",
     "sourceMap": true,
     // Interop Constraints
     "verbatimModuleSyntax": true,
     // Projects
     "incremental": true,
     // Language and Environment
-    "target": "ES2021"
+    "target": "ES2021",
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary

Prepare the codebase for TypeScript 6.0 compatibility while maintaining support for TS 5.7 and 5.8.

### tsconfig changes
- Set explicit `rootDir` in base `@skiplabs/tsconfig` and per-package overrides
- Add `types: ["node"]` to base tsconfig and examples (TS 6.0 no longer auto-includes `@types/node`)
- Add `skipLibCheck: true` to `sql/ts/tests` for playwright-core compat
- Fix example tsconfigs with `rootDir`/`outDir` for TS 6.0 stricter inference

### Type fixes
- Fix `Uint8Array`/`ArrayBuffer` mismatches (TS 6.0 no longer treats them as assignable)
- Add `toArrayBuffer()` helper for the unavoidable `@types/node` cast (`Uint8Array.buffer` typed as `ArrayBufferLike`)
- Use `.buffer as ArrayBuffer` in test files (documented why safe, when unsafe)
- Widen `SKDBMechanism` interface types (`watchFile`, `diff`, `ProtoData.payload`)
- Use runtime `instanceof` check in `loadWasm` for `WebAssembly.instantiate` overload

### CI
- Add TS 5.8 and 6.0 type-checking steps to `check-ts` job (lint skipped for alternate versions)
- Add version guard to fail CI if locked TS version drifts from 5.7.x
- Add `SKIP_LINT` env var to `check-ts.sh`

### Version bumps and publishing
- Bump and publish all packages with correct dependency versions
- Level 0: `@skiplabs/tsconfig@0.0.2`, `@skip-wasm/std@1.0.7`, `@skip-wasm/worker@0.0.1`, `@skip-wasm/date@1.0.6`, `@skiplang/json@0.0.5`, `@skip-wasm/json@1.0.8`, `@skipruntime/core@0.0.20`, `skdb@1.0.1`
- Level 1: `@skipruntime/helpers@0.0.21`, `@skipruntime/wasm@0.0.21`, `@skipruntime/native@0.0.21`, `@skipruntime/server@0.0.21`, `@skip-adapter/kafka@0.0.21`, `@skip-adapter/postgres@0.0.21`
- Level 2: `@skiplabs/skip@0.0.20`

## Test plan
- [x] `bin/check-ts.sh` passes on TS 5.7, 5.8, and 6.0
- [x] `npm run build` passes
- [x] All published packages verified on npm registry
- [x] CI `check-ts` passes (TS 5.7, 5.8, 6.0)
- [x] CI `check-examples` passes
- [x] CI `skdb-wasm` passes
- [x] CI `skipruntime` passes