### PR TITLE
ci: set SKIP_CAPACITY on gen2 jobs to fit class RAM

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -37,6 +37,8 @@ jobs:
     docker:
       - image: skiplabs/skip:latest
     resource_class: medium.gen2
+    environment:
+      SKIP_CAPACITY: 3G
     steps:
       - custom-checkout:
           submodules: true
@@ -63,6 +65,8 @@ jobs:
     docker:
       - image: skiplabs/skiplang:latest
     resource_class: xlarge.gen2
+    environment:
+      SKIP_CAPACITY: 12G
     steps:
       - custom-checkout:
           submodules: true
@@ -80,6 +84,8 @@ jobs:
     docker:
       - image: skiplabs/skdb-base:latest
     resource_class: large.gen2
+    environment:
+      SKIP_CAPACITY: 6G
     steps:
       - custom-checkout:
           submodules: true
@@ -92,6 +98,8 @@ jobs:
     docker:
       - image: skiplabs/skdb-base:latest
     resource_class: large.gen2
+    environment:
+      SKIP_CAPACITY: 6G
     steps:
       - custom-checkout:
           submodules: true
@@ -160,6 +168,8 @@ jobs:
           KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
     resource_class: large.gen2
+    environment:
+      SKIP_CAPACITY: 6G
     steps:
       - custom-checkout:
           submodules: true


### PR DESCRIPTION
## Summary

Gen2 CircleCI machines enforce virtual memory limits at the cgroup level. The Skip runtime's default `SKIP_CAPACITY` of 16 GB (`skiplang/prelude/runtime/palloc.c:449-451`) fails to `mmap` on any class with <16 GB RAM, producing `ERROR (MAP FAILED): Cannot allocate memory` early in the job.

Observed on `skipruntime` / `large.gen2` in PR #1245 (job 16682) and on an earlier `skdb-wasm` / `large.gen2` run that died at 61 s (workflow `f78dd673`, 2026-05-27 09:37). Gen1 tolerated the same 16 GB virtual mmap because only RSS was enforced and the mmap is lazy — gen2 evidently does not.

Set `SKIP_CAPACITY` explicitly per gen2 job, leaving ~25% RAM headroom for OS + tooling:

| Job | Class | RAM | `SKIP_CAPACITY` |
|---|---|---|---|
| check-ts | medium.gen2 | 4 GB | `3G` |
| skdb | large.gen2 | 8 GB | `6G` |
| skdb-wasm | large.gen2 | 8 GB | `6G` |
| skipruntime | large.gen2 (+ pg/kafka sidecars) | 8 GB primary | `6G` |
| compiler | xlarge.gen2 | 16 GB | `12G` |

Why also setting the ones that haven't (yet) failed: same `mmap` happens on every Skip-toolchain invocation, so any gen2 job using `skiplabs/skip*` images is one coin flip away from the same failure. `skipruntime` on `large.gen2` succeeded 3× in a row on the Phase 1 PR before failing on #1245 — the variance is real.

`check-examples` is on `large.gen2` but uses `cimg/base` and only runs the Skip toolchain inside docker-compose containers (separate cgroups), so it's not affected.

## Test plan

- [ ] Land this, then trigger a PR that exercises each gen2 workflow (touch `skiplang/prelude/src/foo` for compiler + skdb + skdb-wasm + skipruntime, and a ts workspace file for check-ts).
- [ ] Confirm `skipruntime` no longer dies with `MAP FAILED` at `skargo build`.
- [ ] Confirm `compiler` still passes — 12 G cap is well above measured peak (~10 GB).
- [ ] Watch `skdb` and `skdb-wasm` over the next few PRs for any new failures specifically at allocation time; if they appear, drop the cap further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)