### PR TITLE
Dependency audit: Python + npm refresh, package version bump

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplabs/eslint-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Shared ESLint configuration for SkipLabs packages.",
   "main": "src/eslint.config.js",
   "type": "module",

--- a/examples/blogger/reactive_service/package-lock.json
+++ b/examples/blogger/reactive_service/package-lock.json
@@ -19,7 +19,7 @@
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^20.0.0",
-        "eslint": "10.0.0",
+        "eslint": "10.4.0",
         "typescript": "^5.0.0"
       }
     },
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -206,13 +206,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1349,29 +1349,29 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.0.tgz",
-      "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.0",
-        "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.0",
-        "@eslint/plugin-kit": "^0.6.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.0",
-        "eslint-visitor-keys": "^5.0.0",
-        "espree": "^11.1.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1382,7 +1382,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/examples/blogger/reactive_service/package.json
+++ b/examples/blogger/reactive_service/package.json
@@ -25,6 +25,6 @@
     "@skiplabs/tsconfig": "^0.0.2",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0",
-    "eslint": "10.0.0"
+    "eslint": "10.4.0"
   }
 }

--- a/examples/blogger/web_service/requirements.txt
+++ b/examples/blogger/web_service/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.12
 requests==2.33.0
 PyJWT==2.13.0

--- a/examples/blogger/web_service/requirements.txt
+++ b/examples/blogger/web_service/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3
 psycopg2-binary==2.9.12
-requests==2.33.0
+requests==2.34.2
 PyJWT==2.13.0

--- a/examples/cache_invalidation/edge_service/package.json
+++ b/examples/cache_invalidation/edge_service/package.json
@@ -25,7 +25,7 @@
     "@skiplabs/tsconfig": "^0.0.2",
     "@types/node": "^20.19.6",
     "typescript": "^5.8.3",
-    "eslint": "10.0.0"
+    "eslint": "10.4.0"
   },
   "pnpm": {
     "overrides": {

--- a/examples/cache_invalidation/web_service/requirements.txt
+++ b/examples/cache_invalidation/web_service/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.12
 requests==2.33.0
 PyJWT==2.13.0

--- a/examples/cache_invalidation/web_service/requirements.txt
+++ b/examples/cache_invalidation/web_service/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3
 psycopg2-binary==2.9.12
-requests==2.33.0
+requests==2.34.2
 PyJWT==2.13.0

--- a/examples/hackernews/web_service/requirements.txt
+++ b/examples/hackernews/web_service/requirements.txt
@@ -1,3 +1,3 @@
 Flask==3.1.3
-psycopg2_binary==2.9.10
+psycopg2-binary==2.9.12
 requests==2.33.0

--- a/examples/hackernews/web_service/requirements.txt
+++ b/examples/hackernews/web_service/requirements.txt
@@ -1,3 +1,3 @@
 Flask==3.1.3
 psycopg2-binary==2.9.12
-requests==2.33.0
+requests==2.34.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^22.10.0",
-        "eslint": "10.0.0",
+        "eslint": "10.4.0",
         "prettier": "3.4.1",
         "typescript": "^5.7.2"
       }
@@ -353,7 +353,7 @@
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^20.0.0",
-        "eslint": "10.0.0",
+        "eslint": "10.4.0",
         "typescript": "^5.0.0"
       }
     },
