### PR TITLE
ci: run fast-checks in parallel with config generation

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -33,21 +33,6 @@ commands:
             git submodule update
 
 jobs:
-  fast-checks:
-    docker:
-      - image: skiplabs/skip:latest
-    resource_class: small
-    steps:
-      - custom-checkout
-      - run:
-          name: Check code is formatted
-          command: |
-            make check-fmt
-      - run:
-          name: Check shell scripts
-          command: |
-            make check-sh
-
   check-ts:
     docker:
       - image: skiplabs/skip:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,23 @@ jobs:
       - continuation/continue:
           configuration_path: generated_config.yml
 
+  fast-checks:
+    docker:
+      - image: skiplabs/skip:latest
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Check code is formatted
+          command: |
+            make check-fmt
+      - run:
+          name: Check shell scripts
+          command: |
+            make check-sh
+
 workflows:
   setup:
     jobs:
       - setup
+      - fast-checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,17 @@ setup: true
 orbs:
   continuation: circleci/continuation@1.0.0
 
-jobs:
-  setup:
-    executor: continuation/default
-    resource_class: small
+commands:
+  custom-checkout:
+    description: "SSH-authenticated checkout"
+    parameters:
+      with_main:
+        type: boolean
+        default: false
+        description: "Also clone the main branch (needed for diffing against main)"
     steps:
       - run:
-          name: Checkout code (only main and branch)
+          name: Checkout code
           command: |
             if [ -z "$CIRCLE_BRANCH" ] || [ -n "$CIRCLE_TAG" ]; then echo "TODO: handle no-branch or tag-triggered CI"; exit 1; fi
             mkdir -p ~/.ssh
@@ -20,13 +24,26 @@ jobs:
             github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
             ' > ~/.ssh/known_hosts
             cat $CHECKOUT_KEY > ~/.ssh/id_rsa
-            git clone --single-branch --branch main "$CIRCLE_REPOSITORY_URL" .
-            if [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]; then
-              git fetch --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+            if << parameters.with_main >> || [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]; then
+              # PR branches need a base clone to fetch the PR ref into; with_main also pulls main for diffing.
+              git clone --single-branch --branch main "$CIRCLE_REPOSITORY_URL" .
+              if [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]; then
+                git fetch --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+              else
+                git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+              fi
             else
-              git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+              git clone --single-branch --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
             fi
             git checkout "$CIRCLE_SHA1" -B "$CIRCLE_BRANCH"
+
+jobs:
+  setup:
+    executor: continuation/default
+    resource_class: small
+    steps:
+      - custom-checkout:
+          with_main: true
       - run:
           name: Generate config
           command: |
@@ -43,7 +60,7 @@ jobs:
       - image: skiplabs/skip:latest
     resource_class: small
     steps:
-      - checkout
+      - custom-checkout
       - run:
           name: Check code is formatted
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
           name: Generate config
           command: |
             .circleci/generate_config.sh > generated_config.yml
+            if ! grep -q '^workflows:' generated_config.yml; then
+              echo "No dynamic workflows to run"
+              circleci-agent step halt
+            fi
       - continuation/continue:
           configuration_path: generated_config.yml
 

--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -60,12 +60,6 @@ WORKFLOWS=$(mktemp)
 trap 'rm -f "$WORKFLOWS"' EXIT
 
 {
-    cat <<EOF
-  fast-checks:
-    jobs:
-      - fast-checks
-EOF
-
 if $check_ts
 then
     cat <<EOF

--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -56,8 +56,10 @@ fi
 
 cat .circleci/base.yml
 
-echo "workflows:"
+WORKFLOWS=$(mktemp)
+trap 'rm -f "$WORKFLOWS"' EXIT
 
+{
     cat <<EOF
   fast-checks:
     jobs:
@@ -136,4 +138,10 @@ then
     jobs:
       - check-examples
 EOF
+fi
+} > "$WORKFLOWS"
+
+if [ -s "$WORKFLOWS" ]; then
+  echo "workflows:"
+  cat "$WORKFLOWS"
 fi


### PR DESCRIPTION
## Summary

- Hoist the `fast-checks` job out of the dynamically-generated continuation config and into `.circleci/config.yml` so it runs in parallel with the `setup` job (config generation), instead of waiting for the continuation to schedule it.
- Add a guard in `generate_config.sh` and the `setup` job so the pipeline doesn't error out when a PR touches only top-level files (e.g. `.circleci/`) and no dynamic workflows are needed — previously `fast-checks` always filled that slot.

Two small, independent commits:

1. **`ci: handle empty dynamic workflows gracefully`** — defensive change, no behavior change yet. Buffers workflow output and only emits the top-level `workflows:` key if at least one workflow fires; setup job halts before calling `continuation/continue` when nothing was generated.
2. **`ci: hoist fast-checks into setup workflow`** — moves the `fast-checks` job into `config.yml` (using a plain `checkout`, since it doesn't need submodules) and removes it from `base.yml` / `generate_config.sh`.

## Test plan

- [ ] CI on this PR runs `fast-checks` in the `setup` workflow (visible at the start, in parallel with `setup`).
- [ ] CI on this PR does **not** emit a duplicate `fast-checks` in the continuation workflow.
- [ ] For a PR that only touches top-level files (e.g. this one before adding any source change), the setup job halts cleanly and `fast-checks` still runs.