### PR TITLE
ci: forward SKIP_CAPACITY into docker builds invoking Skip toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN --mount=type=bind,source=./bin/apt-install.sh,target=/tmp/apt-install.sh \
 ENV CC=clang
 ENV CXX=clang++
 
+# Override at build time with --build-arg SKIP_CAPACITY=<value> to fit the
+# build host's memory budget. Empty (the default) preserves the runtime's
+# own 16 GB default for local dev builds.
+ARG SKIP_CAPACITY=
+ENV SKIP_CAPACITY=$SKIP_CAPACITY
+
 FROM skiplang-base AS bootstrap
 
 ARG STAGE=0

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -22,6 +22,10 @@
 # Environment variables:
 #   STAGE              Compiler bootstrap stage (default: 0). Passed as STAGE
 #                      build arg to the root Dockerfile (skiplang/skip targets).
+#   SKIP_CAPACITY      If set, forwarded as SKIP_CAPACITY build arg to targets
+#                      that invoke the Skip toolchain at build time, capping
+#                      the runtime's mmap reservation. Required on hosts that
+#                      enforce virtual memory limits (e.g. gen2 CI builders).
 #   DOCKER_DEFAULT_ARCH  Default platform(s) when --arch is not given.
 #                        Supports same shorthands as --arch.
 #
@@ -196,6 +200,18 @@ fi
 # Pass STAGE build arg to targets using the root Dockerfile
 if [[ -n "${STAGE:-}" ]]; then
     BAKE_ARGS+=(--set "skiplang.args.STAGE=$STAGE" --set "skip.args.STAGE=$STAGE")
+fi
+
+# Forward SKIP_CAPACITY to targets that invoke the Skip toolchain at build
+# time. Required on memory-constrained hosts (e.g. gen2 CircleCI builders)
+# where the runtime's 16 GB default mmap would fail.
+if [[ -n "${SKIP_CAPACITY:-}" ]]; then
+    BAKE_ARGS+=(
+        --set "skiplang.args.SKIP_CAPACITY=$SKIP_CAPACITY"
+        --set "skip.args.SKIP_CAPACITY=$SKIP_CAPACITY"
+        --set "skiplang-bin-builder.args.SKIP_CAPACITY=$SKIP_CAPACITY"
+        --set "skipruntime.args.SKIP_CAPACITY=$SKIP_CAPACITY"
+    )
 fi
 
 # Determine which bake targets to build

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -33,6 +33,12 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
 ENV CC=clang
 ENV CXX=clang++
 
+# Override at build time with --build-arg SKIP_CAPACITY=<value> to fit the
+# build host's memory budget. Empty (the default) preserves the runtime's
+# own 16 GB default for local dev builds.
+ARG SKIP_CAPACITY=
+ENV SKIP_CAPACITY=$SKIP_CAPACITY
+
 FROM base AS skiplang
 
 COPY ./skiplang /work/skiplang

--- a/skipruntime-ts/Dockerfile
+++ b/skipruntime-ts/Dockerfile
@@ -3,6 +3,12 @@
 
 FROM skiplabs/skiplang-bin-builder AS build
 
+# Override at build time with --build-arg SKIP_CAPACITY=<value> to fit the
+# build host's memory budget. Empty (the default) preserves the runtime's
+# own 16 GB default for local dev builds.
+ARG SKIP_CAPACITY=
+ENV SKIP_CAPACITY=$SKIP_CAPACITY
+
 COPY ./skiplang /work/skiplang
 COPY ./skipruntime-ts /work/skipruntime-ts
 

--- a/skipruntime-ts/tests/native_addon/run.sh
+++ b/skipruntime-ts/tests/native_addon/run.sh
@@ -5,5 +5,5 @@ set -euo pipefail
 # build, run, and remove the test container
 TEMP_FILE=$(mktemp)
 docker build --iidfile "$TEMP_FILE" .
-docker run --rm "$(cat "$TEMP_FILE")"
+docker run --rm -e SKIP_CAPACITY "$(cat "$TEMP_FILE")"
 rm "$TEMP_FILE"

--- a/skipruntime-ts/tests/native_addon_unreleased/run.sh
+++ b/skipruntime-ts/tests/native_addon_unreleased/run.sh
@@ -34,6 +34,6 @@ for arch in ${ARCH//,/ }; do
     echo "Testing linux/$arch..."
     TEMP_FILE=$(mktemp)
     docker build --platform="linux/$arch" --iidfile "$TEMP_FILE" .
-    docker run --rm "$(cat "$TEMP_FILE")"
+    docker run --rm -e SKIP_CAPACITY "$(cat "$TEMP_FILE")"
     rm "$TEMP_FILE"
 done


### PR DESCRIPTION
## Summary

Follow-up to #1246. The previous PR set `SKIP_CAPACITY` on the CircleCI primary container, but the value doesn't propagate into nested `docker build` steps that run on the remote-docker host. Skip toolchain invocations inside those builds reverted to the runtime's 16 GB default `mmap` and OOM'd on gen2 hosts.

Observed in [pipeline 4507 / job 16690](https://app.circleci.com/pipelines/github/SkipLabs/skip/4507/workflows/bb0eb244-0515-4641-8e4f-974a89f63aac/jobs/16690) (skipruntime job, "Run native addon unreleased test" step): the docker build of `skiplabs/skiplang-bin-builder` failed at [skiplang/Dockerfile:41](skiplang/Dockerfile#L41) with `ERROR (MAP FAILED): Cannot allocate memory` during `make STAGE=0`.

## Fix

Two parts:

1. **Declare `ARG SKIP_CAPACITY=` + `ENV SKIP_CAPACITY=$SKIP_CAPACITY`** in each Dockerfile that invokes the Skip toolchain at build time:
   - [Dockerfile](Dockerfile) (top-level, `bootstrap` stage inherits ENV via `skiplang-base`)
   - [skiplang/Dockerfile](skiplang/Dockerfile) (`skiplang` stage inherits via `base`)
   - [skipruntime-ts/Dockerfile](skipruntime-ts/Dockerfile)

   ARG defaults to empty so local dev builds preserve the runtime's 16 GB default — `palloc.c:449-451` treats an empty `SKIP_CAPACITY` as unset.

2. **[bin/docker_build.sh](bin/docker_build.sh) forwards `$SKIP_CAPACITY`** (when set) as a build arg to all bake targets that invoke the toolchain (`skiplang`, `skip`, `skiplang-bin-builder`, `skipruntime`). Mirrors the existing `STAGE` forwarding pattern. In CI this picks up the value already set on the job by #1246, so no additional `.circleci/base.yml` change is needed.

## Test plan

- [ ] After merge, watch the next PR that triggers `skipruntime` — the "Run native addon unreleased test" step's docker build should no longer fail with `MAP FAILED`.
- [ ] Confirm local `bin/docker_build.sh skipruntime` (without `SKIP_CAPACITY` env var) still uses the runtime's 16 GB default and builds fine on a developer machine.
- [ ] Confirm `STAGE=1 bin/docker_build.sh skiplang` still works — the new SKIP_CAPACITY block sits next to STAGE and shouldn't interfere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)