@@ -388,9 +388,9 @@
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.2",
-        "@types/node": "^20.0.0",
-        "eslint": "10.0.0",
-        "typescript": "^5.0.0"
+        "@types/node": "^20.19.6",
+        "eslint": "10.4.0",
+        "typescript": "^5.8.3"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/@types/node": {
@@ -401,6 +401,20 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/undici-types": {
@@ -919,35 +933,35 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.1.tgz",
-      "integrity": "sha512-uVSdg/V4dfQmTjJzR0szNczjOH/J+FyUMMjYtr07xFRXR7EDf9i1qdxrD0VusZH9knj1/ecxzCQQxyic5NzAiA==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.1",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^10.1.1"
+        "minimatch": "^10.2.4"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
-      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1025,21 +1039,21 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.1.tgz",
-      "integrity": "sha512-P9cq2dpr+LU8j3qbLygLcSZrl2/ds/pUpfnHNNuk5HW7mnngHs+6WSq5C9mO3rqRX8A1poxqLTC9cu0KOyJlBg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
-      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1711,9 +1725,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1977,12 +1991,12 @@
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2592,28 +2606,28 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.0.tgz",
-      "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.0",
-        "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.0",
-        "@eslint/plugin-kit": "^0.6.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.0",
-        "eslint-visitor-keys": "^5.0.0",
-        "espree": "^11.1.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2624,7 +2638,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2647,9 +2661,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.0.tgz",
-      "integrity": "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
@@ -2677,9 +2691,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -2689,14 +2703,14 @@
       }
     },
     "node_modules/eslint/node_modules/espree": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
-      "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.0"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -3636,12 +3650,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "examples/blogger/reactive_service"
       ],
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.1",
-        "@skiplabs/tsconfig": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^22.10.0",
         "eslint": "10.4.0",
         "prettier": "3.4.1",
@@ -41,7 +41,7 @@
     },
     "eslint-config": {
       "name": "@skiplabs/eslint-config",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.0",
@@ -357,6 +357,301 @@
         "typescript": "^5.0.0"
       }
     },
