### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/skipruntime-ts/adapters/postgres/src/index.ts
+++ b/skipruntime-ts/adapters/postgres/src/index.ts
@@ -67,8 +67,9 @@ export class PostgresExternalService implements ExternalService {
         ].forEach((sig) => process.on(sig, handler));
       },
       (e: unknown) => {
+        const safeDbConfig = { ...db_config, password: "[REDACTED]" };
         console.error(
-          `Error connecting to Postgres at ${JSON.stringify(db_config)}:`,
+          `Error connecting to Postgres at ${JSON.stringify(safeDbConfig)}:`,
         );
         console.error(e);
       },


### PR DESCRIPTION
Potential fix for [https://github.com/SkipLabs/skip/security/code-scanning/13](https://github.com/SkipLabs/skip/security/code-scanning/13)

The best fix is to keep useful diagnostics while redacting secrets before logging. Specifically, in `skipruntime-ts/adapters/postgres/src/index.ts` within the `constructor` error handler (around lines 69–73), replace logging of `JSON.stringify(db_config)` with a sanitized object that masks the password.

Implement by creating a local `safeDbConfig` object in the error callback and setting `password: "[REDACTED]"`, then logging `JSON.stringify(safeDbConfig)`. This preserves existing behavior (still logs host/port/database/user context and error object) without exposing sensitive data. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
