### PR TITLE
Potential fix for code scanning alert no. 16: Information exposure through a stack trace

### DIFF
--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -25,7 +25,7 @@ export function registerControlServiceRoutes(
       })
       .catch((e: unknown) => {
         console.log(e);
-        res.status(500).json(e instanceof Error ? e.message : e);
+        res.status(500).json({ error: "Internal server error" });
       });
   });
 
@@ -35,7 +35,7 @@ export function registerControlServiceRoutes(
       res.sendStatus(200);
     } catch (e: unknown) {
       console.log(e);
-      res.status(500).json(e instanceof Error ? e.message : e);
+      res.status(500).json({ error: "Internal server error" });
     }
   });
 
@@ -48,11 +48,12 @@ export function registerControlServiceRoutes(
           res.status(200).json(data);
         })
         .catch((err: unknown) => {
-          res.status(500).json(err instanceof Error ? err.message : err);
+          console.log(err);
+          res.status(500).json({ error: "Internal server error" });
         });
     } catch (e: unknown) {
       console.log(e);
-      res.status(500).json(e instanceof Error ? e.message : e);
+      res.status(500).json({ error: "Internal server error" });
     }
   });
 
@@ -72,11 +73,12 @@ export function registerControlServiceRoutes(
           res.status(200).json(data);
         })
         .catch((err: unknown) => {
-          res.status(500).json(err instanceof Error ? err.message : err);
+          console.log(err);
+          res.status(500).json({ error: "Internal server error" });
         });
     } catch (e: unknown) {
       console.log(e);
-      res.status(500).json(e instanceof Error ? e.message : e);
+      res.status(500).json({ error: "Internal server error" });
     }
   });
 
@@ -95,7 +97,7 @@ export function registerControlServiceRoutes(
           res.sendStatus(404);
         } else {
           console.error(e);
-          res.status(500).json("Internal server error");
+          res.status(500).json({ error: "Internal server error" });
         }
       });
   });


### PR DESCRIPTION
Potential fix for [https://github.com/SkipLabs/skip/security/code-scanning/16](https://github.com/SkipLabs/skip/security/code-scanning/16)

The best fix is to stop returning exception content (`e`, `e.message`, or other thrown values) in HTTP responses, and instead return a generic message for 500 errors while logging full details on the server.

In `skipruntime-ts/server/src/rest.ts`, replace the flagged response at line 79 (and the corresponding similar catch responses shown in the snippet) with a constant generic payload such as `{ error: "Internal server error" }`. Keep existing status codes and behavior otherwise unchanged. Logging (`console.log` / `console.error`) can remain to preserve debuggability, though `console.error` is preferable for errors.

No new imports, helper methods, or dependencies are required for this fix in the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
