### PR TITLE
Pin uuid >=11.1.1 in /www

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -18074,13 +18074,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/www/package.json
+++ b/www/package.json
@@ -48,6 +48,7 @@
     "node": ">=20"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Fixes Dependabot alert [#316](https://github.com/SkipLabs/skip/security/dependabot/316) — [GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq) / CVE-2026-41907 (missing buffer bounds check in uuid's `v3()`/`v5()`/`v6()` methods; medium severity).

`uuid@8.3.2` is pulled transitively into [www/package-lock.json](www/package-lock.json) via `@docusaurus/core` → `webpack-dev-server` → `sockjs`. The advisory affects all uuid versions `< 11.1.1` (plus 12.0.x and 13.0.x prereleases) — 8.3.2 is in scope.

Adds an npm `overrides` entry pinning `uuid: ^11.1.1`, the lowest patched version on a still-supported line (uuid 10 and below is upstream-deprecated). Surgical `npm update uuid --package-lock-only` regenerated the lockfile, swapping the single transitive entry `8.3.2 → 11.1.1`.

## Compatibility verified
- `uuid@11.1.1` has CommonJS exports under the `node.require` condition (`./dist/cjs/index.js`); `require('uuid').v4()` returns a valid UUID — sockjs's `require('uuid').v4()` keeps working.
- This dep only runs during `docusaurus start` (HMR via sockjs in webpack-dev-server); never reaches the production static site.

## Diff
- `www/package.json`: +1 line in `overrides` block.
- `www/package-lock.json`: surgical 13-line change (single `uuid` entry, version 8.3.2 → 11.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)