### PR TITLE
Cli: register --data/--init/--capacity via opt-in runtimeArgs()

### DIFF
--- a/skiplang/cli/Skargo.toml
+++ b/skiplang/cli/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/cli/src/cli.sk
+++ b/skiplang/cli/src/cli.sk
@@ -177,6 +177,33 @@ class Command(
     )
   }
 
+  // Register the flags that the Skip runtime consumes directly from argv
+  // (--data, --init, --capacity) so the Cli parser stops rejecting them.
+  // The values are read by the runtime, not by the user program.
+  fun runtimeArgs(): this {
+    this.args(
+      Array[
+        Cli.Arg::string("data")
+          .long("data")
+          .value_name("FILE")
+          .about("Use the given file as persistent storage (Skip runtime)")
+          .global(),
+        Cli.Arg::string("init")
+          .long("init")
+          .value_name("FILE")
+          .about(
+            "Initialize the given file as persistent storage (Skip runtime)",
+          )
+          .global(),
+        Cli.Arg::string("capacity")
+          .long("capacity")
+          .value_name("SIZE")
+          .about("Override runtime heap capacity (bytes, or with K/M/G suffix)")
+          .global(),
+      ],
+    )
+  }
+
   fun parseArgs(): ParseResults {
     res = parseArgs(this);
 

--- a/skiplang/cli/tests/tests.sk
+++ b/skiplang/cli/tests/tests.sk
@@ -460,4 +460,36 @@ fun argDefaultWithUndefinedDefault(): void {
   );
 }
 
+@test
+fun runtimeArgsAccepted(): void {
+  cmd = Cli.Command("foo").runtimeArgs();
+  args = Cli.parseArgsFrom(
+    cmd,
+    Array["--capacity", "8G", "--data", "foo.db", "--init", "bar.db"],
+  );
+
+  T.expectTrue(args.error is None _);
+  T.expectEq(args.getString("capacity"), "8G");
+  T.expectEq(args.getString("data"), "foo.db");
+  T.expectEq(args.getString("init"), "bar.db");
+}
+
+@test
+fun runtimeArgsRejectedWithoutOptIn(): void {
+  cmd = Cli.Command("foo");
+  args = Cli.parseArgsFrom(cmd, Array["--capacity", "8G"]);
+
+  T.expectTrue(args.error is Some(Cli.InvalidArgumentError _));
+}
+
+@test
+fun runtimeArgsAreGlobal(): void {
+  cmd = Cli.Command("foo").runtimeArgs().subcommand(Cli.Command("bar"));
+  args = Cli.parseArgsFrom(cmd, Array["bar", "--capacity", "8G"]);
+
+  T.expectTrue(args.error is None _);
+  T.expectEq(args.subcommand, Some("bar"));
+  T.expectEq(args.getString("capacity"), "8G");
+}
+
 module end;

--- a/skiplang/compiler/Skargo.toml
+++ b/skiplang/compiler/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skc"
-version = "0.3.2"
+version = "0.3.3"
 tests = ["tests/tests.sk"]
 test-harness = "SkcTests.main"
 

--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -9,6 +9,7 @@ fun main(): void {
   results = Cli.Command("skc")
     .about("Skip compiler")
     .help()
+    .runtimeArgs()
     .arg(Cli.Arg::bool("disasm-all"))
     .arg(Cli.Arg::bool("disasm-annotated"))
     .arg(Cli.Arg::string("disasm-file").repeatable())
@@ -55,8 +56,6 @@ fun main(): void {
     // Just allow them to be ignored here
     .arg(Cli.Arg::bool("profile"))
     .arg(Cli.Arg::bool("canonize-paths").negatable())
-    .arg(Cli.Arg::string("data"))
-    .arg(Cli.Arg::string("init"))
     .arg(Cli.Arg::bool("check").about("Run the front end only."))
     .arg(
       Cli.Arg::bool("link")

--- a/skiplang/compiler/src/skfmt.sk
+++ b/skiplang/compiler/src/skfmt.sk
@@ -46,6 +46,7 @@ untracked fun main(): void {
         .about("File name used to report errors on stdin"),
     )
     .help()
+    .runtimeArgs()
     .parseArgs();
 
   inplace = args.getBool("inplace");

--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skargo"
-version = "0.3.4"
+version = "0.3.5"
 
 [dependencies]
 std = { path = "../prelude" }

--- a/skiplang/skargo/src/main.sk
+++ b/skiplang/skargo/src/main.sk
@@ -52,7 +52,7 @@ fun main(): void {
     !cmd = cmd.subcommand(subcommand);
     commands.set(subcommand.name, cmdFn);
   };
-  !cmd = cmd.help();
+  !cmd = cmd.help().runtimeArgs();
   args = cmd.parseArgs();
   if (args.getBool("version")) {
     pkg_name = #env ("SKARGO_PKG_NAME");


### PR DESCRIPTION
## Summary

- Adds `Cli.Command.runtimeArgs()` builder method that registers `--data <FILE>`, `--init <FILE>`, and `--capacity <SIZE>` as recognized global args. Without it, the Cli parser rejects them as `Invalid argument …` even though the runtime is the one that consumes the values from argv — that's what made `--capacity` unusable on every standard Skip toolchain binary (the second half of #1189).
- Adopted in `skargo`, `skc`, and `skfmt`. `skc` previously had its own bare `--data`/`--init` declarations as a workaround; replaced with the shared call.
- Bumps `cli` 0.1.2 → 0.1.3, `skc` 0.3.2 → 0.3.3, `skargo` 0.3.3 → 0.3.4.

Follows up on #1190 which landed the `SKIP_CAPACITY` env var half of #1189.

## Why opt-in

Most Skip programs don't use the persistent-storage flags at all, so silently registering them on every `Command` would be noise in `--help`. Calling `.runtimeArgs()` (parallel to the existing `.help()`) keeps the surface minimal and discoverable: programs that care opt in; everything else is unaffected.

Mutual exclusivity of `--data`/`--init` is left to the runtime — Cli has no exclusive-group primitive and the runtime already errors cleanly.

## Test plan

- [x] 3 new unit tests in `skiplang/cli/tests/tests.sk`:
  - `runtimeArgs()` parses `--capacity 8G --data foo.db --init bar.db` without error
  - `Command` without `.runtimeArgs()` still rejects `--capacity` (regression guard for opt-in)
  - The flags are global — work on subcommands too
- [x] All 39 cli tests pass (was 36, +3)
- [x] `skc --capacity 8G --version` → exit 0, capacity set, version printed (previously: `Invalid argument --capacity`)
- [x] `skargo build --capacity 8G` → global flag works on subcommand; spawned skc honors it
- [x] `skfmt --capacity 8G --help` → flag accepted, listed in usage
- [x] `skc --capacity bogus` still rejected by the runtime parser with the K/M/G error

🤖 Generated with [Claude Code](https://claude.com/claude-code)