### PR TITLE
Pin serialize-javascript >=7.0.3 in npm lockfiles

### DIFF
--- a/examples/blogger/www/package-lock.json
+++ b/examples/blogger/www/package-lock.json
@@ -10231,16 +10231,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10722,13 +10712,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/examples/blogger/www/package.json
+++ b/examples/blogger/www/package.json
@@ -28,5 +28,8 @@
     "eslint-plugin-vue": "^8.0.3",
     "prettier": "3.4.1",
     "typescript": "~4.5.5"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "skip2",
+  "name": "skip",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -4322,15 +4322,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4549,12 +4540,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "clean": "npm run clean --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
   }
 }

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -26,7 +26,7 @@
         "typescript": "~5.7.2"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -15543,15 +15543,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16545,12 +16536,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/www/package.json
+++ b/www/package.json
@@ -46,5 +46,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary
Fixes Dependabot alerts [#198](https://github.com/SkipLabs/skip/security/dependabot/198), [#199](https://github.com/SkipLabs/skip/security/dependabot/199), [#200](https://github.com/SkipLabs/skip/security/dependabot/200) — all the same [GHSA-5c6j-r48x-rmvq](https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-5c6j-r48x-rmvq) (RCE via `RegExp.flags` / `Date.toISOString`, severity high, patched in 7.0.3).

`serialize-javascript@6.0.2` is a transitive dev-only dep pulled in by various webpack plugins under `@docusaurus/core` (www/) and `@vue/cli-service` (blogger/www). Same approach as #1205: add an npm `overrides` clause in each `package.json` and surgically update each lockfile (`npm update serialize-javascript --package-lock-only`).

Each lockfile now resolves to `serialize-javascript@7.0.5`. Diffs are minimal (~20 lines per lockfile).

Manifests affected:
- [package.json](package.json) / [package-lock.json](package-lock.json) — root workspace (alert #199)
- [www/package.json](www/package.json) / [www/package-lock.json](www/package-lock.json) — docusaurus site (alert #198)
- [examples/blogger/www/package.json](examples/blogger/www/package.json) / [examples/blogger/www/package-lock.json](examples/blogger/www/package-lock.json) — blogger Vue example (alert #200)

## Breaking-change check (between 6.0.2 → 7.0.5)
- **v7.0.0**: requires Node.js v20+. All affected manifests' build/runtime environments are on Node 20+ (docusaurus engine pin `>=20`, vue example Dockerfile uses `node:22.13.1`, root workspaces use Node 20+).
- v7.0.1: function body sanitization (security improvement). webpack-plugin usage is metadata-only.
- v7.0.5: array-like object validation, CPU usage fix.

## Test plan
- [x] All three `package-lock.json` files now resolve `serialize-javascript` to `7.0.5` (verified via `jq`/python).
- [x] `docker build` of `examples/blogger/www/Dockerfile` succeeds.
- [x] `npm install` succeeds in all three manifests.
- [ ] CI: check-examples runs blogger docker compose (will run on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)