### PR TITLE
Add @skiplabs/{tsconfig,eslint-config}, @skiplang/*, @skip-wasm/* to publish-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,39 @@ skbuild-%:
 build-all:
 	npm run build --workspaces --if-present
 
+.PHONY: publish-tsconfig
+publish-tsconfig: build-all
+	bin/release_npm.sh @skiplabs/tsconfig tsconfig/package.json $(OTP)
+
+.PHONY: publish-eslint-config
+publish-eslint-config: build-all
+	bin/release_npm.sh @skiplabs/eslint-config eslint-config/package.json $(OTP)
+
+.PHONY: publish-skiplang-std
+publish-skiplang-std: build-all
+	bin/release_npm.sh @skiplang/std skiplang/prelude/ts/binding/package.json $(OTP)
+
+.PHONY: publish-skiplang-json
+publish-skiplang-json: build-all
+	bin/release_npm.sh @skiplang/json skiplang/skjson/ts/binding/package.json $(OTP)
+
+.PHONY: publish-skip-wasm-std
+publish-skip-wasm-std: build-all
+	bin/release_npm.sh @skip-wasm/std skiplang/prelude/ts/wasm/package.json $(OTP)
+
+.PHONY: publish-skip-wasm-worker
+publish-skip-wasm-worker: build-all
+	bin/release_npm.sh @skip-wasm/worker skiplang/prelude/ts/worker/package.json $(OTP)
+
+.PHONY: publish-skip-wasm-json
+publish-skip-wasm-json: build-all
+	bin/release_npm.sh @skip-wasm/json skiplang/skjson/ts/wasm/package.json $(OTP)
+
+# @skip-wasm/date depends on @skip-wasm/std, so publish std first.
+.PHONY: publish-skip-wasm-date
+publish-skip-wasm-date: build-all publish-skip-wasm-std
+	bin/release_npm.sh @skip-wasm/date skiplang/skdate/ts/package.json $(OTP)
+
 .PHONY: publish-core
 publish-core: build-all
 	bin/release_npm.sh @skipruntime/core skipruntime-ts/core/package.json $(OTP)
@@ -304,4 +337,20 @@ publish-metapackage: build-all
 	bin/release_npm.sh @skiplabs/skip skipruntime-ts/metapackage/package.json $(OTP)
 
 .PHONY: publish-all
-publish-all: clean publish-core publish-helpers publish-wasm publish-native publish-server publish-postgres-adapter publish-kafka-adapter publish-metapackage
+publish-all: clean \
+	publish-tsconfig \
+	publish-eslint-config \
+	publish-skiplang-std \
+	publish-skiplang-json \
+	publish-skip-wasm-std \
+	publish-skip-wasm-worker \
+	publish-skip-wasm-json \
+	publish-skip-wasm-date \
+	publish-core \
+	publish-helpers \
+	publish-wasm \
+	publish-native \
+	publish-server \
+	publish-postgres-adapter \
+	publish-kafka-adapter \
+	publish-metapackage


### PR DESCRIPTION
## Summary
The Makefile's `publish-*` targets and the `publish-all` umbrella only covered the `@skipruntime/*` family + `@skiplabs/skip` metapackage. The other published packages — `@skiplabs/{tsconfig,eslint-config}`, `@skiplang/{std,json}`, `@skip-wasm/{std,worker,date,json}` — had no Makefile targets and had to be released by hand (`cd <pkg> && npm publish ...`), which is easy to forget after a uniform version bump like #1229.

Adds one `publish-*` target per package and chains them into `publish-all` in dependency-respecting order: configs and base langs first, then the `@skip-wasm/*` packages (with `@skip-wasm/date` declaring `publish-skip-wasm-std` as a prereq to honor its internal dep), then the existing `@skipruntime/*` chain unchanged.

`release_npm.sh`'s idempotent skip-if-already-published check makes re-running `publish-all` safe — packages already on the registry at the right version are no-ops.

## Resulting publish-all order
```
publish-tsconfig
publish-eslint-config
publish-skiplang-std
publish-skiplang-json
publish-skip-wasm-std
publish-skip-wasm-worker
publish-skip-wasm-json
publish-skip-wasm-date          # depends on publish-skip-wasm-std
publish-core
publish-helpers
publish-wasm
publish-native
publish-server
publish-postgres-adapter
publish-kafka-adapter
publish-metapackage
```

## Out of scope
`skdb`, `skdb-dev`, `skdb-react` have their own bespoke release scripts ([bin/release_npm_skdb*.sh](bin/release_npm_skdb.sh)) with interactive OTP prompts and different build dependencies, so they're not folded into `publish-all` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)