### PR TITLE
Fix skargo not rebuilding when test files change in merged mode

### DIFF
--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skargo"
-version = "0.3.3"
+version = "0.3.4"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -670,9 +670,9 @@ mutable class BuildRunner(
     } else {
       names = bins.map(b -> b.name);
       if (test_entry_opt.isSome()) !names = names.concat(Array["test"]);
-      lines.push(`  | _unknown ->`);
+      lines.push(`  | _ ->`);
       lines.push(
-        `    print_error("Unknown binary '\`\${_unknown}\`'. Set SKARGO_BIN to one of: ${names.join(
+        `    print_error("Unknown binary '\`\${name}\`'. Set SKARGO_BIN to one of: ${names.join(
           ", ",
         )}");`,
       );

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -670,9 +670,9 @@ mutable class BuildRunner(
     } else {
       names = bins.map(b -> b.name);
       if (test_entry_opt.isSome()) !names = names.concat(Array["test"]);
-      lines.push(`  | unknown ->`);
+      lines.push(`  | _unknown ->`);
       lines.push(
-        `    print_error("Unknown binary '\`\${unknown}\`'. Set SKARGO_BIN to one of: ${names.join(
+        `    print_error("Unknown binary '\`\${_unknown}\`'. Set SKARGO_BIN to one of: ${names.join(
           ", ",
         )}");`,
       );

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -132,8 +132,17 @@ mutable class BuildRunner(
 
   private mutable fun fingerprint_for(unit: Unit): Int {
     if (!this.fingerprints.containsKey(unit)) {
+      srcs = unit.target.srcs;
+      // In merged mode, test sources are compiled into the lib,
+      // so they must be included in the fingerprint.
+      if (
+        unit.target.kind is LibTarget(LibraryTypeSklib _) &&
+        should_merge(unit.profile, unit.pkg.manifest)
+      ) {
+        unit.pkg.manifest.test_target().each(t -> !srcs = srcs.concat(t.srcs));
+      };
       this.fingerprints![unit] = (
-        unit.target.srcs
+        srcs
           .map(f ->
             (
               f,


### PR DESCRIPTION
## Summary
- **Fix test file fingerprinting in merged mode:** In dev mode with bins, test sources are compiled into the lib but were not included in the fingerprint calculation. Modifying a test file would not trigger a rebuild of the `__merged` binary. Fix: include test target sources in the lib fingerprint when `should_merge()` is true.
- **Fix generated dispatcher for multi-bin packages:** The generated `dispatch()` function used `| unknown ->` which triggers an "unused variable" error. Replaced with `| _ ->` wildcard and references the already-bound `name` variable, since underscore-prefixed names don't bind in Skip patterns.
- **Bump skargo version** to 0.3.4
- **Update bootstrap** with the new skargo binary

## Test plan
- [x] `skargo test` on skjson (package with bins) — builds `__merged`, all 9 tests pass
- [x] Second `skargo test` — everything shows "Fresh"
- [x] `touch tests/test.sk` then `skargo test` — lib and `__merged` recompile (fixed)
- [x] Verified system skargo (without fix) does NOT recompile after touching test file (bug confirmed)
- [x] `skargo build` on compiler package (2 bins: skc + skfmt) — no unused variable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)