+    "examples/blogger/reactive_service/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skip-adapter/postgres": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.21.tgz",
+      "integrity": "sha512-zR81Uac7v+e2HfLLS7ctfSNGxrErNQvi9tWnPldKJXno2hOi85ofMjbRY7dWyRGGx4jZxx4I+9eiKdWSdEdtGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "pg": "^8.13.1",
+        "pg-format": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.1.tgz",
+      "integrity": "sha512-IzgczqEAcJ1HNFI6556DSV9wqqW1RF88FAZS+cew6WVMweAGE1FTpTLzuu8odyvCfduLaq531dAIZF1BaG3C4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^9.14.0",
+        "@stylistic/eslint-plugin-js": "^2.9.0",
+        "eslint-plugin-jsdoc": "^50.4.3",
+        "typescript-eslint": "^8.10.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config/node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config/node_modules/eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skiplabs/tsconfig": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/tsconfig/-/tsconfig-0.0.2.tgz",
+      "integrity": "sha512-F1LpZF/G/sDb8tGSodB3ZhJuPlM7UfY2aRj+Dev0XFkzb5VmPGU/5/6xZ8tbFIG8wl/CrlOpO17f2m+UWkd7qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/blogger/reactive_service/node_modules/@skipruntime/core": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.20.tgz",
+      "integrity": "sha512-GQhQiVP4wv5Zg2vNqzW2dMt0W/QJP3DVFxuujumZazEW8E1INaI9ZfV/rl1OU0czpue4jKiO9Q6bDO9INpBSDg=="
+    },
+    "examples/blogger/reactive_service/node_modules/@skipruntime/helpers": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.21.tgz",
+      "integrity": "sha512-6s/ylS/BtOO4euc0TDeTnOZ94S44ZCK0a7Meus+caIoLqFOinxy9q8SzlU3IPTcPmGyxgWA37Xk3lqdUX2MIHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "eventsource": "^2.0.2",
+        "express": "^4.21.1"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skipruntime/native": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
+      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skipruntime/server": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.21.tgz",
+      "integrity": "sha512-8uMYV6TKDuv63WZSZCjgbcy2FhYlTtsKQqoXV4bcIj+tHov/qlU0/MvV/BV9TPEKX4icDvHu1B9q8zTP75XJdA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "express": "^4.21.1"
+      },
+      "optionalDependencies": {
+        "@skipruntime/native": "0.0.21",
+        "@skipruntime/wasm": "0.0.21"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@skipruntime/wasm": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.21.tgz",
+      "integrity": "sha512-f6iM1jzrg3IaQc33Npgf0fIqXFKMsitQQrKe3JFidGWGGNWwdimBZCsPr5HBYsALxPy5o9GV1RB73Ue8tH8XEA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
+      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
     "examples/blogger/reactive_service/node_modules/@types/node": {
       "version": "20.17.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
@@ -365,6 +660,68 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/blogger/reactive_service/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "examples/blogger/reactive_service/node_modules/undici-types": {
@@ -393,6 +750,301 @@
         "typescript": "^5.8.3"
       }
     },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skip-adapter/postgres": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.21.tgz",
+      "integrity": "sha512-zR81Uac7v+e2HfLLS7ctfSNGxrErNQvi9tWnPldKJXno2hOi85ofMjbRY7dWyRGGx4jZxx4I+9eiKdWSdEdtGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "pg": "^8.13.1",
+        "pg-format": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.1.tgz",
+      "integrity": "sha512-IzgczqEAcJ1HNFI6556DSV9wqqW1RF88FAZS+cew6WVMweAGE1FTpTLzuu8odyvCfduLaq531dAIZF1BaG3C4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^9.14.0",
+        "@stylistic/eslint-plugin-js": "^2.9.0",
+        "eslint-plugin-jsdoc": "^50.4.3",
+        "typescript-eslint": "^8.10.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config/node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config/node_modules/eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/tsconfig": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/tsconfig/-/tsconfig-0.0.2.tgz",
+      "integrity": "sha512-F1LpZF/G/sDb8tGSodB3ZhJuPlM7UfY2aRj+Dev0XFkzb5VmPGU/5/6xZ8tbFIG8wl/CrlOpO17f2m+UWkd7qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/core": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.20.tgz",
+      "integrity": "sha512-GQhQiVP4wv5Zg2vNqzW2dMt0W/QJP3DVFxuujumZazEW8E1INaI9ZfV/rl1OU0czpue4jKiO9Q6bDO9INpBSDg=="
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/helpers": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.21.tgz",
+      "integrity": "sha512-6s/ylS/BtOO4euc0TDeTnOZ94S44ZCK0a7Meus+caIoLqFOinxy9q8SzlU3IPTcPmGyxgWA37Xk3lqdUX2MIHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "eventsource": "^2.0.2",
+        "express": "^4.21.1"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/native": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
+      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/server": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.21.tgz",
+      "integrity": "sha512-8uMYV6TKDuv63WZSZCjgbcy2FhYlTtsKQqoXV4bcIj+tHov/qlU0/MvV/BV9TPEKX4icDvHu1B9q8zTP75XJdA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "express": "^4.21.1"
+      },
+      "optionalDependencies": {
+        "@skipruntime/native": "0.0.21",
+        "@skipruntime/wasm": "0.0.21"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/wasm": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.21.tgz",
+      "integrity": "sha512-f6iM1jzrg3IaQc33Npgf0fIqXFKMsitQQrKe3JFidGWGGNWwdimBZCsPr5HBYsALxPy5o9GV1RB73Ue8tH8XEA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
+      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
     "examples/cache_invalidation/edge_service/node_modules/@types/node": {
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
@@ -401,6 +1053,68 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/cache_invalidation/edge_service/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/typescript": {
@@ -442,6 +1156,362 @@
         "@types/node": "^22.10.0"
       }
     },
