### PR TITLE
ci: gen2 migration and resource-class right-sizing

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -51,7 +51,7 @@ jobs:
   check-ts:
     docker:
       - image: skiplabs/skip:latest
-    resource_class: large
+    resource_class: medium.gen2
     steps:
       - custom-checkout:
           submodules: true
@@ -77,7 +77,7 @@ jobs:
   compiler:
     docker:
       - image: skiplabs/skiplang:latest
-    resource_class: xlarge
+    resource_class: xlarge.gen2
     steps:
       - custom-checkout:
           submodules: true
@@ -94,7 +94,7 @@ jobs:
   skdb:
     docker:
       - image: skiplabs/skdb-base:latest
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - custom-checkout:
           submodules: true
@@ -106,7 +106,7 @@ jobs:
   skdb-wasm:
     docker:
       - image: skiplabs/skdb-base:latest
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - custom-checkout:
           submodules: true
@@ -174,7 +174,7 @@ jobs:
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-    resource_class: xlarge
+    resource_class: large.gen2
     steps:
       - custom-checkout:
           submodules: true
@@ -197,7 +197,7 @@ jobs:
   check-examples:
     docker:
       - image: cimg/base:2025.01
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - custom-checkout:
           submodules: true

--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -51,6 +51,7 @@ jobs:
   check-ts:
     docker:
       - image: skiplabs/skip:latest
+    resource_class: large
     steps:
       - custom-checkout:
           submodules: true
@@ -93,6 +94,7 @@ jobs:
   skdb:
     docker:
       - image: skiplabs/skdb-base:latest
+    resource_class: large
     steps:
       - custom-checkout:
           submodules: true
@@ -104,6 +106,7 @@ jobs:
   skdb-wasm:
     docker:
       - image: skiplabs/skdb-base:latest
+    resource_class: large
     steps:
       - custom-checkout:
           submodules: true
@@ -194,6 +197,7 @@ jobs:
   check-examples:
     docker:
       - image: cimg/base:2025.01
+    resource_class: large
     steps:
       - custom-checkout:
           submodules: true


### PR DESCRIPTION
## Summary

Resource-class audit of the CircleCI suite based on peak CPU/RAM utilization data pulled from recent runs.

Two commits:

1. **Phase 0 — make every `resource_class` explicit.** No behavior change. CircleCI's org default was silently giving `large` to jobs that omit `resource_class:` (check-ts, skdb, skdb-wasm, check-examples). Pins them in place so future edits are unambiguous.
2. **Phase 1 — gen2 migration + right-sizing.** Changes driven by measured peak utilization per job:

   | Job | Before | After | Why |
   |---|---|---|---|
   | compiler | xlarge | xlarge.gen2 | ~42m → ~30m (gen2 ~1.4× on both bootstrap + test phases) |
   | skdb-wasm | large | large.gen2 | RAM peak 89% is snug but not OOM; revisit if it regresses |
   | skdb | large | large.gen2 | Straight gen2 speedup |
   | skipruntime | xlarge | large.gen2 | CPU peak 32%, RAM 16% — xlarge was wildly over-provisioned |
   | check-ts | large | medium.gen2 | CPU ~2 cores effective, RAM 31% — fits in medium cleanly |
   | check-examples | large | large.gen2 | CPU peak 81% means we keep the 4 cores |

Skip plan caps at xlarge (no 2xlarge.gen2 available), so all wins come from gen2's ~1.4× boost or from right-sizing, not from doubling parallelism.

`setup`, `fast-checks`, and `skip-package-*` jobs deliberately left alone — too short for gen2 to pay off after accounting for fixed overhead (checkout, image pull) and credit-per-minute premium.

## Test plan

- [ ] Land Phase 0 first; touch a file in each affected area on a follow-up PR and confirm durations match the baseline — verifies the explicit-resource-class commit is truly a no-op.
- [ ] After landing Phase 1, monitor 3+ runs of each affected workflow:
  - [ ] `compiler` p50 drops from ~42m to ~30m
  - [ ] `skdb` p50 drops from ~10m to ~7m
  - [ ] `skdb-wasm` p50 drops from ~14m to ~10m and **no OOMs**
  - [ ] `skipruntime` p50 stays around ~11m (this one's a credit-cost win, not a wall-time win)
  - [ ] `check-ts` p50 stays around ~7m
  - [ ] `check-examples` p50 drops from ~5m to ~3.5m
- [ ] Pull a representative week of CircleCI billing before/after to confirm net credit usage is flat or down.
- [ ] If `skdb-wasm` OOMs, bump to `xlarge.gen2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)