### PR TITLE
Blog SEO & GEO: social cards, JSON-LD, series, llms.txt

### DIFF
--- a/www/blog/adapters.md
+++ b/www/blog/adapters.md
@@ -4,7 +4,7 @@ description: How to make Postgres and Kafka-backed reactive services
 slug: non-reactive-dependencies
 date: 2025-04-14
 authors: benno
-image: /img/skip.png
+image: /img/og/non-reactive-dependencies.png
 ---
 
 The Skip framework is a system for building and running incremental backend services, simplifying the challenges of engineering complex reactive systems.

--- a/www/blog/backend_pressure.md
+++ b/www/blog/backend_pressure.md
@@ -4,7 +4,7 @@ description: A technical exploration of how reactive systems can solve backend p
 slug: backend_pressure
 date: 2025-06-20
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/backend_pressure.png
 ---
 
 Backend systems face constant pressure from multiple directions: user requests demanding instant responses, databases struggling under query loads, and servers managing finite computational resources. This backend pressure—the cumulative stress of handling concurrent requests while maintaining performance and resource constraints—manifests in bottlenecks, latency spikes, and system instability. Traditional approaches often treat these pressures as isolated problems—adding a cache here, optimizing a query there—resulting in complex patches that fix symptoms but ignore deeper architectural issues.

