### PR TITLE
Re-apply serialize-javascript override to mocha-nested copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,15 +3730,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4361,15 +4352,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4614,6 +4596,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {


### PR DESCRIPTION
## Summary
Dependabot alert [#199](https://github.com/SkipLabs/skip/security/dependabot/199) ([GHSA-5c6j-r48x-rmvq](https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-5c6j-r48x-rmvq)) was reopened because a later dependabot lockfile regeneration ([21bed71fb](https://github.com/SkipLabs/skip/commit/21bed71fb5f73e4c18e43aafe0b8ce9aea969f01) "Bump glob from 10.4.5 to 10.5.0") re-introduced a nested copy:

```
node_modules/mocha/node_modules/serialize-javascript: 6.0.2
```

The root `overrides` clause (added in #1206) only hoisted-out the top-level entry; dependabot's resolver didn't apply it to mocha's nested install. Re-running `npm update serialize-javascript --package-lock-only` locally dedups the nested copy back to the hoisted 7.0.5.

## Diff
- Removed `node_modules/mocha/node_modules/serialize-javascript` (6.0.2)
- Removed dead `node_modules/randombytes` entry (only used by 6.0.2)
- Only one `serialize-javascript@7.0.5` left at the root (overridden)

## Test plan
- [x] `python -c '...'` confirms only one `serialize-javascript` entry in lockfile, version 7.0.5
- [ ] CI green (will run on this PR)
- [ ] Dependabot alert #199 auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)