### PR TITLE
Honor SKIP_CAPACITY env var for runtime heap capacity

### DIFF
--- a/skiplang/compiler/Skargo.toml
+++ b/skiplang/compiler/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skc"
-version = "0.3.1"
+version = "0.3.2"
 tests = ["tests/tests.sk"]
 test-harness = "SkcTests.main"
 

--- a/skiplang/prelude/runtime/palloc.c
+++ b/skiplang/prelude/runtime/palloc.c
@@ -380,8 +380,8 @@ static char* parse_args(int argc, char** argv, int* is_init) {
 }
 
 // Parse a byte count, optionally suffixed with K/M/G (case-insensitive,
-// multipliers 1024, 1024^2, 1024^3). On error, writes to stderr citing
-// `source` and exits with code 2.
+// multipliers 1024, 1024^2, 1024^3). On malformed input or size_t overflow,
+// writes to stderr citing `source` and exits with code 2.
 static size_t parse_capacity_value(const char* str, const char* source) {
   if (str[0] < '0' || str[0] > '9') {
     fprintf(stderr,
@@ -392,7 +392,12 @@ static size_t parse_capacity_value(const char* str, const char* source) {
   size_t value = 0;
   int j = 0;
   while (str[j] >= '0' && str[j] <= '9') {
-    value = value * 10 + (size_t)(str[j] - '0');
+    size_t digit = (size_t)(str[j] - '0');
+    if (value > (SIZE_MAX - digit) / 10) {
+      fprintf(stderr, "%s: value out of range\n", source);
+      exit(2);
+    }
+    value = value * 10 + digit;
     j++;
   }
   size_t multiplier = 1;
@@ -417,6 +422,10 @@ static size_t parse_capacity_value(const char* str, const char* source) {
               source);
       exit(2);
     }
+  }
+  if (multiplier > 1 && value > SIZE_MAX / multiplier) {
+    fprintf(stderr, "%s: value out of range\n", source);
+    exit(2);
   }
   return value * multiplier;
 }

--- a/skiplang/prelude/runtime/palloc.c
+++ b/skiplang/prelude/runtime/palloc.c
@@ -436,6 +436,12 @@ size_t parse_capacity(int argc, char** argv) {
       }
     }
   }
+
+  const char* env = getenv("SKIP_CAPACITY");
+  if (env != NULL && env[0] != '\0') {
+    return parse_capacity_value(env, "SKIP_CAPACITY");
+  }
+
   return DEFAULT_CAPACITY;
 }
 

--- a/skiplang/prelude/runtime/palloc.c
+++ b/skiplang/prelude/runtime/palloc.c
@@ -379,30 +379,60 @@ static char* parse_args(int argc, char** argv, int* is_init) {
   }
 }
 
+// Parse a byte count, optionally suffixed with K/M/G (case-insensitive,
+// multipliers 1024, 1024^2, 1024^3). On error, writes to stderr citing
+// `source` and exits with code 2.
+static size_t parse_capacity_value(const char* str, const char* source) {
+  if (str[0] < '0' || str[0] > '9') {
+    fprintf(stderr,
+            "%s expects an integer (optionally suffixed with K, M, or G)\n",
+            source);
+    exit(2);
+  }
+  size_t value = 0;
+  int j = 0;
+  while (str[j] >= '0' && str[j] <= '9') {
+    value = value * 10 + (size_t)(str[j] - '0');
+    j++;
+  }
+  size_t multiplier = 1;
+  if (str[j] != 0) {
+    char c = str[j];
+    if (c >= 'a' && c <= 'z') c = (char)(c - 'a' + 'A');
+    if (c == 'K') {
+      multiplier = 1024L;
+    } else if (c == 'M') {
+      multiplier = 1024L * 1024L;
+    } else if (c == 'G') {
+      multiplier = 1024L * 1024L * 1024L;
+    } else {
+      fprintf(stderr,
+              "%s expects an integer (optionally suffixed with K, M, or G)\n",
+              source);
+      exit(2);
+    }
+    if (str[j + 1] != 0) {
+      fprintf(stderr,
+              "%s expects an integer (optionally suffixed with K, M, or G)\n",
+              source);
+      exit(2);
+    }
+  }
+  return value * multiplier;
+}
+
 size_t parse_capacity(int argc, char** argv) {
   int i;
 
   for (i = 1; i < argc; i++) {
     if (strcmp(argv[i], "--capacity") == 0) {
       if (i + 1 < argc) {
-        if (argv[i + 1][0] >= '0' && argv[i + 1][0] <= '9') {
-          int j = 0;
-
-          while (argv[i + 1][j] != 0) {
-            if (argv[i + 1][j] >= '0' && argv[i + 1][j] <= '9') {
-              j++;
-              continue;
-            }
-            fprintf(stderr, "--capacity expects an integer\n");
-            exit(2);
-          }
-          return atol(argv[i + 1]);
-        } else if (argv[i + 1][0] == '-') {
+        // Preserve the existing quirk: `--capacity -<something>` silently
+        // falls back to the default.
+        if (argv[i + 1][0] == '-') {
           return DEFAULT_CAPACITY;
-        } else {
-          fprintf(stderr, "--capacity expects an integer\n");
-          exit(2);
         }
+        return parse_capacity_value(argv[i + 1], "--capacity");
       }
     }
   }


### PR DESCRIPTION
## Summary

- Adds `SKIP_CAPACITY` env var as a fallback when `--capacity` is absent from argv. Accepts raw bytes or a single K/M/G suffix (case-insensitive). CLI flag still wins when present.
- Factors capacity parsing into a `parse_capacity_value` helper used by both code paths; rejects size_t overflow with a clear error.
- Bumps skc to 0.3.2 to pick up the new runtime behavior.

Fixes the env-var half of #1189. The motivating use case: GitHub-hosted `ubuntu-latest` runners (16 GB nominal, default heuristic overcommit) refuse the runtime's 16 GB anonymous mmap, so the very first Skip binary in the build chain — `skargo` itself — aborts at startup. With this change, setting `SKIP_CAPACITY=8G` once at workflow level unblocks the build for every Skip binary on the host.

The `--capacity` argv-strip half of #1189 (so user-program `Cli` parsers stop rejecting the flag) is intentionally deferred — left as a follow-up if/when it becomes a problem.

End-to-end env propagation through `skargo → skc` is automatic: Skip's `Posix.Popen::create` merges `Environ.vars()` into the child env unless `clear_env=true`, and skargo's `run_cmd` doesn't pass `clear_env`. Verified with strace.

## Test plan

- [x] `SKIP_CAPACITY=8G|512M|1024K|2g|8589934592` set the heap correctly (`CAPACITY SET TO: …`)
- [x] `SKIP_CAPACITY=garbage|8X|8GB|99999999999999999999999|20000000000G` → stderr error citing `SKIP_CAPACITY`, exit 2
- [x] `SKIP_CAPACITY=` (empty) → behaves as unset, default 16 GB
- [x] `SKIP_CAPACITY=4G` + `--capacity 8G` → CLI wins (8589934592)
- [x] `--capacity garbage` and `--capacity 99999999999999999999999` → stderr error citing `--capacity`, exit 2
- [x] All 69 existing prelude tests pass
- [x] strace confirms `SKIP_CAPACITY` is in skc's envp when spawned by skargo

🤖 Generated with [Claude Code](https://claude.com/claude-code)