### PR TITLE
Pin serialize-javascript >=7.0.3 in cache_invalidation/www

### DIFF
--- a/examples/cache_invalidation/www/package.json
+++ b/examples/cache_invalidation/www/package.json
@@ -28,5 +28,13 @@
     "eslint-plugin-vue": "^9.28.0",
     "prettier": "3.4.1",
     "typescript": "~5.0.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "serialize-javascript": "^7.0.3"
+    }
   }
 }

--- a/examples/cache_invalidation/www/pnpm-lock.yaml
+++ b/examples/cache_invalidation/www/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  serialize-javascript: ^7.0.3
+
 importers:
 
   .:
@@ -3264,9 +3267,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -3416,8 +3416,9 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   serve-index@1.9.2:
     resolution: {integrity: sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==}
@@ -6088,7 +6089,7 @@ snapshots:
       globby: 11.1.0
       normalize-path: 3.0.0
       schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.106.2(cssnano@5.1.15(postcss@8.5.15))(postcss@8.5.15)
 
   core-js-compat@3.49.0:
@@ -6158,7 +6159,7 @@ snapshots:
       jest-worker: 27.5.1
       postcss: 8.5.15
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       source-map: 0.6.1
       webpack: 5.106.2(cssnano@5.1.15(postcss@8.5.15))(postcss@8.5.15)
 
@@ -7667,10 +7668,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -7845,9 +7842,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   serve-index@1.9.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert [#201](https://github.com/SkipLabs/skip/security/dependabot/201) — [GHSA-5c6j-r48x-rmvq](https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-5c6j-r48x-rmvq) (RCE via `RegExp.flags` / `Date.toISOString`, severity high, patched in 7.0.3).
- The vulnerable `serialize-javascript@6.0.2` is a transitive dev-only dep, pulled in by `@vue/cli-service` via `copy-webpack-plugin` and `css-minimizer-webpack-plugin`.
- Adds both `overrides` (npm) and `pnpm.overrides` in [examples/cache_invalidation/www/package.json](examples/cache_invalidation/www/package.json) so the lockfile (scanned by Dependabot) and the Docker build's `npm install` both resolve to `serialize-javascript@7.0.5`.

## Test plan
- [x] `pnpm install --lockfile-only` resolves `serialize-javascript: 7.0.5` (verified via `grep serialize-javascript pnpm-lock.yaml`).
- [x] `npm install` (fresh, no lockfile) → `npm ls serialize-javascript` shows `serialize-javascript@7.0.5 overridden` under both consumers.
- [x] `npm run build` (vue-cli-service) still completes successfully — build hash unchanged vs. 6.0.2 build.
- [ ] CI: full `docker compose build` for cache_invalidation example (will run on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)