### PR TITLE
[skipruntime/addon] Add missing <sstream> include in common.cc

### DIFF
--- a/skipruntime-ts/addon/src/common.cc
+++ b/skipruntime-ts/addon/src/common.cc
@@ -4,6 +4,7 @@
 #include <functional>
 #include <iostream>
 #include <regex>
+#include <sstream>
 
 #define SKCONTEXT void*
 


### PR DESCRIPTION
## Summary
[skipruntime-ts/addon/src/common.cc](skipruntime-ts/addon/src/common.cc) uses `std::ostringstream` at six call sites but only includes `<functional>`, `<iostream>`, and `<regex>`. This previously compiled because older libstdc++ pulled `<sstream>` in transitively via `<iostream>`; newer GCC dropped that transitive include, breaking `node-gyp rebuild` of `@skipruntime/native` with:

```
error: aggregate 'std::ostringstream error' has incomplete type and cannot be defined
```

The bug has been latent since the file was first added in `8e3f2a08e`; it surfaced now because the `skiplabs/skip:latest` Docker image picked up a newer GCC and because the `skipruntime` CI workflow only recently started exercising the "Run native addon unreleased test" step on dependabot PRs.

Surfaced by CI build [16417](https://circleci.com/gh/SkipLabs/skip/16417) on #1209, but unrelated to that PR's path-to-regexp/express dep bumps.

## Test plan
- [ ] CI: `skipruntime` workflow's "Run native addon unreleased test" step compiles cleanly (will run on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)