### PR TITLE
Add Makefile targets for skdb / skdb-dev / skdb-react publishes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,3 +354,24 @@ publish-all: clean \
 	publish-postgres-adapter \
 	publish-kafka-adapter \
 	publish-metapackage
+
+# skdb packages use bespoke release scripts (not bin/release_npm.sh) with
+# different semantics: they ERROR if the version hasn't been bumped (vs.
+# release_npm.sh's silent skip-if-already-published), prompt interactively
+# for OTP, and skdb-{dev,react} validate that their published skdb dep
+# matches the latest published skdb. Run in order; skdb must publish first.
+
+.PHONY: publish-skdb
+publish-skdb:
+	bin/release_npm_skdb.sh
+
+.PHONY: publish-skdb-dev
+publish-skdb-dev: publish-skdb
+	bin/release_npm_skdb_dev.sh
+
+.PHONY: publish-skdb-react
+publish-skdb-react: publish-skdb
+	bin/release_npm_skdb_react.sh
+
+.PHONY: publish-all-skdb
+publish-all-skdb: publish-skdb publish-skdb-dev publish-skdb-react


### PR DESCRIPTION
## Summary
The three skdb packages have bespoke release scripts under [bin/](bin/) ([release_npm_skdb.sh](bin/release_npm_skdb.sh), [release_npm_skdb_dev.sh](bin/release_npm_skdb_dev.sh), [release_npm_skdb_react.sh](bin/release_npm_skdb_react.sh)) but no Makefile wrappers, so they had to be invoked by hand.

Adds:
- `publish-skdb` — wraps `bin/release_npm_skdb.sh`
- `publish-skdb-dev` — wraps `bin/release_npm_skdb_dev.sh`, declares `publish-skdb` as a prereq
- `publish-skdb-react` — wraps `bin/release_npm_skdb_react.sh`, declares `publish-skdb` as a prereq
- `publish-all-skdb` umbrella

Order is enforced via Make dependencies: skdb-dev and skdb-react both depend on skdb, so even a standalone `make publish-skdb-react` will publish skdb first if needed. This matches the cross-version check in `release_npm_skdb_{dev,react}.sh` which errors out if the published skdb version doesn't match their declared dep.

## Why these aren't folded into `publish-all`
The underlying scripts have semantics that don't match the rest of the publish-* family:
- They **error** if the version hasn't been bumped (vs. `release_npm.sh`'s silent skip-if-already-published).
- `release_npm_skdb.sh` prompts **interactively** for OTP — no env-var support.
- skdb has its own release rhythm separate from the @skipruntime/* family.

Harmonizing the scripts to match `release_npm.sh` would be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)