+    "examples/chatroom/reactive_service/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@skip-adapter/kafka": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skip-adapter/kafka/-/kafka-0.0.21.tgz",
+      "integrity": "sha512-GICUxw9C46YmS6beB3Mfp8tFbP2RrJZmXcgY9NJQYLDr1tGe9YAVbvUbsuuBqUclj5P3v0bJzLu58jEmub0gXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "kafkajs": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=22.6.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.1.tgz",
+      "integrity": "sha512-IzgczqEAcJ1HNFI6556DSV9wqqW1RF88FAZS+cew6WVMweAGE1FTpTLzuu8odyvCfduLaq531dAIZF1BaG3C4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^9.14.0",
+        "@stylistic/eslint-plugin-js": "^2.9.0",
+        "eslint-plugin-jsdoc": "^50.4.3",
+        "typescript-eslint": "^8.10.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@skiplabs/tsconfig": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/tsconfig/-/tsconfig-0.0.2.tgz",
+      "integrity": "sha512-F1LpZF/G/sDb8tGSodB3ZhJuPlM7UfY2aRj+Dev0XFkzb5VmPGU/5/6xZ8tbFIG8wl/CrlOpO17f2m+UWkd7qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/chatroom/reactive_service/node_modules/@skipruntime/core": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.20.tgz",
+      "integrity": "sha512-GQhQiVP4wv5Zg2vNqzW2dMt0W/QJP3DVFxuujumZazEW8E1INaI9ZfV/rl1OU0czpue4jKiO9Q6bDO9INpBSDg=="
+    },
+    "examples/chatroom/reactive_service/node_modules/@skipruntime/helpers": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.21.tgz",
+      "integrity": "sha512-6s/ylS/BtOO4euc0TDeTnOZ94S44ZCK0a7Meus+caIoLqFOinxy9q8SzlU3IPTcPmGyxgWA37Xk3lqdUX2MIHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "eventsource": "^2.0.2",
+        "express": "^4.21.1"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@skipruntime/native": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
+      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@skipruntime/server": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.21.tgz",
+      "integrity": "sha512-8uMYV6TKDuv63WZSZCjgbcy2FhYlTtsKQqoXV4bcIj+tHov/qlU0/MvV/BV9TPEKX4icDvHu1B9q8zTP75XJdA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "express": "^4.21.1"
+      },
+      "optionalDependencies": {
+        "@skipruntime/native": "0.0.21",
+        "@skipruntime/wasm": "0.0.21"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@skipruntime/wasm": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.21.tgz",
+      "integrity": "sha512-f6iM1jzrg3IaQc33Npgf0fIqXFKMsitQQrKe3JFidGWGGNWwdimBZCsPr5HBYsALxPy5o9GV1RB73Ue8tH8XEA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
+      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/chatroom/reactive_service/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "examples/hackernews/reactive_service": {
       "name": "reactive-hackernews-leader",
       "version": "1.0.0",
@@ -457,6 +1527,380 @@
         "@skiplabs/eslint-config": "^0.0.1",
         "@skiplabs/tsconfig": "^0.0.2",
         "@types/node": "^22.10.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skip-adapter/postgres": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.21.tgz",
+      "integrity": "sha512-zR81Uac7v+e2HfLLS7ctfSNGxrErNQvi9tWnPldKJXno2hOi85ofMjbRY7dWyRGGx4jZxx4I+9eiKdWSdEdtGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "pg": "^8.13.1",
+        "pg-format": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.1.tgz",
+      "integrity": "sha512-IzgczqEAcJ1HNFI6556DSV9wqqW1RF88FAZS+cew6WVMweAGE1FTpTLzuu8odyvCfduLaq531dAIZF1BaG3C4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^9.14.0",
+        "@stylistic/eslint-plugin-js": "^2.9.0",
+        "eslint-plugin-jsdoc": "^50.4.3",
+        "typescript-eslint": "^8.10.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skiplabs/tsconfig": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/tsconfig/-/tsconfig-0.0.2.tgz",
+      "integrity": "sha512-F1LpZF/G/sDb8tGSodB3ZhJuPlM7UfY2aRj+Dev0XFkzb5VmPGU/5/6xZ8tbFIG8wl/CrlOpO17f2m+UWkd7qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/hackernews/reactive_service/node_modules/@skipruntime/core": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.20.tgz",
+      "integrity": "sha512-GQhQiVP4wv5Zg2vNqzW2dMt0W/QJP3DVFxuujumZazEW8E1INaI9ZfV/rl1OU0czpue4jKiO9Q6bDO9INpBSDg=="
+    },
+    "examples/hackernews/reactive_service/node_modules/@skipruntime/helpers": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.21.tgz",
+      "integrity": "sha512-6s/ylS/BtOO4euc0TDeTnOZ94S44ZCK0a7Meus+caIoLqFOinxy9q8SzlU3IPTcPmGyxgWA37Xk3lqdUX2MIHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "eventsource": "^2.0.2",
+        "express": "^4.21.1"
+      },
+      "engines": {
+        "node": ">=22.6.0 <23.0.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skipruntime/native": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
+      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skipruntime/server": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.21.tgz",
+      "integrity": "sha512-8uMYV6TKDuv63WZSZCjgbcy2FhYlTtsKQqoXV4bcIj+tHov/qlU0/MvV/BV9TPEKX4icDvHu1B9q8zTP75XJdA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20",
+        "express": "^4.21.1"
+      },
+      "optionalDependencies": {
+        "@skipruntime/native": "0.0.21",
+        "@skipruntime/wasm": "0.0.21"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skipruntime/wasm": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.21.tgz",
+      "integrity": "sha512-f6iM1jzrg3IaQc33Npgf0fIqXFKMsitQQrKe3JFidGWGGNWwdimBZCsPr5HBYsALxPy5o9GV1RB73Ue8tH8XEA==",
+      "dependencies": {
+        "@skipruntime/core": "0.0.20"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
+      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+      "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6",
+        "@typescript-eslint/types": "^8.11.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -2276,6 +3720,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3466,6 +4920,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -5503,21 +6967,21 @@
     },
     "skiplang/prelude/ts/binding": {
       "name": "@skiplang/std",
-      "version": "0.0.4"
+      "version": "0.0.5"
     },
     "skiplang/prelude/ts/wasm": {
       "name": "@skip-wasm/std",
-      "version": "1.0.7"
+      "version": "1.0.8"
     },
     "skiplang/prelude/ts/worker": {
       "name": "@skip-wasm/worker",
-      "version": "0.0.1"
+      "version": "0.0.2"
     },
     "skiplang/skdate/ts": {
       "name": "@skip-wasm/date",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
-        "@skip-wasm/std": "1.0.7"
+        "@skip-wasm/std": "1.0.8"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -5526,18 +6990,18 @@
     },
     "skiplang/skjson/ts/binding": {
       "name": "@skiplang/json",
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     "skiplang/skjson/ts/wasm": {
       "name": "@skip-wasm/json",
-      "version": "1.0.8"
+      "version": "1.0.9"
     },
     "skipruntime-ts/adapters/kafka": {
       "name": "@skip-adapter/kafka",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.20",
+        "@skipruntime/core": "0.0.21",
         "kafkajs": "^2.2.4"
       },
       "engines": {
@@ -5546,10 +7010,10 @@
     },
     "skipruntime-ts/adapters/postgres": {
       "name": "@skip-adapter/postgres",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.20",
+        "@skipruntime/core": "0.0.21",
         "pg": "^8.13.1",
         "pg-format": "^1.0.4"
       },
@@ -5563,21 +7027,21 @@
     },
     "skipruntime-ts/addon": {
       "name": "@skipruntime/native",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "hasInstallScript": true,
       "dependencies": {
-        "@skipruntime/core": "0.0.20"
+        "@skipruntime/core": "0.0.21"
       }
     },
     "skipruntime-ts/core": {
       "name": "@skipruntime/core",
-      "version": "0.0.20"
+      "version": "0.0.21"
     },
     "skipruntime-ts/examples": {
       "name": "skipruntime-examples",
       "dependencies": {
-        "@skipruntime/helpers": "0.0.21",
-        "@skipruntime/server": "0.0.21",
+        "@skipruntime/helpers": "0.0.22",
+        "@skipruntime/server": "0.0.22",
         "better-sqlite3": "^11.7.2",
         "eventsource": "^2.0.2"
       },
@@ -5588,10 +7052,10 @@
     },
     "skipruntime-ts/helpers": {
       "name": "@skipruntime/helpers",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.20",
+        "@skipruntime/core": "0.0.21",
         "eventsource": "^2.0.2",
         "express": "^4.22.2"
       },
@@ -5604,24 +7068,24 @@
     },
     "skipruntime-ts/metapackage": {
       "name": "@skiplabs/skip",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
-        "@skipruntime/core": "0.0.20",
-        "@skipruntime/helpers": "0.0.21",
-        "@skipruntime/server": "0.0.21",
-        "@skipruntime/wasm": "0.0.21"
+        "@skipruntime/core": "0.0.21",
+        "@skipruntime/helpers": "0.0.22",
+        "@skipruntime/server": "0.0.22",
+        "@skipruntime/wasm": "0.0.22"
       },
       "optionalDependencies": {
-        "@skip-adapter/kafka": "0.0.21",
-        "@skip-adapter/postgres": "0.0.21",
-        "@skipruntime/native": "0.0.21"
+        "@skip-adapter/kafka": "0.0.22",
+        "@skip-adapter/postgres": "0.0.22",
+        "@skipruntime/native": "0.0.22"
       }
     },
     "skipruntime-ts/server": {
       "name": "@skipruntime/server",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
-        "@skipruntime/core": "0.0.20",
+        "@skipruntime/core": "0.0.21",
         "express": "^4.22.2"
       },
       "devDependencies": {
@@ -5632,18 +7096,18 @@
         "tsx": "^4.19.3"
       },
       "optionalDependencies": {
-        "@skipruntime/native": "0.0.21",
-        "@skipruntime/wasm": "0.0.21"
+        "@skipruntime/native": "0.0.22",
+        "@skipruntime/wasm": "0.0.22"
       }
     },
     "skipruntime-ts/tests": {
       "name": "@skipruntime/tests",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.21",
-        "@skipruntime/core": "0.0.20",
-        "@skipruntime/helpers": "0.0.21",
-        "@skipruntime/native": "0.0.21",
-        "@skipruntime/wasm": "0.0.21",
+        "@skip-adapter/postgres": "0.0.22",
+        "@skipruntime/core": "0.0.21",
+        "@skipruntime/helpers": "0.0.22",
+        "@skipruntime/native": "0.0.22",
+        "@skipruntime/wasm": "0.0.22",
         "earl": "^1.3.0",
         "mocha": "^11.0.1",
         "pg": "^8.13.1"
@@ -5655,14 +7119,14 @@
     },
     "skipruntime-ts/wasm": {
       "name": "@skipruntime/wasm",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
-        "@skipruntime/core": "0.0.20"
+        "@skipruntime/core": "0.0.21"
       }
     },
     "sql/ts": {
       "name": "skdb",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "bin": {
         "skdb-cli": "dist/src/skdb-cli.js"
       },
@@ -5676,7 +7140,7 @@
       "name": "skdb-tests",
       "dependencies": {
         "@playwright/test": "^1.47.2",
-        "skdb": "^1.0.1",
+        "skdb": "^1.0.2",
         "ws": "^8.20.1"
       },
       "devDependencies": {
@@ -5687,7 +7151,7 @@
     },
     "tsconfig": {
       "name": "@skiplabs/tsconfig",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   ],
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "@skiplabs/eslint-config": "^0.0.1",
-    "@skiplabs/tsconfig": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/tsconfig": "^0.0.3",
     "eslint": "10.4.0",
     "prettier": "3.4.1",
     "typescript": "^5.7.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22.10.0",
     "@skiplabs/eslint-config": "^0.0.1",
     "@skiplabs/tsconfig": "^0.0.2",
-    "eslint": "10.0.0",
+    "eslint": "10.4.0",
     "prettier": "3.4.1",
     "typescript": "^5.7.2"
   },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 # Development dependencies
