### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/sql/ts/vitejs/server.js
+++ b/sql/ts/vitejs/server.js
@@ -35,9 +35,10 @@ const post = (response, file, errorFile, contentType) => {
 const port = 5154;
 
 const distPath = "./dist";
+const distRoot = path.resolve(distPath);
 
 const requestHandler = (request, response) => {
-  const error = path.join(distPath, "404.html");
+  const error = path.join(distRoot, "404.html");
   if (request.url == "/api/succeed") {
     let message = chalk.green("[OK]") + " Bundled SKDB successfully started.";
     response.setHeader("Content-Type", "text/plain");
@@ -60,12 +61,20 @@ const requestHandler = (request, response) => {
     // @ts-ignore
     process.exit();
   } else {
-    let page;
-    if (request.url?.endsWith("/")) {
-      page = path.join(distPath + request.url, "index.html");
-    } else {
-      page = distPath + request.url;
+    const rawPath = request.url ? request.url.split("?")[0] : "/";
+    const decodedPath = decodeURIComponent(rawPath);
+    let page = path.resolve(distRoot, "." + decodedPath);
+    if (decodedPath.endsWith("/")) {
+      page = path.join(page, "index.html");
     }
+
+    const rel = path.relative(distRoot, page);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      response.writeHead(403);
+      response.end("Forbidden\n\n");
+      return;
+    }
+
     post(response, page, error, mime.lookup(page));
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/SkipLabs/skip/security/code-scanning/5](https://github.com/SkipLabs/skip/security/code-scanning/5)

Use a safe-root strategy: resolve all requested paths against a canonical `dist` root, normalize them, and reject anything escaping that root before calling `fs.readFile`.

Best fix in this file:
1. Define a canonical root once (for `./dist`) using `path.resolve`.
2. Parse and decode only the URL pathname (ignore query string).
3. Build a candidate path using `path.resolve(root, "." + pathname)` and append `index.html` for trailing-slash routes.
4. Enforce containment with `path.relative(root, candidate)`; reject if it starts with `..` or is absolute.
5. Use the validated absolute path in `post(...)`.
6. Keep 404 page under the same canonical root.

This preserves current behavior (serving from `dist`, handling `/.../` with `index.html`) while blocking traversal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
