### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through a stack trace

### DIFF
--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -95,7 +95,7 @@ export function registerControlServiceRoutes(
           res.sendStatus(404);
         } else {
           console.error(e);
-          res.status(500).json(e instanceof Error ? e.message : e);
+          res.status(500).json("Internal server error");
         }
       });
   });


### PR DESCRIPTION
Potential fix for [https://github.com/SkipLabs/skip/security/code-scanning/18](https://github.com/SkipLabs/skip/security/code-scanning/18)

To fix this without changing endpoint behavior, keep server-side logging of the full error, but stop returning raw exception details in 500 responses.

Best change in `skipruntime-ts/server/src/rest.ts`:
- In the `/v1/inputs/:collection` catch block (the CodeQL-highlighted location), replace:
  - `res.status(500).json(e instanceof Error ? e.message : e);`
- With:
  - `res.status(500).json("Internal server error");`

This preserves status code and JSON response type, while removing sensitive detail exposure. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