-black==26.3.1
+black==26.5.1

--- a/skiplang/prelude/ts/binding/package.json
+++ b/skiplang/prelude/ts/binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplang/std",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skiplang/prelude/ts/wasm/package.json
+++ b/skiplang/prelude/ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/std",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skiplang/prelude/ts/worker/package.json
+++ b/skiplang/prelude/ts/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/worker",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "exports": {
     "browser": "./dist/browser.js",

--- a/skiplang/skdate/ts/package.json
+++ b/skiplang/skdate/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/date",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "exports": {
     ".": "./dist/src/sk_date.js"
@@ -15,6 +15,6 @@
     "@types/ws": "^8.5.13"
   },
   "dependencies": {
-    "@skip-wasm/std": "1.0.7"
+    "@skip-wasm/std": "1.0.8"
   }
 }

--- a/skiplang/skjson/ts/binding/package.json
+++ b/skiplang/skjson/ts/binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplang/json",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/skiplang/skjson/ts/wasm/package.json
+++ b/skiplang/skjson/ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-wasm/json",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "exports": {
     ".": "./dist/skjson.js",

--- a/skipruntime-ts/adapters/kafka/package.json
+++ b/skipruntime-ts/adapters/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/kafka",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "kafkajs": "^2.2.4",
-    "@skipruntime/core": "0.0.20"
+    "@skipruntime/core": "0.0.21"
   }
 }

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/postgres",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "pg": "^8.13.1",
     "pg-format": "^1.0.4",
