### PR TITLE
Bump PyJWT to 2.13.0 in /examples/cache_invalidation/web_service

### DIFF
--- a/examples/blogger/web_service/requirements.txt
+++ b/examples/blogger/web_service/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3
 psycopg2-binary==2.9.9
 requests==2.33.0
-PyJWT==2.12.0
+PyJWT==2.13.0

--- a/examples/cache_invalidation/web_service/requirements.txt
+++ b/examples/cache_invalidation/web_service/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3
 psycopg2-binary==2.9.9
 requests==2.33.0
-PyJWT==2.12.0
+PyJWT==2.13.0


### PR DESCRIPTION
## Summary
Clears Dependabot alert [#207](https://github.com/SkipLabs/skip/security/dependabot/207) — [GHSA-752w-5fwx-jx9f](https://github.com/jpadilla/pyjwt/security/advisories/GHSA-752w-5fwx-jx9f) (PyJWT accepts unknown `crit` header extensions, patched in 2.12.0).

The alert was raised 2026-03-14 against `PyJWT==2.8.0`. [PR #1144](https://github.com/SkipLabs/skip/pull/1144) bumped to 2.12.0 (the first patched version) on 2026-05-20, but Dependabot never auto-closed the alert. Bumping to **2.13.0** (latest) forces a re-scan and is itself a security release: 5 additional CVEs fixed plus 3 hardening changes (JWK-as-HMAC-secret algorithm confusion, PyJWK/PyJWKClient algorithm allow-list bypass, base64 DoS, etc.).

## Compatibility
This app's PyJWT usage is the basic plain-string-secret + HS256 flow:
- `jwt.encode(token_data, JWT_SECRET, algorithm="HS256")`
- `jwt.decode(token, JWT_SECRET, algorithms=["HS256"])`
- `except jwt.ExpiredSignatureError` / `except jwt.InvalidTokenError`

None of the 2.13.0 changes touch these APIs — the security fixes are around JWK/PyJWK paths we don't use.

Verified `import jwt; HS256 algorithm registered` cleanly with PyJWT 2.13.0 on Python 3.10 (system) — the Dockerfile uses Python 3.12.13 which exercises the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)