### PR TITLE
Add build-all prereq to publish-* Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,36 +263,44 @@ skfmt-%:
 skbuild-%:
 	cd $* && skargo b --profile $(SKARGO_PROFILE)
 
+# Build every workspace package in dependency order. Required before any
+# publish-* target so that downstream packages can see their dependencies'
+# emitted .d.ts and .js (which release_npm.sh's idempotent skip-if-already-
+# published check would otherwise bypass).
+.PHONY: build-all
+build-all:
+	npm run build --workspaces --if-present
+
 .PHONY: publish-core
-publish-core:
+publish-core: build-all
 	bin/release_npm.sh @skipruntime/core skipruntime-ts/core/package.json $(OTP)
 
 .PHONY: publish-helpers
-publish-helpers:
+publish-helpers: build-all
 	bin/release_npm.sh @skipruntime/helpers skipruntime-ts/helpers/package.json $(OTP)
 
 .PHONY: publish-wasm
-publish-wasm:
+publish-wasm: build-all
 	bin/release_npm.sh @skipruntime/wasm skipruntime-ts/wasm/package.json $(OTP)
 
 .PHONY: publish-native
-publish-native:
+publish-native: build-all
 	bin/release_npm.sh @skipruntime/native skipruntime-ts/addon/package.json $(OTP)
 
 .PHONY: publish-server
-publish-server:
+publish-server: build-all
 	bin/release_npm.sh @skipruntime/server skipruntime-ts/server/package.json $(OTP)
 
 .PHONY: publish-postgres-adapter
-publish-postgres-adapter:
+publish-postgres-adapter: build-all
 	bin/release_npm.sh @skip-adapter/postgres skipruntime-ts/adapters/postgres/package.json $(OTP)
 
 .PHONY: publish-kafka-adapter
-publish-kafka-adapter:
+publish-kafka-adapter: build-all
 	bin/release_npm.sh @skip-adapter/kafka skipruntime-ts/adapters/kafka/package.json $(OTP)
 
 .PHONY: publish-metapackage
-publish-metapackage:
+publish-metapackage: build-all
 	bin/release_npm.sh @skiplabs/skip skipruntime-ts/metapackage/package.json $(OTP)
 
 .PHONY: publish-all


### PR DESCRIPTION
## Summary
`make publish-<single-package>` on a fresh checkout failed with `Cannot find module '@skipruntime/core'` (or similar for other workspace deps). The package's `tsc` needs its workspace deps' emitted `dist/*.d.ts` files, but the individual `publish-*` targets didn't pre-build them, and [bin/release_npm.sh](bin/release_npm.sh)'s idempotent "skip if already at the published version" check would prevent any upstream build from running even when prereq publishes were declared.

Adds a `build-all` target that wraps `npm run build --workspaces --if-present` (the same command root `package.json`'s `build` script does) and makes every `publish-*` target depend on it. tsc is incremental via `tsbuildinfo`, so the prereq is effectively free on subsequent runs.

`publish-all` already worked because (a) its sub-targets run in dep order and (b) `release_npm.sh` runs `npm run build` inside each package; the new prereq just makes individual targets equally robust.

## Test plan
- [x] `make publish-server` on a clean tree no longer dies on missing `@skipruntime/core` types.
- [x] `make publish-all` still produces the same publish sequence (each `publish-*` short-circuits on `build-all` which is incremental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)