### PR TITLE
fix(skstore): purge DeletedDir tombstones at end of update transaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,8 +203,11 @@ test-%:
 	cd $* && skargo test --profile $(SKARGO_PROFILE)
 
 .PHONY: test-native
+# The skargo test step above runs the .sk tests first; the shell pipeline below
+# is silenced (@) so its long command line does not bury those results.
 test-native: build/skdb
-	cd sql/ && SKARGO_PROFILE=$(SKARGO_PROFILE) SKDB_BIN=$(realpath build/skdb) ./test_sql.sh \
+	cd sql && skargo test --profile $(SKARGO_PROFILE)
+	@cd sql/ && SKARGO_PROFILE=$(SKARGO_PROFILE) SKDB_BIN=$(realpath build/skdb) ./test_sql.sh \
 	|tee /tmp/native-test.out ; \
 	! grep -v '\*\|^[[:blank:]]*$$\|OK\|PASS' /tmp/native-test.out
 

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -391,6 +391,8 @@ mutable base class WriteChecker {
 mutable class Context private {
   private mutable toPurge: SortedSet<DirName> = SortedSet[],
   private mutable dirs: Dirs = Dirs{},
+  private mutable deletedDirs: SortedSet<DirName> = SortedSet[],
+  private mutable dirsTombLimit: ?Tick = None(),
   mutable reads: SortedSet<Path> = SortedSet[],
   private mutable time: Time = Time(0),
   /* Invariant: tick is only updated at the end of updateWithStatus */
@@ -443,12 +445,13 @@ mutable class Context private {
     if (this.unsafeMaybeGetEagerDir(dirName).isSome()) {
       throw DirAlreadyExists(dirName)
     };
-    from.unsafeGetDir(dirName) match {
-    | DeletedDir _ -> false
-    | lazy @ LazyDir _ ->
+    from.unsafeMaybeGetDir(dirName) match {
+    | None() -> false
+    | Some(DeletedDir _) -> false
+    | Some(lazy @ LazyDir _) ->
       this.setDir(lazy);
       true
-    | eager @ EagerDir _ ->
+    | Some(eager @ EagerDir _) ->
       if (eager.input) {
         this.setDir(eager)
       } else {
@@ -550,6 +553,8 @@ mutable class Context private {
     mutable static{
       toPurge => this.toPurge,
       dirs => this.dirs,
+      deletedDirs => this.deletedDirs,
+      dirsTombLimit => this.dirsTombLimit,
       reads => this.reads,
       time => this.time,
       tick => this.tick,
@@ -583,6 +588,8 @@ mutable class Context private {
   mutable fun replaceFromSaved(ctx: readonly Context): void {
     this.!toPurge = ctx.toPurge;
     this.!dirs = ctx.dirs;
+    this.!deletedDirs = ctx.deletedDirs;
+    this.!dirsTombLimit = ctx.dirsTombLimit;
     this.!reads = ctx.reads;
     this.!time = ctx.time;
     this.!tick = ctx.tick;
@@ -910,7 +917,7 @@ mutable class Context private {
     ignoredSessions: Set<String> = Set[],
   ): void {
     changedDirNames = this.getGlobal("CHANGED_DIRS") match {
-    | None() -> this.getDirsChangesAfter(start)
+    | None() -> this.getDirsChangesAfter(start).i1
     | Some(x @ ChangedDirs _) -> x.value
     | _ -> invariant_violation("Wrong type for CHANGED_DIRS")
     };
@@ -1040,6 +1047,10 @@ mutable class Context private {
   mutable fun setDir(dir: Dir): void {
     dirName = dir.getDirName();
     this.!dirs = this.dirs.set(this.tick, dirName, dir);
+    dir match {
+    | DeletedDir _ -> this.!deletedDirs = this.deletedDirs.set(dirName)
+    | _ -> void
+    };
   }
 
   mutable fun getDir(dirName: DirName): Dir {
@@ -1150,6 +1161,7 @@ mutable class Context private {
         this.fromContext match {
         | Some(from) ->
           from.unsafeMaybeGetDir(dirName) match {
+          | None() -> false
           | Some(DeletedDir _) -> false
           | _ -> true
           }
@@ -1162,6 +1174,32 @@ mutable class Context private {
       this.!sharedSubDirsRefCount = this.sharedSubDirsRefCount.remove(dirName);
       this.setDir(DeletedDir::ofDir(dir))
     };
+  }
+  // Purge DeletedDir tombstones older than `limit`. Tombstones newer than
+  // `limit` are kept so a lagging import can still observe the deletion (see
+  // getDirsChangesAfter). When something is purged, advance dirsTombLimit
+  // monotonically: below that tick deletions are no longer visible as
+  // tombstones, and import must fall back to the full live-dir list.
+  mutable fun purgeDeletedDirs(limit: Tick): Int {
+    purged = 0;
+    stillTracked = SortedSet[];
+    for (dirName in this.deletedDirs) {
+      this.dirs.maybeGetWithTick(dirName) match {
+      | Some((DeletedDir _, tick)) if (tick.value < limit.value) ->
+        this.!dirs = this.dirs.removeDir(dirName);
+        !purged = purged + 1
+      | Some((DeletedDir _, _)) -> !stillTracked = stillTracked.set(dirName)
+      | _ -> void
+      }
+    };
+    this.!deletedDirs = stillTracked;
+    if (purged > 0) {
+      this.!dirsTombLimit = this.dirsTombLimit match {
+      | Some(prev) if (prev.value >= limit.value) -> Some(prev)
+      | _ -> Some(limit)
+      }
+    };
+    purged
   }
 
   readonly fun transitiveChildDirs(dirName: DirName): SortedSet<DirName> {
@@ -1223,8 +1261,24 @@ mutable class Context private {
     this.dirs.values()
   }
 
-  readonly fun getDirsChangesAfter(start: Tick): SortedSet<DirName> {
-    this.dirs.getChangesAfter(start)
+  // (purged, changed, allExisting):
+  //  - changed: dirs changed after `start` (the usual diff)
+  //  - purged: true if start <= dirsTombLimit, i.e. deletions in that window
+  //    were purged and are no longer present in `changed`
+  //  - allExisting: when purged, the full set of live dir names so a lagging
+  //    import can deduce deletions by absence; empty otherwise.
+  readonly fun getDirsChangesAfter(
+    start: Tick,
+  ): (Bool, SortedSet<DirName>, SortedSet<DirName>) {
+    changed = this.dirs.getChangesAfter(start);
+    this.dirsTombLimit match {
+    | Some(limit) if (start.value <= limit.value) ->
+      (true, changed, this.dirs.aliveDirNames())
+    | _ -> (false, changed, SortedSet[])
+    }
+  }
+  readonly fun aliveDirNames(): SortedSet<DirName> {
+    this.dirs.aliveDirNames()
   }
 
   mutable fun addToPurge(dirName: DirName): void {
@@ -1286,6 +1340,21 @@ private class Dirs{private state: DMap<DirName, Dir> = DMap::empty()} {
   fun maybeGet(key: DirName): ?Dir {
     this.state.maybeGet(key)
   }
+  fun maybeGetWithTick(key: DirName): ?(Dir, Tick) {
+    this.state.maybeGetWithTick(key)
+  }
+  // Names of all live dirs (DeletedDir tombstones excluded).
+  fun aliveDirNames(): SortedSet<DirName> {
+    result = SortedSet[];
+    this.state.items().each(kv -> {
+      (dirName, dir) = kv;
+      dir match {
+      | DeletedDir _ -> void
+      | _ -> !result = result.set(dirName)
+      }
+    });
+    result
+  }
   fun get(key: DirName): Dir {
     this.maybeGet(key) match {
     | None() ->
@@ -1299,6 +1368,11 @@ private class Dirs{private state: DMap<DirName, Dir> = DMap::empty()} {
   }
   fun getChangesAfter(start: Tick): SortedSet<DirName> {
     this.state.getChangesAfter(start)
+  }
+
+  fun removeDir(key: DirName): this {
+    !this.state = this.state.remove(key);
+    this
   }
 }
 
@@ -1316,12 +1390,28 @@ fun import(
   tick: Tick,
   sourceCtx: readonly Context,
 ): void {
-  changedDirNames = sourceCtx.getDirsChangesAfter(tick);
+  (purged, changedDirNames, allExisting) = sourceCtx.getDirsChangesAfter(tick);
   for (dirName in changedDirNames) {
     sourceCtx.unsafeMaybeGetDir(dirName) match {
     | Some(DeletedDir{}) -> targetCtx.removeDir(dirName)
     | Some(dir @ EagerDir _) -> dir.import{targetCtx, tick}
     | _ -> void
+    }
+  };
+  // Source purged its tombstones before `tick`: deletions in that window are
+  // absent from changedDirNames. Deduce them by absence — any dir the target
+  // still has that is no longer in the source's live set was deleted.
+  // Precondition: target was forked from source at `tick`. An inherited dir
+  // has created < tick, so this guard spares dirs created locally afterwards.
+  if (purged) {
+    for (dirName in targetCtx.aliveDirNames()) {
+      targetCtx.unsafeMaybeGetDir(dirName) match {
+      | Some(
+        dir @ EagerDir _,
+      ) if (dir.created < tick && !allExisting.contains(dirName)) ->
+        targetCtx.removeDir(dirName)
+      | _ -> void
+      }
     }
   };
 }
@@ -1355,7 +1445,7 @@ fun resolveContext(
   | None() if (tick == root.getTick()) -> delta
   | None() -> invariant_violation("Concurrent access without synchronizer")
   | Some(sync) ->
-    changedDirs = delta.getDirsChangesAfter(tick);
+    changedDirs = delta.getDirsChangesAfter(tick).i1;
     try {
       sync.importFromRoot(delta, tick, root);
       None()
@@ -1379,6 +1469,12 @@ fun resolveContext(
     | Some(exn) -> return cloneContextWithError(root, exn)
     | None() -> void
     };
+    // Deletions inferred by absence during the imports are posted after the
+    // changedDirs snapshot above, so they are missing from it. Re-scan the
+    // final context so they reach CHANGED_DIRS and their subscribers are
+    // notified. Covers both import directions (posted on / propagated to
+    // newRoot).
+    !changedDirs = changedDirs.union(newRoot.getDirsChangesAfter(tick).i1);
 
     lockF match {
     | None() -> void
@@ -1387,7 +1483,7 @@ fun resolveContext(
         newRootTick = newRoot.getTick();
         f(newRoot, delta, root);
         !changedDirs = changedDirs.union(
-          newRoot.getDirsChangesAfter(newRootTick),
+          newRoot.getDirsChangesAfter(newRootTick).i1,
         );
         None()
       } catch {
@@ -1402,6 +1498,10 @@ fun resolveContext(
     };
     newRoot
   };
+  // Same fixed 1000-tick window as the existing file-history purge: bound the
+  // leak rather than eliminate it. Tombstones inside the window stay visible to
+  // a lagging import; older ones fall back to absence deduction.
+  _ = context.purgeDeletedDirs(Tick(max(0, context.getTick().value - 1000)));
   context.purge();
   context
 }

--- a/skiplang/prelude/src/skstore/DMap.sk
+++ b/skiplang/prelude/src/skstore/DMap.sk
@@ -230,6 +230,15 @@ base class DMap<K: Orderable, +V> {
     | GT() -> right.maybeGet(k)
     }
 
+  fun maybeGetWithTick(k: K): ?(V, Tick)
+  | Nil() -> None()
+  | Node{tick, key, value, left, right} ->
+    k.compare(key) match {
+    | LT() -> left.maybeGetWithTick(k)
+    | EQ() -> Some((value, tick.current))
+    | GT() -> right.maybeGetWithTick(k)
+    }
+
   fun get(k: K): V {
     this.maybeGet(k).fromSome()
   }

--- a/skiplang/prelude/tests/skfs/TestImportAfterPurge.sk
+++ b/skiplang/prelude/tests/skfs/TestImportAfterPurge.sk
@@ -1,0 +1,75 @@
+module alias T = SKTest;
+module alias SK = SKStore;
+
+module SKStoreTest;
+
+// After a purge removes a dir's tombstone, a later import from an older tick
+// must still turn that dir into a DeletedDir on the target (deduction by absence).
+@test
+fun testImportAfterPurge(): void {
+  SK.withRegionVoid(() ~> {
+    aName = SK.DirName::create("/a/");
+    bName = SK.DirName::create("/b/");
+
+    source = SK.Context::create{}.mclone();
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      aName,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      bName,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    source.update();
+
+    // Tick before deletion: a lagging reader is stuck here.
+    tickBefore = source.getTick();
+
+    // Clone a target that still sees both /a/ and /b/ (the lagging reader).
+    target = source.mclone();
+    T.expectTrue(
+      target.maybeGetDir(aName) is Some _ &&
+        target.maybeGetDir(bName) is Some _,
+      "Target starts with both dirs",
+    );
+
+    // Delete /b/ in source: this leaves a DeletedDir tombstone.
+    source.removeDir(bName);
+    source.update();
+    T.expectTrue(
+      source.maybeGetDir(bName) is Some(SK.DeletedDir _),
+      "Source has a tombstone for /b/",
+    );
+
+    // Move forward, then purge with a low limit so the tombstone is collected
+    // and dirsTombLimit advances past tickBefore.
+    source.update();
+    purged = source.purgeDeletedDirs(source.getTick());
+    T.expectTrue(purged > 0, "Tombstone for /b/ was purged");
+    T.expectTrue(
+      source.maybeGetDir(bName) is None _,
+      "Tombstone is gone from source after purge",
+    );
+
+    // Import into the lagging target from tickBefore (older than the purge).
+    // Without the fix the deletion is invisible and /b/ stays a phantom.
+    // With the fix import deduces it by absence.
+
+    SK.import(target, tickBefore, source);
+
+    T.expectTrue(
+      target.maybeGetDir(bName) is Some(SK.DeletedDir _),
+      "Deletion of /b/ propagated to lagging target",
+    );
+    T.expectTrue(
+      target.maybeGetDir(aName) is Some(SK.EagerDir _),
+      "/a/ still present in target",
+    );
+  })
+}
+
+module end;

--- a/skiplang/prelude/tests/skfs/TestImportPreservesLocalDirs.sk
+++ b/skiplang/prelude/tests/skfs/TestImportPreservesLocalDirs.sk
@@ -1,0 +1,72 @@
+module alias T = SKTest;
+module alias SK = SKStore;
+
+module SKStoreTest;
+
+// Absence deduction must not delete a dir created locally in the target after
+// the fork (created == tick): it was never in the source, not deleted from it.
+@test
+fun testImportPreservesLocalDirs(): void {
+  SK.withRegionVoid(() ~> {
+    aName = SK.DirName::create("/a/");
+    localName = SK.DirName::create("/local/");
+
+    // Source with one dir /a/.
+    source = SK.Context::create{}.mclone();
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      aName,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    source.update();
+
+    tickFork = source.getTick();
+
+    // Target forks from source, then creates a LOCAL dir /local/ that the
+    // source never had.
+    target = source.mclone();
+    _ = target.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      localName,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    target.update();
+
+    T.expectTrue(
+      target.maybeGetDir(localName) is Some(SK.EagerDir _),
+      "Local dir exists before import",
+    );
+
+    // Create then delete a throwaway dir in source so there IS a tombstone to
+    // purge, which advances dirsTombLimit past tickFork.
+    throwaway = SK.DirName::create("/throwaway/");
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      throwaway,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    source.update();
+    source.removeDir(throwaway);
+    source.update();
+    source.update();
+    _ = source.purgeDeletedDirs(source.getTick());
+
+    // Sanity: importing from tickFork should see purged=true.
+    (purged, _, _) = source.getDirsChangesAfter(tickFork);
+    T.expectTrue(purged, "purged flag is true for a lagging fork");
+    // Import from tickFork. The local dir must NOT be deleted — it was never
+    // in the source, it is a local addition, not a source deletion.
+    SK.import(target, tickFork, source);
+
+    T.expectTrue(
+      target.maybeGetDir(localName) is Some(SK.EagerDir _),
+      "local dir /local/ was wrongly deleted by absence deduction — " +
+        "it was never in the source, so its absence there does not mean deletion",
+    );
+  })
+}
+
+module end;

--- a/skiplang/prelude/tests/skfs/TestInheritedDeletionPropagate.sk
+++ b/skiplang/prelude/tests/skfs/TestInheritedDeletionPropagate.sk
@@ -1,0 +1,48 @@
+module alias T = SKTest;
+module alias SK = SKStore;
+
+module SKStoreTest;
+
+// Confirms the `created < tick` guard does NOT break propagation of a real
+// deletion: an inherited dir (created strictly before the fork) that is
+// deleted and purged is still propagated to a lagging target. This is the
+// counterpart of testImportPreservesLocalDirs — together they show the guard
+// separates inherited dirs (deletable) from local additions (protected).
+@test
+fun testInheritedDeletionPropagates(): void {
+  SK.withRegionVoid(() ~> {
+    cName = SK.DirName::create("/c/");
+    source = SK.Context::create{}.mclone();
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      cName,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    source.update();
+    tickFork = source.getTick();
+    // /c/ is inherited with created < tickFork (an update ran after its mkdir).
+    source.unsafeMaybeGetEagerDir(cName) match {
+    | Some(d @ SK.EagerDir _) ->
+      T.expectTrue(d.created.value < tickFork.value, "/c/ created before fork")
+    | _ -> T.fail("/c/ should be an eager dir")
+    };
+    target = source.mclone();
+    // Delete /c/ in source, then purge past tickFork.
+    source.removeDir(cName);
+    source.update();
+    source.update();
+    purged = source.purgeDeletedDirs(source.getTick());
+    T.expectTrue(purged > 0, "Tombstone for /c/ was purged");
+    (isPurged, _, _) = source.getDirsChangesAfter(tickFork);
+    T.expectTrue(isPurged, "purged flag true for tickFork");
+    SK.import(target, tickFork, source);
+    T.expectTrue(
+      target.maybeGetDir(cName) is Some(SK.DeletedDir _),
+      "Inherited /c/ was deleted in source; its deletion must propagate to the " +
+        "lagging target even with the created < tick guard",
+    );
+  })
+}
+
+module end;

--- a/sql/Skargo.toml
+++ b/sql/Skargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "skdb"
 version = "0.2.0"
+tests = [
+  "test/sktests/tests.sk",
+  "test/sktests/test_importnext_after_purge.sk",
+]
+test-harness = "SKDBTest.main"
 
 [dependencies]
 std = { path = "../skiplang/prelude" }

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1187,7 +1187,7 @@ class Evaluator{options: Options, user: ?UserFile} {
           // If the deps haven't changed, that means we can reuse
           // the pre-computed data.
           if (sameDeps) {
-            changedDirNames = delta.getDirsChangesAfter(startTick);
+            changedDirNames = delta.getDirsChangesAfter(startTick).i1;
             for (changedDirName in changedDirNames) {
               if (context.unsafeMaybeGetDir(changedDirName).isNone()) {
                 context.setGlobal(
@@ -2039,7 +2039,7 @@ fun importNext(
   tick: SKStore.Tick,
   sourceCtx: readonly SKStore.Context,
 ): Bool {
-  changedDirNames = sourceCtx.getDirsChangesAfter(tick);
+  (purged, changedDirNames, allExisting) = sourceCtx.getDirsChangesAfter(tick);
   updates = mutable Map[];
   hasMultipleVersions = false;
   for (dirName in changedDirNames) {
@@ -2058,6 +2058,25 @@ fun importNext(
   for (targetDirName => src in updates) {
     (_version, dir) = src;
     dir.importNext{targetCtx, tick, targetDirName}
+  };
+  // Deduce deletions by absence (see import in the prelude). Source names are
+  // translated through makeInputDirName so the comparison is in the target's
+  // /table/ namespace. Precondition: target was forked from source at `tick`.
+  if (purged) {
+    expected = SortedSet[];
+    for (srcDirName in allExisting) {
+      (targetDirName, _version) = makeInputDirName(srcDirName);
+      !expected = expected.set(targetDirName)
+    };
+    for (targetDirName in targetCtx.aliveDirNames()) {
+      targetCtx.unsafeMaybeGetDir(targetDirName) match {
+      | Some(
+        dir @ SKStore.EagerDir{input => true},
+      ) if (dir.created < tick && !expected.contains(targetDirName)) ->
+        targetCtx.removeDir(targetDirName)
+      | _ -> void
+      }
+    }
   };
   hasMultipleVersions
 }

--- a/sql/test/sktests/test_importnext_after_purge.sk
+++ b/sql/test/sktests/test_importnext_after_purge.sk
@@ -1,0 +1,74 @@
+module alias T = SKTest;
+module alias SK = SKStore;
+module SKDBTest;
+
+// Proves the SKDB importNext path handles a lagging import after tombstone
+// purge: a source input dir /next/1/foo/ deleted then purged is still
+// propagated to the target's renamed /foo/ via absence deduction.
+fun testImportNextAfterPurge(): void {
+  SK.withRegionVoid(() ~> {
+    nextFoo = SK.DirName::create("/next/foo/1/");
+    nextBar = SK.DirName::create("/next/bar/1/");
+    foo = SK.DirName::create("/foo/");
+    bar = SK.DirName::create("/bar/");
+
+    // Source: two input dirs in /next/ form.
+    source = SKDB.makeSqlContext().mclone();
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      nextFoo,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    _ = source.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      nextBar,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    source.update();
+
+    tickBefore = source.getTick();
+
+    // Target: already holds the renamed dirs /foo/ and /bar/ (as inputs).
+    target = SKDB.makeSqlContext().mclone();
+    _ = target.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      foo,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    _ = target.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      bar,
+      Array[(SK.IID(0), SK.IntFile(0))],
+    );
+    target.update();
+
+    // Delete /next/1/foo/ in source, then purge so the tombstone is gone.
+    source.removeDir(nextFoo);
+    source.update();
+    source.update();
+    purged = source.purgeDeletedDirs(source.getTick());
+    T.expectTrue(purged > 0, "Source tombstone purged");
+    T.expectTrue(source.maybeGetDir(nextFoo) is None _, "Tombstone gone");
+
+    // Lagging import from tickBefore (older than the purge). Without the fix
+    // the deletion is invisible; with it, importNext deduces /foo/ was deleted.
+    _ = SKDB.importNext(target, tickBefore, source);
+
+    T.expectTrue(
+      target.maybeGetDir(foo) is Some(SK.DeletedDir _),
+      "After a lagging importNext past a tombstone purge, /foo/ should " +
+        "be a DeletedDir (deletion deduced by absence), but it is still alive " +
+        "in the target — the deletion was lost",
+    );
+    T.expectTrue(
+      target.maybeGetDir(bar) is Some(SK.EagerDir _),
+      "/bar/ still alive in target",
+    );
+  })
+}
+
+module end;

--- a/sql/test/sktests/tests.sk
+++ b/sql/test/sktests/tests.sk
@@ -1,0 +1,27 @@
+module alias T = SKTest;
+module alias SK = SKStore;
+module SKDBTest;
+
+untracked fun main(): void {
+  // If SKTEST_RANK doesn't exist, it means that we are in main process, and not a child
+  if (Environ.varOpt("SKTEST_RANK") is None()) {
+    print_string(
+      "*******************************************************************************\n" +
+        "* SKDB SKIPLANG TESTS *\n" +
+        "*******************************************************************************",
+    );
+  };
+  tests = mutable Map[];
+  tests.set(
+    "SKDBTest",
+    mutable Vector[
+      SKTest.Test{
+        name => "testImportNextAfterPurge",
+        func => () ~> testImportNextAfterPurge(),
+      },
+    ],
+  );
+  SKTest.test_harness(tests)
+}
+
+module end;


### PR DESCRIPTION
fix(skstore): bound DeletedDir tombstone leak and keep deletions visible

Rebased on main (1813f196). Test setup adjusted for the region API change:
the tests now use SKStore.withRegionVoid instead of the newly-private
newObstack.

DeletedDir tombstones created by removeDir were never collected, leaking
indefinitely. They are now purged once older than a fixed tick window
(tick - 1000), in the tail of resolveContext on the committed context, so
the purge applies uniformly to every commit path (both the delta branch and
the synchronizer's newRoot branch) and reaches the shared root. Bounding the
leak rather than eliminating it mirrors the window strategy already used for
file history.

Purging tombstones breaks deletion visibility for a lagging import reader,
since the deletion vanishes from getDirsChangesAfter once its tombstone is
gone. To keep deletions observable, getDirsChangesAfter now returns
(purged, changed, allExisting): when the requested tick predates the purge
window, it flags purged and returns the full live-dir set, so import (and
SKDB's importNext) can deduce deletions by absence instead of relying on the
tombstone. SKDB's importNext translates source input dirs through
makeInputDirName before the absence check, to account for its /next/
versioning rename.

Absence deduction only removes dirs that existed before the fork: the guard
created < tick protects dirs created locally in the target after the fork
(created == tick), which are additions never present in the source, not
deletions. Without it, a lagging import could destroy the target's local
writes.

Deductions inferred during import are posted after resolveContext snapshots
changedDirs, so the final context is re-scanned before CHANGED_DIRS is set,
otherwise subscribers to the deleted dirs are never notified.

Tests: prelude tests cover the generic import path (deletion propagated
after purge, local dirs preserved, inherited deletion still propagated), and
a first SKDB .sk test covers the importNext rename path. Each fails without
its guard and passes with it. The SKDB test runs via a small skargo
test-harness wired into make test-native.