-    "@skipruntime/core": "0.0.20"
+    "@skipruntime/core": "0.0.21"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/native",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "gypfile": true,
   "type": "module",
   "exports": {
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.20"
+    "@skipruntime/core": "0.0.21"
   }
 }

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/core",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -12,8 +12,8 @@
     "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
-    "@skipruntime/helpers": "0.0.21",
-    "@skipruntime/server": "0.0.21",
+    "@skipruntime/helpers": "0.0.22",
+    "@skipruntime/server": "0.0.22",
     "eventsource": "^2.0.2",
     "better-sqlite3": "^11.7.2"
   }

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/helpers",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "eventsource": "^2.0.2",
     "express": "^4.22.2",
-    "@skipruntime/core": "0.0.20"
+    "@skipruntime/core": "0.0.21"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15"

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@skiplabs/skip",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "dependencies": {
-    "@skipruntime/core": "0.0.20",
-    "@skipruntime/server": "0.0.21",
-    "@skipruntime/helpers": "0.0.21",
-    "@skipruntime/wasm": "0.0.21"
+    "@skipruntime/core": "0.0.21",
+    "@skipruntime/server": "0.0.22",
+    "@skipruntime/helpers": "0.0.22",
+    "@skipruntime/wasm": "0.0.22"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.21",
-    "@skip-adapter/kafka": "0.0.21",
-    "@skip-adapter/postgres": "0.0.21"
+    "@skipruntime/native": "0.0.22",
+    "@skip-adapter/kafka": "0.0.22",
+    "@skip-adapter/postgres": "0.0.22"
   }
 }

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/server",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "exports": {
     ".": "./dist/src/server.js"
