### PR TITLE
Also clean tsconfig.tsbuildinfo in npm clean scripts

### DIFF
--- a/examples/blogger/reactive_service/package.json
+++ b/examples/blogger/reactive_service/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "start": "node server.js",
     "dev": "tsc --watch & node server.js",
-    "clean": "rm -rf dist && rm -rf node_modules",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo && rm -rf node_modules",
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/examples/blogger/www/package.json
+++ b/examples/blogger/www/package.json
@@ -8,7 +8,7 @@
     "build": "vue-tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "clean": "rm -rf node_modules && rm -rf dist"
+    "clean": "rm -rf node_modules && rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "vue": "^3.5.0",

--- a/examples/cache_invalidation/edge_service/package.json
+++ b/examples/cache_invalidation/edge_service/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "start": "node server.js",
     "dev": "tsc --watch & node server.js",
-    "clean": "rm -rf dist && rm -rf node_modules",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo && rm -rf node_modules",
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/examples/cache_invalidation/www/package.json
+++ b/examples/cache_invalidation/www/package.json
@@ -8,7 +8,7 @@
     "build": "vue-tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "clean": "rm -rf node_modules && rm -rf dist"
+    "clean": "rm -rf node_modules && rm -rf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "vue": "^3.5.0",

--- a/skiplang/prelude/ts/binding/package.json
+++ b/skiplang/prelude/ts/binding/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   }
 }

--- a/skiplang/prelude/ts/wasm/package.json
+++ b/skiplang/prelude/ts/wasm/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "node ../../../../prebuild.mjs skiplang-std && tsc",
-    "clean": "rm -rf dist skiplang-std",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skiplang-std",
     "lint": "eslint"
   }
 }

--- a/skiplang/prelude/ts/worker/package.json
+++ b/skiplang/prelude/ts/worker/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "node ../../../../prebuild.mjs skiplang-std skipwasm-std && tsc",
-    "clean": "rm -rf dist skiplang-std skipwasm-std",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skiplang-std skipwasm-std",
     "lint": "eslint"
   }
 }

--- a/skiplang/skdate/ts/package.json
+++ b/skiplang/skdate/ts/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "node ../../../prebuild.mjs skiplang-std skipwasm-std && tsc",
-    "clean": "rm -rf dist skiplang-std skipwasm-std",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skiplang-std skipwasm-std",
     "lint": "eslint"
   },
   "devDependencies": {

--- a/skiplang/skjson/ts/binding/package.json
+++ b/skiplang/skjson/ts/binding/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "node ../../../../prebuild.mjs skiplang-std && tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   }
 }

--- a/skiplang/skjson/ts/wasm/package.json
+++ b/skiplang/skjson/ts/wasm/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "node ../../../../prebuild.mjs skiplang-std skipwasm-std skiplang-json && tsc",
-    "clean": "rm -rf dist skiplang-std skipwasm-std skiplang-json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skiplang-std skipwasm-std skiplang-json",
     "lint": "eslint"
   }
 }

--- a/skipruntime-ts/adapters/kafka/package.json
+++ b/skipruntime-ts/adapters/kafka/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   },
   "author": "SkipLabs",

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   },
   "author": "SkipLabs",

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "install": "VERSION=$(./calculate_version.sh) node-gyp rebuild",
-    "clean": "rm -rf dist && node-gyp clean",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo && node-gyp clean",
     "lint": "eslint"
   },
   "dependencies": {

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "node ../../prebuild.mjs skiplang-std skiplang-json && tsc",
-    "clean": "rm -rf dist skiplang-std skiplang-js",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skiplang-std skiplang-js",
     "lint": "eslint"
   }
 }

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   },
   "devDependencies": {

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "node ../../prebuild.mjs skiplang-std && tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   },
   "author": "SkipLabs",

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint",
     "test": "mocha test/**/*.spec.ts"
   },

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint src/",
     "test": "mocha"
   },

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run typecheck && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../skiplang/ffi/Skargo.toml --out-dir=./dist/src/",
     "typecheck": "node ../../prebuild.mjs skipwasm-std skipwasm-json && tsc",
-    "clean": "rm -rf dist skipwasm-std skipwasm-json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skipwasm-std skipwasm-json",
     "lint": "eslint"
   },
   "dependencies": {

--- a/sql/ts/package.json
+++ b/sql/ts/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run typecheck && skargo build -r --target wasm32-unknown-unknown --lib --manifest-path=../Skargo.toml --out-dir=./dist/src/",
     "typecheck": "node ../../prebuild.mjs skiplang-std skiplang-json skipwasm-std skipwasm-json skipwasm-date skipwasm-worker && tsc",
-    "clean": "rm -rf dist skiplang-std skiplang-json skipwasm-std skipwasm-json skipwasm-date skipwasm-worker",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo skiplang-std skiplang-json skipwasm-std skipwasm-json skipwasm-date skipwasm-worker",
     "lint": "eslint",
     "cli": "node ./dist/src/skdb-cli.js"
   },

--- a/sql/ts/tests/package.json
+++ b/sql/ts/tests/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint"
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #1230. Existing per-workspace `clean` scripts wipe `dist/` but leave behind `tsconfig.tsbuildinfo`. TypeScript's incremental build state then thinks the package is up-to-date and `tsc` emits nothing — but `dist/` is gone, so downstream packages can't find any `.d.ts`. This shows up as a spurious "Cannot find module" build failure that's only resolved by a manual `rm tsconfig.tsbuildinfo`.

Adds `tsconfig.tsbuildinfo` to the `rm -rf` chain in every workspace `clean` script so `npm run clean` fully resets the build state.

21 packages touched; one-line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)