### PR TITLE
Pin qs >=6.14.1 in /examples/cache_invalidation/edge_service

### DIFF
--- a/examples/cache_invalidation/edge_service/package.json
+++ b/examples/cache_invalidation/edge_service/package.json
@@ -29,7 +29,8 @@
   },
   "pnpm": {
     "overrides": {
-      "path-to-regexp": "^0.1.13"
+      "path-to-regexp": "^0.1.13",
+      "qs": "^6.14.1"
     }
   }
 }

--- a/examples/cache_invalidation/edge_service/pnpm-lock.yaml
+++ b/examples/cache_invalidation/edge_service/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   path-to-regexp: ^0.1.13
+  qs: ^6.14.1
 
 importers:
 
@@ -754,8 +755,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -1174,7 +1175,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.13.0
+      qs: 6.15.2
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -1380,7 +1381,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -1672,7 +1673,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.13.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary
Fixes Dependabot alert [#111](https://github.com/SkipLabs/skip/security/dependabot/111) — [GHSA-6rw7-vpxm-498p](https://github.com/ljharb/qs/security/advisories/GHSA-6rw7-vpxm-498p) (medium: arrayLimit bypass in bracket notation enabling DoS via memory exhaustion, patched in 6.14.1).

`qs@6.13.0` is a transitive runtime dep pulled in by `express` (via `@skipruntime/server`). Added to the existing pnpm `overrides` block; resolution moves to **6.15.2** (latest patched in 6.x).

## Diff
- `package.json`: +1 line in `pnpm.overrides`.
- `pnpm-lock.yaml`: surgical change — `qs@6.13.0 → qs@6.15.2` across the express and body-parser snapshots.

## Compatibility
Changelog 6.13 → 6.15.2 is patches plus additive options (`throwOnParameterLimitExceeded` in 6.14.0, `strictMerge` in 6.15.0). The `arrayLimit` enforcement fix in 6.14.1 — the security patch — only changes behavior under attacker-style oversize inputs; default express query parsing on our skipruntime endpoints is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)