@@ -19,11 +19,11 @@
     "tsx": "^4.19.3"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.20",
+    "@skipruntime/core": "0.0.21",
     "express": "^4.22.2"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.21",
-    "@skipruntime/wasm": "0.0.21"
+    "@skipruntime/native": "0.0.22",
+    "@skipruntime/wasm": "0.0.22"
   }
 }

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -16,10 +16,10 @@
     "earl": "^1.3.0",
     "mocha": "^11.0.1",
     "pg": "^8.13.1",
-    "@skipruntime/core": "0.0.20",
-    "@skipruntime/helpers": "0.0.21",
-    "@skipruntime/native": "0.0.21",
-    "@skipruntime/wasm": "0.0.21",
-    "@skip-adapter/postgres": "0.0.21"
+    "@skipruntime/core": "0.0.21",
+    "@skipruntime/helpers": "0.0.22",
+    "@skipruntime/native": "0.0.22",
+    "@skipruntime/wasm": "0.0.22",
+    "@skip-adapter/postgres": "0.0.22"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/wasm",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "exports": {
     ".": {
@@ -15,6 +15,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.20"
+    "@skipruntime/core": "0.0.21"
   }
 }

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skdb",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "exports": {
     ".": {

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@playwright/test": "^1.47.2",
     "ws": "^8.20.1",
-    "skdb": "^1.0.1"
+    "skdb": "^1.0.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplabs/tsconfig",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Shared tsconfig.json config for SkipLabs packages.",
   "author": "SkipLabs",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Audit of `requirements*.txt` and published npm package deps. One commit per package update, with a final uniform patch bump across the 17 published packages.

## Commits

1. **Bump psycopg2-binary to 2.9.12 in example web_services** — 2.9.9/2.9.10 → 2.9.12 across blogger, cache_invalidation, hackernews. Latest 2.9.x; adds cp313/cp314 wheels. Hackernews migrated from `psycopg2_binary` (underscore) to the canonical hyphenated dist name.

2. **Bump requests to 2.34.2 in example web_services** — 2.33.0 → 2.34.2 across all three. No API breaks for our basic `requests.get/post` usage.

3. **Bump black to 26.5.1 in requirements-dev.txt** — pre-commit hook reads this version. Verified all `.py` files in the repo already conform to 26.5.1's formatting (no reflow).

4. **Bump eslint to 10.4.0 across exact-pinned packages** — root + `examples/blogger/reactive_service` + `examples/cache_invalidation/edge_service` (the three places exact-pinning `10.0.0`). Other workspaces use `^9.15.0` and are unchanged (eslint 9→10 is a major bump, out of scope).

5. **Bump all published npm packages by one patch** — uniform patch bump across the 17 packages we publish, plus internal cross-dep refresh and root lockfile update:
   - @skipruntime/core: 0.0.20 → 0.0.21
   - @skipruntime/{helpers,wasm,native,server}: 0.0.21 → 0.0.22
   - @skip-adapter/{kafka,postgres}: 0.0.21 → 0.0.22
   - @skiplabs/skip (metapackage): 0.0.20 → 0.0.21
   - @skiplabs/eslint-config: 0.0.1 → 0.0.2
   - @skiplabs/tsconfig: 0.0.2 → 0.0.3
   - @skiplang/std: 0.0.4 → 0.0.5
   - @skiplang/json: 0.0.5 → 0.0.6
   - @skip-wasm/std: 1.0.7 → 1.0.8
   - @skip-wasm/worker: 0.0.1 → 0.0.2
   - @skip-wasm/date: 1.0.6 → 1.0.7
   - @skip-wasm/json: 1.0.8 → 1.0.9
   - skdb: 1.0.1 → 1.0.2

Downstream standalone consumers (under `examples/*`, `packages/{dev,react}`, `sql/ts/{bun,vitejs}`) intentionally still pin to the previously-published versions; they will be updated in a follow-up after these new versions land on the registry.

## Out of scope (audit findings worth following up separately)
- **Major bumps left for separate review**: typescript 5→6, @types/node 22→25, express 4→5, chai 5→6, earl 1→2, better-sqlite3 11→12, eventsource 2→4, @types/eventsource 1→3, eslint-plugin-jsdoc 62→63 — each needs its own migration consideration.
- **Within-range floors**: many devDeps (e.g., `mocha: ^11.0.1` and `^11.1.0` across packages) could unify, but npm install already picks the latest in-range, so functionally no-op.
- **prettier 3.4.1 → 3.8.3**: skipped here because bumping it may trigger a repo-wide reformat (separate from a dep audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)