--- a/www/blog/cache_invalidation.md
+++ b/www/blog/cache_invalidation.md
@@ -4,7 +4,7 @@ description: A technical blog post examining cache invalidation challenges in di
 slug: cache_invalidation
 date: 2025-07-04
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/cache_invalidation.png
 ---
 
 Phil Karlton famously said *there are only two hard things in computer science: cache invalidation and naming things*. While naming things may be subjective, [cache invalidation](https://en.wikipedia.org/wiki/Cache_invalidation) is a problem that only gets harder as our systems grow more complex. As applications scale and users expect real-time data everywhere, traditional approaches to cache management crack under pressure.

--- a/www/blog/chat_with_react_vite.md
+++ b/www/blog/chat_with_react_vite.md
@@ -4,7 +4,7 @@ description: Build a modern chat app with real-time updates using Skip's reactiv
 slug: skip_with_react_vite
 date: 2025-05-30
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/skip_with_react_vite.png
 ---
 
 Hello skippers. Today, we are introducing a new template to our collection: React + Vite. While our previous blog posts focused on building skip services, this new template represents our first step into the frontend, bringing together the best of both worlds: front and back.

--- a/www/blog/closed_loop.md
+++ b/www/blog/closed_loop.md
@@ -4,7 +4,7 @@ description: Closed-loop control requires a feedback signal trustworthy enough t
 slug: closed_loop_coding_agent
 date: 2026-05-18
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/closed_loop_coding_agent.png
 ---
 
 Skipper is a closed-loop coding agent. That label carries more weight than it appears. The industry adopted "closed-loop" without retaining its original meaning, so many tools labeled that way don't truly qualify. Once you understand the distinction, you see what sets Skipper apart.

--- a/www/blog/codegen_as_complier.md
+++ b/www/blog/codegen_as_complier.md
@@ -4,7 +4,7 @@ description: Why our discomfort with AI-generated code reveals exactly what we h
 slug: codegen_as_compiler
 date: 2026-03-09
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/codegen_as_compiler.png
 ---
 
 Philip Su's recent post argues that code reviews are not just impractical in the age of coding agents, they're headed toward being *irresponsible*. He's right on trend. But I think the framing of "lights-out codebases" skips over the more interesting and uncomfortable question: **why does lights-out feel so scary**, and what does that fear actually tell us?

--- a/www/blog/create_skip_service_announcement.md
+++ b/www/blog/create_skip_service_announcement.md
@@ -4,7 +4,7 @@ description: A CLI designed to streamline the creation and initialization of Ski
 slug: announcing_create_skip_service_cli
 date: 2025-05-23
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/announcing_create_skip_service_cli.png
 ---
 
 Hello Skippers. Today, we are excited to announce the release of `create-skip-service`: A CLI Tool for Skip Service Development. It aims to simplify the development workflow by providing a convenient way to bootstrap new Skip services.

--- a/www/blog/event_hidden_arch.md
+++ b/www/blog/event_hidden_arch.md
@@ -4,7 +4,7 @@ description: Interactive features without events
 slug: event-hidden-arch
 date: 2025-04-21
 authors: charles
-image: /img/skip.png
+image: /img/og/event-hidden-arch.png
 ---
 
 ## Event-Hidden Architectures

--- a/www/blog/future_of_tools_for_ai.md
+++ b/www/blog/future_of_tools_for_ai.md
@@ -4,7 +4,7 @@ description: We spent decades making languages readable. Agents don't care. Why 
 slug: future_of_tools_for_ai
 date: 2026-03-23
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/future_of_tools_for_ai.png
 ---
 
 In my [last post](https://skiplabs.io/blog/codegen_as_compiler), I argued that we should treat agent output the way we treat compiler output: not something to be read and reviewed by humans, but something to be verified by process. The framing resonated with a lot of people, but it leaves a deeper question on the table.

--- a/www/blog/interview_lucas.md
+++ b/www/blog/interview_lucas.md
@@ -4,6 +4,7 @@ description: An in-depth conversation with a SkipLabs engineer about reactive pr
 slug: interview_lucas
 date: 2025-07-11
 authors: hubyrod
+image: /img/og/interview_lucas.png
 ---
 
 Ever wondered what it's like to work on cutting-edge reactive programming? This chat with a Lucas, a SkipLabs engineer, gives you the inside scoop on building tools that tackle gnarly data synchronization problems. We have created something called the Skip Framework, which runs on our own programming language, SkipLang, pretty cool stuff. What makes this interview particularly interesting is how it bounces between the nuts and bolts of performance testing (like figuring out why stream creation was too slow) and the bigger picture of where tech is headed. You'll get a feel for SkipLabs' laid-back engineering culture where people work independently but always have each other's backs, plus some thoughtful takes on everything from open source development to why we still edit code like it's 1995. Whether you're into the technical weeds of load testing or curious about how small teams tackle ambitious projects, there's something here for you.

--- a/www/blog/notes_from_the_comments.md
+++ b/www/blog/notes_from_the_comments.md
@@ -4,7 +4,7 @@ description: A follow-up to "Treat Agent Output Like Compiler Output" — addres
 slug: notes_from_the_comments
 date: 2026-05-05
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/notes_from_the_comments.png
 ---
 
 *A follow-up to ["Treat Agent Output Like Compiler Output"](https://skiplabs.io/blog/codegen_as_compiler), published in March.*

--- a/www/blog/postgresql_and_skip_poc.md
+++ b/www/blog/postgresql_and_skip_poc.md
@@ -4,7 +4,7 @@ description: How to use Skip's reactive data streaming with a PostgreSQL backend
 slug: postgresql_and_skip
 date: 2025-05-16
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/postgresql_and_skip.png
 ---
 
 Hello Skippers. Today, we are going to plug a [PostgreSQL](https://www.postgresql.org/) service and our starting point is the following project on GitHub: [Skip Postgres Demo](https://github.com/SkipLabs/postgres_and_skip_poc). We will demonstrate how to use Skip's reactive data streaming with a PostgreSQL backend. This project implements a simple blog post system with real-time updates using Skip's streaming capabilities.

--- a/www/blog/reactive_social_skip_service_poc.md
+++ b/www/blog/reactive_social_skip_service_poc.md
@@ -4,7 +4,7 @@ description: Build step by step a skip service
 slug: reactive_social_network_service_poc
 date: 2025-04-30
 authors: hubyrod
-image: /img/skip.png
+image: /img/og/reactive_social_network_service_poc.png
 ---
 
 Reactive programming often sounds complex—but it doesn't have to be. What if you could actually see how data responds to change, in real time, right from your terminal?

--- a/www/blog/scaling.md
+++ b/www/blog/scaling.md
@@ -4,7 +4,7 @@ description: How to horizontally scale Skip services with Kubernetes
 slug: horizontal-scaling
 date: 2025-06-06
 authors: benno
-image: /img/skip.png
+image: /img/og/horizontal-scaling.png
 ---
 
 Skip makes it fast and easy to build reactive services which efficiently update

--- a/www/blog/skip_alpha.md
+++ b/www/blog/skip_alpha.md
@@ -4,7 +4,7 @@ description: Announce the alpha release of Skip
 slug: skip-alpha
 date: 2024-12-24
 authors: skiplabsteam
-image: /img/skip.png
+image: /img/og/skip-alpha.png
 ---
 
 We’re pleased to share the alpha release of the [Skip Framework](https://github.com/SkipLabs/skip), an open source (MIT license) system for building and running reactive backend services.

--- a/www/blog/skiplabs_funding.md
+++ b/www/blog/skiplabs_funding.md
@@ -4,7 +4,7 @@ description: SkipLabs raises $8M in seed funding
 slug: skiplabs-funding
 date: 2025-03-25
 authors: jverlaguet
-image: /img/skip.png
+image: /img/og/skiplabs-funding.png
 ---
 
 **The News**

--- a/www/blog/skips_origins.md
+++ b/www/blog/skips_origins.md
@@ -4,7 +4,7 @@ description: Describe the origins of the Skip framework and programming language
 slug: skips-origins
 date: 2025-02-11T12:00:00Z
 authors: jverlaguet
-image: /img/skip.png
+image: /img/og/skips-origins.png
 ---
 
 **Coping with success**

--- a/www/blog/why_skip.md
+++ b/www/blog/why_skip.md
@@ -4,6 +4,7 @@ description: Why use the Skip framework?
 slug: why-skip
 date: 2025-02-11T12:00:01Z
 authors: jverlaguet
+image: /img/og/why-skip.png
 ---
 
 **Skip After Meta**

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -110,6 +110,9 @@ const config: Config = {
   } satisfies Preset.ThemeConfig,
 
   plugins: [
+    // Generates a per-post Open Graph card into build/img/og/<slug>.png.
+    // Posts reference it via their `image` front matter.
+    "./plugins/og-image-generator",
     [
       "docusaurus-plugin-typedoc",
       {

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -50,9 +50,18 @@ const config: Config = {
   ],
 
   themeConfig: {
-    // Replace with your project's social card
+    // Default social card, used as a fallback when a page has no `image`.
+    // Blog posts override this with a per-post generated card (see the
+    // og-image-generator plugin) via their `image` front matter.
     image: "img/skip.png",
-    metadata: [{ name: "twitter:card", content: "summary" }],
+    metadata: [
+      // Large image previews on X/Twitter; LinkedIn uses og:image directly.
+      { name: "twitter:card", content: "summary_large_image" },
+      { property: "og:site_name", content: "SkipLabs" },
+      // Site-wide default. Blog posts override this with `og:type=article`
+      // (emitted later in the head by the blog theme, so it wins there).
+      { property: "og:type", content: "website" },
+    ],
     navbar: {
       title: "",
       logo: {

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -42,6 +42,15 @@ const config: Config = {
           // Remove this to remove the "edit this page" links.
           // editUrl: "",
         },
+        blog: {
+          // Used as the schema.org Blog name (isPartOf) and the blog index title.
+          blogTitle: "Skip Blog",
+          // Emit freshness signals: a populated `lastUpdatedAt` drives the
+          // BlogPosting `dateModified` (JSON-LD) and `article:modified_time`.
+          // Defaults to the file's last git commit time; override per post
+          // with a `last_update: { date: YYYY-MM-DD }` front matter field.
+          showLastUpdateTime: true,
+        },
         theme: {
           customCss: "./src/css/custom.css",
         },

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -20,7 +20,9 @@
         "@docusaurus/preset-classic": "^3.10.1",
         "@docusaurus/tsconfig": "^3.10.1",
         "@docusaurus/types": "^3.10.1",
+        "@resvg/resvg-js": "^2.6.2",
         "docusaurus-plugin-typedoc": "^1.1.0",
+        "satori": "^0.26.0",
         "typedoc": "^0.27.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "~5.7.2"
@@ -4985,6 +4987,234 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "license": "MIT"
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "1.27.2",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.27.2.tgz",
@@ -5013,6 +5243,23 @@
       "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -6362,6 +6609,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.31",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
@@ -6684,6 +6941,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-api": {
@@ -7387,6 +7654,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/css-blank-pseudo": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-7.0.1.tgz",
@@ -7425,6 +7699,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
@@ -7435,6 +7726,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/css-has-pseudo": {
@@ -7614,6 +7915,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -8206,6 +8519,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/emojilib": {
       "version": "2.4.0",
@@ -8817,6 +9140,13 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-loader": {
       "version": "6.2.0",
@@ -9595,6 +9925,19 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/history": {
@@ -10609,6 +10952,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -13644,6 +13998,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -13664,6 +14025,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
       }
     },
     "node_modules/parse-entities": {
@@ -16376,6 +16748,29 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -17087,6 +17482,13 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -17396,6 +17798,13 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -17698,6 +18107,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unified": {
@@ -18736,6 +19156,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/www/package.json
+++ b/www/package.json
@@ -27,7 +27,9 @@
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/tsconfig": "^3.10.1",
     "@docusaurus/types": "^3.10.1",
+    "@resvg/resvg-js": "^2.6.2",
     "docusaurus-plugin-typedoc": "^1.1.0",
+    "satori": "^0.26.0",
     "typedoc": "^0.27.0",
     "typedoc-plugin-markdown": "^4.3.0",
     "typescript": "~5.7.2"

--- a/www/plugins/og-image-generator/index.js
+++ b/www/plugins/og-image-generator/index.js
@@ -1,0 +1,197 @@
+// Build-time Open Graph card generator.
+//
+// Generates a unique 1200x630 social card per blog post (Skip branding + post
+// title + author) into <outDir>/img/og/<slug>.png during postBuild. Each post
+// points its `image` front matter at /img/og/<slug>.png, so the generated card
+// becomes the og:image / twitter:image and the JSON-LD image for that post.
+//
+// satori (HTML/CSS -> SVG) and @resvg/resvg-js (SVG -> PNG) are build-only
+// dependencies; nothing here ships to the browser.
+
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+const yaml = require("js-yaml");
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+const BRAND_RED = "#d62f0d";
+const BG = "#0f1115";
+const TITLE_COLOR = "#ffffff";
+const MUTED_COLOR = "#9aa0a6";
+
+function loadAuthors(blogDir) {
+  const authorsPath = path.join(blogDir, "authors.yml");
+  try {
+    return yaml.load(fs.readFileSync(authorsPath, "utf8")) || {};
+  } catch {
+    return {};
+  }
+}
+
+// Resolve the `authors` front matter (a key, list of keys, or inline object)
+// into a display string, using authors.yml for keyed authors.
+function resolveAuthorName(authors, authorsMap) {
+  const one = (a) => {
+    if (!a) return undefined;
+    if (typeof a === "string") return authorsMap[a]?.name ?? a;
+    if (typeof a === "object") return a.name ?? authorsMap[a.key]?.name;
+    return undefined;
+  };
+  const list = Array.isArray(authors) ? authors : [authors];
+  const names = list.map(one).filter(Boolean);
+  return names.join(", ");
+}
+
+// satori accepts a React-element-like tree; build it with plain objects so the
+// plugin needs no JSX transform.
+function el(type, style, children) {
+  return {
+    type,
+    props: { style, ...(children !== undefined ? { children } : {}) },
+  };
+}
+
+function card({ title, author }) {
+  return el(
+    "div",
+    {
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      width: "100%",
+      height: "100%",
+      backgroundColor: BG,
+      padding: 72,
+      fontFamily: "Quicksand",
+    },
+    [
+      // Brand header
+      el("div", { display: "flex", alignItems: "center" }, [
+        el("div", {
+          width: 32,
+          height: 32,
+          backgroundColor: BRAND_RED,
+          borderRadius: 8,
+          marginRight: 20,
+        }),
+        el(
+          "div",
+          {
+            display: "flex",
+            fontFamily: "Space Mono",
+            fontSize: 28,
+            letterSpacing: 4,
+            color: BRAND_RED,
+          },
+          "SKIPLABS BLOG",
+        ),
+      ]),
+      // Title
+      el(
+        "div",
+        {
+          display: "flex",
+          fontWeight: 700,
+          fontSize: 64,
+          lineHeight: 1.12,
+          color: TITLE_COLOR,
+        },
+        title,
+      ),
+      // Footer / author
+      el(
+        "div",
+        {
+          display: "flex",
+          fontWeight: 500,
+          fontSize: 30,
+          color: MUTED_COLOR,
+        },
+        author ? `By ${author}` : "skiplabs.io",
+      ),
+    ],
+  );
+}
+
+module.exports = function ogImageGenerator(context) {
+  const { siteDir } = context;
+  const blogDir = path.join(siteDir, "blog");
+  const fontsDir = path.join(siteDir, "static", "fonts");
+
+  return {
+    name: "og-image-generator",
+
+    async postBuild({ outDir }) {
+      const satori = (await import("satori")).default;
+      const { Resvg } = require("@resvg/resvg-js");
+
+      const fonts = [
+        {
+          name: "Quicksand",
+          data: fs.readFileSync(path.join(fontsDir, "Quicksand-Bold.ttf")),
+          weight: 700,
+          style: "normal",
+        },
+        {
+          name: "Quicksand",
+          data: fs.readFileSync(path.join(fontsDir, "Quicksand-Medium.ttf")),
+          weight: 500,
+          style: "normal",
+        },
+        {
+          name: "Space Mono",
+          data: fs.readFileSync(path.join(fontsDir, "SpaceMono-Regular.ttf")),
+          weight: 400,
+          style: "normal",
+        },
+      ];
+
+      const authorsMap = loadAuthors(blogDir);
+      const ogDir = path.join(outDir, "img", "og");
+      fs.mkdirSync(ogDir, { recursive: true });
+
+      const files = fs
+        .readdirSync(blogDir)
+        .filter((f) => f.endsWith(".md") || f.endsWith(".mdx"));
+
+      let generated = 0;
+      const skipped = [];
+
+      for (const file of files) {
+        try {
+          const { data } = matter(
+            fs.readFileSync(path.join(blogDir, file), "utf8"),
+          );
+          if (data.draft || !data.title) {
+            skipped.push(file);
+            continue;
+          }
+          const slug = data.slug || file.replace(/\.mdx?$/, "");
+          const author = resolveAuthorName(data.authors, authorsMap);
+
+          const svg = await satori(card({ title: data.title, author }), {
+            width: WIDTH,
+            height: HEIGHT,
+            fonts,
+          });
+          const png = new Resvg(svg, {
+            fitTo: { mode: "width", value: WIDTH },
+          })
+            .render()
+            .asPng();
+          fs.writeFileSync(path.join(ogDir, `${slug}.png`), png);
+          generated += 1;
+        } catch (err) {
+          skipped.push(`${file} (${err.message})`);
+        }
+      }
+
+      console.log(
+        `[og-image-generator] generated ${generated} card(s) in img/og/` +
+          (skipped.length ? `; skipped: ${skipped.join(", ")}` : ""),
+      );
+    },
+  };
+};

--- a/www/src/components/blog/SeriesNav.tsx
+++ b/www/src/components/blog/SeriesNav.tsx
@@ -1,0 +1,40 @@
+import React, { type ReactNode } from "react";
+import Link from "@docusaurus/Link";
+import type { Series } from "./series";
+import styles from "./callouts.module.css";
+
+/**
+ * Renders a "Part of a series" block listing every post in the series in
+ * reading order, with the current post highlighted. Links use the post titles
+ * as anchor text so the cluster is legible to crawlers and readers.
+ */
+export default function SeriesNav({
+  series,
+  currentSlug,
+}: {
+  series: Series;
+  currentSlug?: string;
+}): ReactNode {
+  return (
+    <nav className={styles.series} aria-label={`Series: ${series.title}`}>
+      <p className={styles.seriesLabel}>Part of a series on {series.title}</p>
+      <ol className={styles.seriesList}>
+        {series.posts.map((post) => {
+          const isCurrent = post.slug === currentSlug;
+          return (
+            <li
+              key={post.slug}
+              className={isCurrent ? styles.current : undefined}
+            >
+              {isCurrent ? (
+                <span aria-current="true">{post.title}</span>
+              ) : (
+                <Link to={`/blog/${post.slug}`}>{post.title}</Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/www/src/components/blog/Tldr.tsx
+++ b/www/src/components/blog/Tldr.tsx
@@ -1,0 +1,16 @@
+import React, { type ReactNode } from "react";
+import styles from "./callouts.module.css";
+
+/**
+ * A short, self-contained thesis rendered at the top of a post, sourced from
+ * the optional `tldr` front matter field. Gives readers (and LLMs) one or two
+ * quotable sentences stating the post's core claim.
+ */
+export default function Tldr({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <aside className={styles.tldr} aria-label="Summary">
+      <p className={styles.tldrLabel}>TL;DR</p>
+      <p className={styles.tldrBody}>{children}</p>
+    </aside>
+  );
+}

--- a/www/src/components/blog/callouts.module.css
+++ b/www/src/components/blog/callouts.module.css
@@ -1,0 +1,59 @@
+/* Shared styling for the blog TL;DR and series-navigation callouts that the
+   swizzled BlogPostItem/Content renders at the top of a post. */
+
+.tldr {
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.25rem;
+  border-left: 4px solid var(--ifm-color-primary);
+  border-radius: 6px;
+  background: var(
+    --ifm-color-primary-contrast-background,
+    rgba(214, 47, 13, 0.06)
+  );
+}
+
+.tldrLabel {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+.tldrBody {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.series {
+  margin: 0 0 1.75rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  background: var(--ifm-background-surface-color);
+}
+
+.seriesLabel {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.seriesList {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.seriesList li {
+  margin: 0.15rem 0;
+}
+
+.current {
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}

--- a/www/src/components/blog/series.ts
+++ b/www/src/components/blog/series.ts
@@ -1,0 +1,57 @@
+// Blog series definitions. Membership is keyed on a post's `slug`, so adding a
+// post to a series needs no per-post front matter — just list it here, in
+// reading order. The series block is rendered automatically on each member
+// post by the swizzled BlogPostItem/Content component.
+
+export interface SeriesPost {
+  /** The post's `slug` front matter value (the /blog/<slug> path segment). */
+  slug: string;
+  /** Exact post title, used as the link's anchor text. */
+  title: string;
+}
+
+export interface Series {
+  id: string;
+  /**
+   * Human-facing label for the series, rendered as
+   * "Part of a series on {title}". Provisional wording — adjust freely.
+   */
+  title: string;
+  posts: SeriesPost[];
+}
+
+export const BLOG_SERIES: Series[] = [
+  {
+    id: "verified-codegen",
+    title: "verified AI code generation",
+    posts: [
+      {
+        slug: "codegen_as_compiler",
+        title: "Treat Agent Output Like Compiler Output",
+      },
+      {
+        slug: "future_of_tools_for_ai",
+        title: "Code Was Never for Machines — Until Now",
+      },
+      {
+        slug: "notes_from_the_comments",
+        title: "The apparatus, not the artifact",
+      },
+      {
+        slug: "closed_loop_coding_agent",
+        title: "What a Closed-Loop Coding Agent Actually Is",
+      },
+    ],
+  },
+];
+
+export function findSeriesForSlug(
+  slug: string | undefined,
+): Series | undefined {
+  if (!slug) {
+    return undefined;
+  }
+  return BLOG_SERIES.find((series) =>
+    series.posts.some((post) => post.slug === slug),
+  );
+}

--- a/www/src/theme/BlogPostItem/Content/index.tsx
+++ b/www/src/theme/BlogPostItem/Content/index.tsx
@@ -1,0 +1,33 @@
+import React, { type ReactNode } from "react";
+import Content from "@theme-original/BlogPostItem/Content";
+import type ContentType from "@theme/BlogPostItem/Content";
+import type { WrapperProps } from "@docusaurus/types";
+import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
+import Tldr from "@site/src/components/blog/Tldr";
+import SeriesNav from "@site/src/components/blog/SeriesNav";
+import { findSeriesForSlug } from "@site/src/components/blog/series";
+
+type Props = WrapperProps<typeof ContentType>;
+
+/**
+ * Wraps the blog post body to render, at the top of the full post page only,
+ * an optional TL;DR callout (from the `tldr` front matter) and a series
+ * navigation block (when the post belongs to a defined series). Both are
+ * skipped on the blog list page, where Content renders truncated excerpts.
+ */
+export default function ContentWrapper(props: Props): ReactNode {
+  const { frontMatter, isBlogPostPage } = useBlogPost();
+  const slug = frontMatter.slug as string | undefined;
+  const tldr = frontMatter.tldr as string | undefined;
+  const series = findSeriesForSlug(slug);
+
+  return (
+    <>
+      {isBlogPostPage && tldr && <Tldr>{tldr}</Tldr>}
+      {isBlogPostPage && series && (
+        <SeriesNav series={series} currentSlug={slug} />
+      )}
+      <Content {...props} />
+    </>
+  );
+}

--- a/www/src/theme/BlogPostItem/Content/index.tsx
+++ b/www/src/theme/BlogPostItem/Content/index.tsx
@@ -17,8 +17,11 @@ type Props = WrapperProps<typeof ContentType>;
  */
 export default function ContentWrapper(props: Props): ReactNode {
   const { frontMatter, isBlogPostPage } = useBlogPost();
-  const slug = frontMatter.slug as string | undefined;
-  const tldr = frontMatter.tldr as string | undefined;
+  // `tldr` is a custom front matter field (Docusaurus preserves unknown keys).
+  const { slug, tldr } = frontMatter as typeof frontMatter & {
+    slug?: string;
+    tldr?: string;
+  };
   const series = findSeriesForSlug(slug);
 
   return (

--- a/www/src/theme/BlogPostPage/StructuredData/index.tsx
+++ b/www/src/theme/BlogPostPage/StructuredData/index.tsx
@@ -39,7 +39,7 @@ function withSameAs(author: Author): Author {
 
 export default function BlogPostStructuredData(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
-  const data = useBlogPostStructuredData() as StructuredData;
+  const data = useBlogPostStructuredData() as unknown as StructuredData;
 
   const siteUrl = siteConfig.url.replace(/\/$/, "");
 

--- a/www/src/theme/BlogPostPage/StructuredData/index.tsx
+++ b/www/src/theme/BlogPostPage/StructuredData/index.tsx
@@ -1,0 +1,78 @@
+import React, { type ReactNode } from "react";
+import Head from "@docusaurus/Head";
+import { useBlogPostStructuredData } from "@docusaurus/plugin-content-blog/client";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+/**
+ * Overrides the default blog post structured data so that, on top of the
+ * BlogPosting JSON-LD Docusaurus already emits, we add:
+ *
+ *  - a `publisher` Organization (with logo) — required by Google's Article
+ *    rich-result spec and not emitted by Docusaurus by default;
+ *  - `sameAs` on each author, mirroring the author `url` (schema.org's
+ *    preferred property for linking to a person's canonical profile);
+ *  - an `article:modified_time` meta tag whenever a `dateModified` is known
+ *    (populated from `lastUpdatedAt`, i.e. git or `last_update` front matter).
+ *
+ * Everything else is reused verbatim from the native structured data, so this
+ * stays in sync with Docusaurus across upgrades.
+ */
+
+type Author = {
+  url?: string;
+  sameAs?: string | string[];
+  [key: string]: unknown;
+};
+
+type StructuredData = {
+  author?: Author | Author[];
+  dateModified?: string;
+  [key: string]: unknown;
+};
+
+function withSameAs(author: Author): Author {
+  if (author?.url && !author.sameAs) {
+    return { ...author, sameAs: [author.url] };
+  }
+  return author;
+}
+
+export default function BlogPostStructuredData(): ReactNode {
+  const { siteConfig } = useDocusaurusContext();
+  const data = useBlogPostStructuredData() as StructuredData;
+
+  const siteUrl = siteConfig.url.replace(/\/$/, "");
+
+  const publisher = {
+    "@type": "Organization",
+    name: "SkipLabs",
+    url: siteUrl,
+    logo: {
+      "@type": "ImageObject",
+      url: `${siteUrl}/img/skip.png`,
+    },
+  };
+
+  const author = Array.isArray(data.author)
+    ? data.author.map(withSameAs)
+    : data.author
+      ? withSameAs(data.author)
+      : undefined;
+
+  const structuredData = {
+    ...data,
+    ...(author ? { author } : {}),
+    publisher,
+  };
+
+  return (
+    <Head>
+      {data.dateModified && (
+        <meta property="article:modified_time" content={data.dateModified} />
+      )}
+      <script type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </script>
+    </Head>
+  );
+}

--- a/www/static/llms.txt
+++ b/www/static/llms.txt
@@ -1,0 +1,45 @@
+# Skip
+
+> Skip is an open-source framework for building reactive backend services. You define a declarative computation graph over your data, and the Skip runtime keeps the outputs continuously and correctly up to date — delivering from-scratch-consistent results in real time without manual cache invalidation or hand-written change-propagation code. Skip is developed by SkipLabs, which also builds Skipper, a closed-loop AI coding agent, and SKJS, a fully sound TypeScript-compatible type checker.
+
+Key terms, as Skip/SkipLabs use them:
+
+- **Reactive service**: a service that exposes *resources* — data and computation outputs queryable over HTTP or subscribable for real-time updates — which the runtime updates automatically as inputs change.
+- **Collections and mappers**: the vertices and edges of the Skip reactive computation graph. Mappers are deterministic and side-effect free, so the runtime can re-execute them to keep results correct.
+- **From-scratch consistency**: a reactive result guaranteed to be identical to recomputing the equivalent non-reactive computation from scratch on the current input.
+- **Skipper**: SkipLabs' closed-loop coding agent. "Closed-loop" is used in its control-theory sense: the loop is closed on feedback signals trustworthy enough to act on (a sound type checker, deterministic execution, reactive computation), not on lossy proxies like test output or model self-judgment.
+- **SKJS**: a TypeScript-compatible type checker that is *sound* — it lacks the unsound escape hatches that make standard TypeScript ergonomic for humans but unreliable as a verification layer.
+
+## Documentation
+
+- [Introduction](https://skiplabs.io/docs/introduction): What Skip is and its core concepts — reactive resources, collections, and mappers.
+- [Getting started](https://skiplabs.io/docs/getting_started): Build and run your first Skip service.
+- [Functions](https://skiplabs.io/docs/functions): Writing reactive computations with mappers and reducers.
+- [Resources](https://skiplabs.io/docs/resources): Exposing reactive resources to clients.
+- [External services](https://skiplabs.io/docs/externals): Integrating Postgres, Kafka, and other external data.
+- [Glossary](https://skiplabs.io/docs/glossary): Definitions of Skip terminology.
+- [API reference](https://skiplabs.io/docs/api/core/): TypeScript API for @skipruntime/core, server, helpers, and adapters.
+
+## Blog: verified AI code generation (series)
+
+A four-part argument that AI-generated code should be trusted the way compiler output is trusted — through a verification apparatus, not human review — and what that requires.
+
+- [Treat Agent Output Like Compiler Output](https://skiplabs.io/blog/codegen_as_compiler): Why our discomfort with AI-generated code reveals exactly what we haven't built yet, and what the compiler analogy teaches us about trusting coding agents.
+- [Code Was Never for Machines — Until Now](https://skiplabs.io/blog/future_of_tools_for_ai): We spent decades making languages readable. Agents don't care. Why we'll resist this shift — and why we'll embrace it anyway.
+- [The apparatus, not the artifact](https://skiplabs.io/blog/notes_from_the_comments): A follow-up addressing the responses — why determinism isn't the point, and what static analysis actually buys you.
+- [What a Closed-Loop Coding Agent Actually Is](https://skiplabs.io/blog/closed_loop_coding_agent): Closed-loop control requires a feedback signal trustworthy enough to act on. Most AI coding agents close their loops on lossy sensors and inherit the instability that follows.
+
+## Blog: the Skip framework
+
+- [Why Skip?](https://skiplabs.io/blog/why-skip): Why use the Skip framework.
+- [Skip's Origins](https://skiplabs.io/blog/skips-origins): The origins of the Skip framework and programming language.
+- [Backend Pressure from a Reactive Point of View](https://skiplabs.io/blog/backend_pressure): How reactive systems address backend pressure through persistent computational structures.
+- [Cache Invalidation and Reactive Systems](https://skiplabs.io/blog/cache_invalidation): Cache invalidation challenges in distributed systems and Skip's reactive alternative.
+- [Event-Hidden Architectures](https://skiplabs.io/blog/event-hidden-arch): Interactive features without events.
+- [Dynamically scaling your Skip services](https://skiplabs.io/blog/horizontal-scaling): Horizontally scaling Skip services with Kubernetes.
+- [SkipLabs Funding](https://skiplabs.io/blog/skiplabs-funding): SkipLabs raises $8M in seed funding.
+
+## About
+
+- [SkipLabs](https://skiplabs.io): Company site.
+- [GitHub](https://github.com/SkipLabs/skip): Source for the Skip framework and runtime.

--- a/www/static/robots.txt
+++ b/www/static/robots.txt
@@ -1,0 +1,10 @@
+# https://skiplabs.io robots.txt
+#
+# AI/LLM crawlers are intentionally allowed: being read and cited by
+# generative engines (ChatGPT, Claude, Perplexity, Gemini, etc.) is a goal.
+# Do not add Disallow rules for AI user-agents here.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://skiplabs.io/sitemap.xml


### PR DESCRIPTION
Technical SEO and GEO (generative-engine optimization) improvements for the Skip blog. **Structure, schema, and metadata only — no post prose was edited.**

## Context / deviations from the original brief
- The site is on **Docusaurus 3.10.1**, not 3.7. Notably, 3.10 **already emits `BlogPosting` JSON-LD natively**, and `og:type=article` + per-page `og:url` were already correct — so this PR *augments* rather than rebuilds.
- `node_modules` was stale at 3.7.0 vs the committed 3.10.1 lockfile, so `npm run build` was broken before this branch; `npm install` (no lockfile change) fixes it.
- Sitemap was already enabled (classic preset, 86 URLs). No post had an empty/`"Blog"` description.

## Changes (one logical change per commit)
1. **Social cards** — `twitter:card` → `summary_large_image`; add `og:site_name` and default `og:type=website` (posts still emit `article`).
2. **Crawler files** — `static/robots.txt` (allow-all, AI crawlers unblocked, points to sitemap) + curated `static/llms.txt`.
3. **Freshness** — enable `showLastUpdateTime` (drives `dateModified`); set `blogTitle`.
4. **JSON-LD** — override `BlogPostPage/StructuredData` to add `publisher` (Organization + logo, required by Google) and author `sameAs`; emit `article:modified_time`. Reuses native data so it survives upgrades.
5. **Series + TL;DR** — swizzle `BlogPostItem/Content` for a slug-driven "Part of a series" block (4-post verified-codegen cluster, descriptive anchors) and an optional `tldr` callout. No prose edited.
6. **OG card generator** — local plugin (`satori` + `@resvg/resvg-js`, build-only deps) renders a branded 1200×630 card per post into `build/img/og/<slug>.png`; all 18 posts' `image` frontmatter point at their card.

## Verification
`npm run build` and `tsc` both pass. Verified per-post `og:image`/`twitter:image`/JSON-LD image, augmented JSON-LD (`publisher`/`sameAs`/`dateModified`), series block presence (4 posts only, not on list view), and the 18 generated cards (long-title wrapping + author resolution).

## Needs author input (intentionally not guessed)
- **5 thin descriptions** to rewrite: `why_skip`, `skips_origins`, `skip_alpha`, `event_hidden_arch`, `reactive_social_skip_service_poc`.
- **4 TL;DRs** to write (mechanism is live; candidate verbatim lifts provided in review notes).
- **Terms:** "closed-loop" is defined ✓; "the compiler contract" is **not** actually defined in the posts — define or drop.
- **Decisions:** series label wording ("verified AI code generation"); `llms.txt` framing; whether git-based `dateModified` (shows merge date; no visible "Last updated" text) is acceptable; optional `twitter:site` handle.

Notes: OG cards are build artifacts (regenerated each build, not committed). Filename `codegen_as_complier.md` has a typo but its slug is correct, so left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)