### PR TITLE
feat(runtime): configurable garbage collector, memory leak fix, regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,13 @@ test-soak-priv: build/skdb build/init.sql npm
 test-soak:
 	$(MAKE) SKARGO_PROFILE=release test-soak-priv
 
+.PHONY: test-mem-stress
+test-mem-stress:
+	@$(MAKE) -C skipruntime-ts build-examples
+	LD_LIBRARY_PATH=$(PWD)/build/skipruntime:$$LD_LIBRARY_PATH \
+	SKIP_PLATFORM=native \
+	node $(PWD)/skipruntime-ts/examples/dist/stress-tests/gc-stress.js $(ARGS)
+
 # run targets
 
 .PHONY: run-dev-server

--- a/skiplang/prelude/runtime/palloc.c
+++ b/skiplang/prelude/runtime/palloc.c
@@ -745,6 +745,10 @@ void SKIP_print_persistent_size() {
   printf("%ld\n", ginfo->total_palloc_size);
 }
 
+int64_t SKIP_get_persistent_size() {
+  return (int64_t)ginfo->total_palloc_size;
+}
+
 void* sk_palloc(size_t size) {
   sk_check_has_lock();
   slot_t slot = sk_slot_of_size(size);

--- a/skiplang/prelude/runtime/runtime.h
+++ b/skiplang/prelude/runtime/runtime.h
@@ -377,6 +377,7 @@ char* sk_new_const(char* cst);
 void sk_obstack_attach_page(sk_obstack_t* lpage, sk_obstack_t* next);
 size_t sk_page_size(sk_obstack_t* page);
 void* sk_palloc(size_t size);
+int64_t SKIP_get_persistent_size();
 void sk_persist_consts();
 void sk_pfree_size(void*, size_t);
 size_t sk_pow2_size(size_t);

--- a/skiplang/prelude/runtime/runtime32_specific.c
+++ b/skiplang/prelude/runtime/runtime32_specific.c
@@ -141,8 +141,8 @@ void SKIP_print_persistent_size() {
   // Not implemented
 }
 
-uint32_t SKIP_get_persistent_size() {
-  return (uint32_t)bump_pointer;
+int64_t SKIP_get_persistent_size() {
+  return (int64_t)bump_pointer;
 }
 
 void SKIP_time() {

--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1664,6 +1664,9 @@ native fun shouldGC(Obstack): UInt32;
 @cpp_extern("SKIP_print_persistent_size")
 native fun printPersistentSize(): void;
 
+@cpp_extern("SKIP_get_persistent_size")
+native fun getPersistentSize(): Int;
+
 fun gContextInit(context: Context, fork: ?String = None()): void {
   invariant(fork.isNone(), "Init can only be used to init main context");
   gContextsInit(Contexts(context))

--- a/skipruntime-ts/addon/src/fromjs.cc
+++ b/skipruntime-ts/addon/src/fromjs.cc
@@ -204,6 +204,14 @@ void SkipRuntime_deleteService(uint32_t serviceId) {
   CallJSVoidFunction(env, externFunctions, "SkipRuntime_deleteService", args);
 }
 
+CJObject SkipRuntime_callGCConfigProvider() {
+  Napi::Env env = kExternFunctions.Env();
+  Napi::Object externFunctions = kExternFunctions.Value();
+  std::vector<napi_value> args = {};
+  return CallJSFunction(env, externFunctions,
+                        "SkipRuntime_callGCConfigProvider", args);
+}
+
 double SkipRuntime_ServiceDefinition__subscribe(uint32_t serviceId,
                                                 char* collection,
                                                 char* supplier, char* sessionId,

--- a/skipruntime-ts/addon/src/tojs.cc
+++ b/skipruntime-ts/addon/src/tojs.cc
@@ -58,6 +58,7 @@ double SkipRuntime_Runtime__abortFork();
 uint32_t SkipRuntime_Runtime__forkExists(char* input);
 CJSON SkipRuntime_Runtime__reload(SKService service);
 double SkipRuntime_Runtime__closeResourceStreams(CJArray streams);
+int64_t SkipRuntime_getSkipPersistentSize();
 }
 
 using skbinding::AddFunction;
@@ -777,6 +778,16 @@ Napi::Value CloseResourceStreamsOfRuntime(const Napi::CallbackInfo& info) {
   return result;
 }
 
+Napi::Value GetSkipPersistentSize(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::Value result;
+  NatTryCatch(env, [&result, env](Napi::Env) {
+    int64_t skresult = SkipRuntime_getSkipPersistentSize();
+    result = Napi::Number::New(env, skresult);
+  });
+  return result;
+}
+
 /* Assemble the binding object exposed to JS. */
 
 Napi::Value GetToJSBinding(const Napi::CallbackInfo& info) {
@@ -850,7 +861,8 @@ Napi::Value GetToJSBinding(const Napi::CallbackInfo& info) {
   AddFunction(env, binding, "SkipRuntime_Runtime__reload", ReloadOfRuntime);
   AddFunction(env, binding, "SkipRuntime_Runtime__closeResourceStreams",
               CloseResourceStreamsOfRuntime);
-
+  AddFunction(env, binding, "SkipRuntime_getSkipPersistentSize",
+              GetSkipPersistentSize);
   return binding;
 }
 

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -585,6 +585,26 @@ export type NamedInputDefinitions = {
 };
 
 /**
+ * Configuration for the resource garbage collector.
+ * Returned by SkipService.gcConfig; all fields are optional and any
+ * unspecified field keeps its current value.
+ */
+export interface GCConfig {
+  enabled?: boolean;
+  /**
+   * How long (ms) a resource may stay queued before collection. 0 collects
+   * almost immediately; a negative value disables time-based eviction.
+   */
+  ttlMillis?: number;
+  /**
+   * Cap on the number of queued entries; oldest are evicted past the cap.
+   * null or a negative value means no cap; 0 evicts the whole queue each sweep.
+   */
+  maxGarbageSize?: number | null;
+  logsEnabled?: boolean;
+}
+
+/**
  * A Skip reactive service encapsulating a reactive computation.
  *
  * A reactive Skip service is defined by a class implementing this `SkipService` interface.
@@ -657,6 +677,11 @@ export interface SkipService<
    * @returns Reactive collections accessible to the resources.
    */
   createGraph(inputCollections: Inputs, context: Context): ResourceInputs;
+  /**
+   * Optional garbage-collection configuration provider.
+   * Called each time the runtime needs the current GC config.
+   */
+  gcConfig?: () => GCConfig;
 }
 
 /**

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -193,6 +193,9 @@ export interface FromBinding {
     streams: Pointer<Internal.CJArray<Internal.CJString>>,
   ): Handle<Error>;
 
+  // Get internal palloc size, used in the stress-tester
+  SkipRuntime_getSkipPersistentSize(): bigint;
+
   // Reducer
 
   SkipRuntime_createReducer<K1 extends Json, V1 extends Json>(

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -39,6 +39,7 @@ import {
   type Watermark,
   type ExternalService,
   InputDefinition,
+  type GCConfig,
 } from "./api.js";
 
 import {
@@ -703,6 +704,24 @@ export class ServiceInstance {
   }
 
   /**
+   * Returns the size in bytes of Skip's persistent memory.
+   *
+   * This measures the memory used by Skip's internal allocator.
+   * Useful for detecting memory leaks in the
+   * runtime. Actually used as the memory metric for the stress-tester
+   *
+   * @returns The persistent memory size in bytes.
+   */
+  getSkipPersistentSize(): number {
+    this.refs.setFork(this.forkName);
+    return Number(
+      this.refs.runWithGC(() => {
+        return this.refs.binding.SkipRuntime_getSkipPersistentSize();
+      }),
+    );
+  }
+
+  /**
    * Initiate reactive subscription on a resource instance
    * @param resourceInstanceId - the resource instance identifier
    * @param notifier - the object containing subscription callbacks
@@ -985,6 +1004,7 @@ export class ToBinding {
   private initializing: boolean;
   readonly handles: Handles;
   changes: Nullable<Handle<ChangeManager>>;
+  private gcConfigProvider: Nullable<() => GCConfig>;
 
   constructor(
     public binding: FromBinding,
@@ -997,6 +1017,7 @@ export class ToBinding {
     this.forkName = null;
     this.changes = null;
     this.initializing = false;
+    this.gcConfigProvider = null;
   }
 
   register<T>(v: T): Handle<T> {
@@ -1029,6 +1050,14 @@ export class ToBinding {
 
   SkipRuntime_getChangeManager(): number {
     return this.changes ?? 0;
+  }
+
+  SkipRuntime_callGCConfigProvider(): Pointer<Internal.CJObject> {
+    const skjson = this.getJsonConverter();
+    const config: GCConfig = this.gcConfigProvider
+      ? this.gcConfigProvider()
+      : {};
+    return skjson.exportJSON(config as JsonObject);
   }
 
   setFork(name: Nullable<string>): void {
@@ -1379,6 +1408,7 @@ export class ToBinding {
     const uuid = crypto.randomUUID();
     this.fork(uuid);
     const definition = new ServiceDefinition(service);
+    this.gcConfigProvider = service.gcConfig ?? null;
     const skservicehHdl = this.handles.register(definition);
     try {
       this.initializing = true;

--- a/skipruntime-ts/examples/stress-tests/gc-stress.ts
+++ b/skipruntime-ts/examples/stress-tests/gc-stress.ts
@@ -1,0 +1,374 @@
+import type {
+  AnySkipService,
+  EagerCollection,
+  Json,
+  Mapper,
+  Resource,
+  ServiceInstance,
+  Values,
+} from "@skipruntime/core";
+import { InputDefinition } from "@skipruntime/core";
+import { initService } from "@skipruntime/native";
+
+// Service definition
+
+type StressInputs = { input: EagerCollection<string, number> };
+
+class StressResource implements Resource<StressInputs> {
+  private readonly value: number;
+
+  constructor(params: Json) {
+    const v = (params as { value: number }).value;
+    this.value = v;
+  }
+
+  instantiate(cs: StressInputs): EagerCollection<string, number> {
+    void this.value;
+    return cs.input;
+  }
+}
+
+class IdentityMapper implements Mapper<string, number, string, number> {
+  mapEntry(key: string, values: Values<number>): Iterable<[string, number]> {
+    const out: [string, number][] = [];
+    for (const v of values) out.push([key, v]);
+    return out;
+  }
+}
+
+class StressResourceWithMap implements Resource<StressInputs> {
+  private readonly value: number;
+
+  constructor(params: Json) {
+    this.value = (params as { value: number }).value;
+  }
+
+  instantiate(cs: StressInputs): EagerCollection<string, number> {
+    void this.value;
+    return cs.input.map(IdentityMapper);
+  }
+}
+
+class StressResourceWithNMaps implements Resource<StressInputs> {
+  private readonly value: number;
+  private readonly n: number;
+
+  constructor(params: Json) {
+    const obj = params as { value: number; n: number };
+    this.value = obj.value;
+    this.n = obj.n;
+  }
+
+  instantiate(cs: StressInputs): EagerCollection<string, number> {
+    void this.value;
+    let result = cs.input;
+    for (let i = 0; i < this.n; i++) {
+      result = result.map(IdentityMapper);
+    }
+    return result;
+  }
+}
+
+let runtimeGcLogs = false;
+
+const stressService: AnySkipService = {
+  inputs: { input: new InputDefinition() },
+  resources: {
+    stress: StressResource,
+    stressWithMap: StressResourceWithMap,
+    stressWithNMaps: StressResourceWithNMaps,
+  },
+  createGraph: (inputs: StressInputs) => inputs,
+  gcConfig: () => ({
+    enabled: true,
+    ttlMillis: 30_000,
+    maxGarbageSize: 100,
+    logsEnabled: runtimeGcLogs,
+  }),
+};
+
+// CLI arg parsing
+
+type Options = {
+  full: boolean;
+  trace: boolean;
+  gcLogs: boolean;
+};
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  const opts: Options = { full: false, trace: false, gcLogs: false };
+  for (const arg of args) {
+    if (arg === "-f" || arg === "--full") opts.full = true;
+    else if (arg === "--trace") opts.trace = true;
+    else if (arg === "--gclogs") opts.gcLogs = true;
+    else if (arg === "-h" || arg === "--help") {
+      console.log("Usage: gc-stress [options]");
+      console.log("  -f, --full     Run long, exhaustive tests");
+      console.log("      --trace    Print intermediate memory measurements");
+      console.log("      --gclogs   Enable internal GC logs");
+      console.log("  -h, --help     Show this help");
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+// Measurement and slope calculation
+
+type Point = { cycle: number; skipMem: number };
+
+type TestResult = {
+  name: string;
+  cycles: number;
+  startMem: number;
+  endMem: number;
+  minStable: number;
+  maxStable: number;
+  avgStable: number;
+  slope: number;
+  threshold: number;
+  passed: boolean;
+  durationSec: number;
+};
+
+// Least squares linear regression. Returns slope in y-units per x-unit.
+function linearSlope(points: Point[]): number {
+  const n = points.length;
+  if (n < 2) return 0;
+  const meanX = points.reduce((s, p) => s + p.cycle, 0) / n;
+  const meanY = points.reduce((s, p) => s + p.skipMem, 0) / n;
+  let num = 0,
+    den = 0;
+  for (const p of points) {
+    num += (p.cycle - meanX) * (p.skipMem - meanY);
+    den += (p.cycle - meanX) * (p.cycle - meanX);
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+function fmtBytes(n: number): string {
+  if (Math.abs(n) >= 1024 * 1024) return (n / 1024 / 1024).toFixed(2) + " MB";
+  if (Math.abs(n) >= 1024) return (n / 1024).toFixed(2) + " KB";
+  return n.toFixed(0) + " B";
+}
+
+// Test runner
+
+async function runMemoryTest(
+  service: ServiceInstance,
+  testName: string,
+  resourceName: string,
+  resourceParams: (i: number) => Json,
+  cycles: number,
+  threshold: number,
+  opts: Options,
+): Promise<TestResult> {
+  const startTime = Date.now();
+  const points: Point[] = [];
+  const numMeasurements = 20;
+  const measureInterval = Math.max(1, Math.floor(cycles / numMeasurements));
+
+  const startMem = service.getSkipPersistentSize();
+  points.push({ cycle: 0, skipMem: startMem });
+
+  if (opts.trace) {
+    console.log(`  [${testName}] cycle 0: skipMem=${fmtBytes(startMem)}`);
+  }
+
+  for (let i = 0; i < cycles; i++) {
+    const uuid = `${testName}-${i}`;
+    await service.instantiateResource(uuid, resourceName, resourceParams(i));
+    service.closeResourceInstance(uuid);
+
+    if ((i + 1) % measureInterval === 0) {
+      const mem = service.getSkipPersistentSize();
+      points.push({ cycle: i + 1, skipMem: mem });
+      if (opts.trace) {
+        console.log(`  [${testName}] cycle ${i + 1}: skipMem=${fmtBytes(mem)}`);
+      }
+    }
+  }
+
+  const endMem = service.getSkipPersistentSize();
+  const lastPoint = points[points.length - 1];
+  if (lastPoint && lastPoint.cycle !== cycles) {
+    points.push({ cycle: cycles, skipMem: endMem });
+  }
+
+  // Ignore first 10% to skip warmup oscillations
+  const skipCount = Math.floor(points.length * 0.1);
+  const stablePoints = points.slice(skipCount);
+  const slope = linearSlope(stablePoints);
+
+  const durationSec = (Date.now() - startTime) / 1000;
+
+  // Compute stats on the stable phase (post-warmup)
+  const stableMems = stablePoints.map((p) => p.skipMem);
+  const minStable = Math.min(...stableMems);
+  const maxStable = Math.max(...stableMems);
+  const avgStable = stableMems.reduce((s, m) => s + m, 0) / stableMems.length;
+
+  return {
+    name: testName,
+    cycles,
+    startMem,
+    endMem,
+    minStable,
+    maxStable,
+    avgStable,
+    slope,
+    threshold,
+    passed: Math.abs(slope) <= threshold,
+    durationSec,
+  };
+}
+
+function printResult(result: TestResult): void {
+  const symbol = result.passed ? "✓" : "✗";
+  const status = result.passed ? "PASS" : "FAIL";
+
+  let analysis: string;
+  if (result.passed) {
+    analysis = "stable memory usage, oscillates within a fixed range";
+  } else {
+    const kbPer1k = (result.slope * 1000) / 1024;
+    analysis = `linear growth of ~${result.slope.toFixed(0)} bytes/cycle (~${kbPer1k.toFixed(1)} KB per 1000 cycles)`;
+  }
+
+  console.log(`[${result.name}]`);
+  console.log(`  cycles:        ${result.cycles}`);
+  console.log(
+    `  initial mem:   ${fmtBytes(result.startMem)} (before any operations)`,
+  );
+  console.log(
+    `  stable mem:    min=${fmtBytes(result.minStable)}, max=${fmtBytes(result.maxStable)}, avg=${fmtBytes(result.avgStable)} (during operations)`,
+  );
+  console.log(`  final mem:     ${fmtBytes(result.endMem)}`);
+  console.log(
+    `  slope:         ${result.slope >= 0 ? "+" : ""}${result.slope.toFixed(2)} bytes/cycle (threshold: ±${result.threshold} bytes/cycle)`,
+  );
+  console.log(`  analysis:      ${analysis}`);
+  console.log(`  duration:      ${result.durationSec.toFixed(1)}s`);
+  console.log(`  RESULT:        ${status} ${symbol}`);
+  console.log("");
+}
+
+// Main
+
+async function main(): Promise<void> {
+  const opts = parseArgs();
+
+  const numTests = opts.full ? 3 : 2;
+  const estimatedDuration = opts.full ? "3-5 minutes" : "30-60 seconds";
+
+  console.log(
+    "==================================================================",
+  );
+  console.log(
+    `gc-stress: regression test for Skip memory leaks${opts.full ? " (full mode)" : ""}`,
+  );
+  console.log(
+    "==================================================================",
+  );
+  console.log("");
+  console.log(
+    `Running ${numTests} test${numTests > 1 ? "s" : ""}, estimated duration: ${estimatedDuration}.`,
+  );
+  if (!opts.trace) {
+    console.log(
+      "Tests run silently. Use --trace to see intermediate measurements.",
+    );
+  }
+  console.log("");
+
+  runtimeGcLogs = opts.gcLogs;
+  const service = await initService(stressService);
+
+  const results: TestResult[] = [];
+  const totalStart = Date.now();
+
+  // ---- Default tests ----
+
+  const readsLeakCycles = opts.full ? 200_000 : 30_000;
+  results.push(
+    await runMemoryTest(
+      service,
+      "instantiate-close-no-map",
+      "stress",
+      (i) => ({ value: i }),
+      readsLeakCycles,
+      100,
+      opts,
+    ),
+  );
+
+  const deletedDirCycles = opts.full ? 200_000 : 30_000;
+  results.push(
+    await runMemoryTest(
+      service,
+      "instantiate-close-with-map",
+      "stressWithMap",
+      (i) => ({ value: i }),
+      deletedDirCycles,
+      100,
+      opts,
+    ),
+  );
+
+  // ---- Full mode extra test ----
+
+  if (opts.full) {
+    results.push(
+      await runMemoryTest(
+        service,
+        "instantiate-close-with-5-maps",
+        "stressWithNMaps",
+        (i) => ({ value: i, n: 5 }),
+        200_000,
+        500, // higher threshold for stacked maps (more allocations, more variance)
+        opts,
+      ),
+    );
+  }
+
+  // ---- Results ----
+
+  console.log("");
+  console.log(
+    "==================================================================",
+  );
+  console.log("Results");
+  console.log(
+    "==================================================================",
+  );
+  console.log("");
+
+  for (const result of results) {
+    printResult(result);
+  }
+
+  const passed = results.filter((r) => r.passed).length;
+  const total = results.length;
+  const totalDuration = (Date.now() - totalStart) / 1000;
+  const overallPass = passed === total;
+
+  console.log(
+    "==================================================================",
+  );
+  console.log(
+    `Overall: ${overallPass ? "PASS ✓" : "FAIL ✗"} (${passed}/${total} tests passed) in ${totalDuration.toFixed(1)}s`,
+  );
+  console.log(
+    "==================================================================",
+  );
+
+  await service.close();
+
+  process.exit(overallPass ? 0 : 1);
+}
+
+main().catch((err: unknown) => {
+  console.error("[gc-stress] fatal error:", err);
+  process.exit(2);
+});

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -1,7 +1,5 @@
 module SkipRuntime;
 
-const kGarbageMillis: Int = 30000;
-
 class ReadInCreatorException() extends Exception {
   fun getMessage(): String {
     "A collection cannot be read in the function that creates it."
@@ -32,6 +30,26 @@ class Params(json: SKJSON.CJSON) extends SKStore.File uses Orderable {
 class ResourceCollections(
   value: SKStore.EHandle<SKStore.SID, ResourceInfo>,
 ) extends SKStore.File
+/**
+ * Default configuration of the resource garbage collector.
+ * - enabled: when false, sweeps (TTL expiration and capacity
+ *   eviction) are skipped.
+ * - ttlMillis: how long a resource may stay in the garbage queue before
+ *   being collected (default 30s). 0 collects almost immediately; a
+ *   negative value disables time-based eviction (kept raw in the config and
+ *   neutralized at the sweep, since the field is not optional).
+ * - maxGarbageSize: optional cap on the number of entries in the garbage
+ *   queue. When exceeded, the oldest entries are evicted on the next sweep.
+ *   null or a negative value means no cap (negative is normalized to None at
+ *   parse time); 0 evicts the whole queue on every sweep.
+ * - logsEnabled: when true, the GC emits print_debug traces on what it does.
+ */
+class GCConfig{
+  enabled: Bool = true,
+  ttlMillis: Int = 30000,
+  maxGarbageSize: ?Int = Some(100),
+  logsEnabled: Bool = false,
+} extends SKStore.File
 
 class ServiceDefinition(runId: String, service: Service) extends SKStore.File
 
@@ -104,7 +122,10 @@ fun buildResourcesGraph(
     context,
     dirname.sub("idbyresource"),
     (_c, writer, key, it) ~> {
-      writer.set(it.first, SKStore.StringFile(key.value));
+      it.next() match {
+      | Some(first) -> writer.set(first, SKStore.StringFile(key.value))
+      | None() -> void
+      }
     },
   );
   availablesHdl = idbyresourceHdl.map(
@@ -113,8 +134,6 @@ fun buildResourcesGraph(
     context,
     kResourceAvailablesDir,
     (_c, writer, key, _it) ~> {
-      // map to ignore array changes
-      // to prevent recompute on each add/remove session
       writer.set(key, SKStore.IntFile(1))
     },
   );
@@ -1128,7 +1147,111 @@ fun getReactiveResource(
   graphHdl.get(context, definition);
 }
 
+// Garbage Collector
+
+fun getSkipPersistentSize(): Int {
+  SKStore.getPersistentSize()
+}
+
+@cpp_extern("SkipRuntime_callGCConfigProvider")
+native fun callGCConfigProvider(): SKJSON.CJObject;
+
+// Read the current GC config from the user-provided lambda on every sweep.
+// This FFI round-trip to JS is intentional: it lets the config react to the
+// environment in real time. Accepted cost.
+fun getGCConfig(context: mutable SKStore.Context): GCConfig {
+  _ = context;
+  try {
+    parseGCConfig(callGCConfigProvider())
+  } catch {
+  | _ -> GCConfig{}
+  }
+}
+
+class GCConfigParseException(
+  field: String,
+  expected: String,
+) extends .Exception {
+  fun getMessage(): String {
+    `GCConfig: invalid type for field '${this.field}', expected ${
+      this.expected
+    }`
+  }
+}
+
+// Parses a partial GCConfig received via FFI as a CJObject.
+// Unspecified fields use defaults.
+// Fields with the wrong type cause an exception.
+// Unknown fields are ignored.
+fun parseGCConfig(partial: SKJSON.CJObject): GCConfig {
+  default = GCConfig{};
+  partial match {
+  | SKJSON.CJObject(fields) ->
+    enabled = default.enabled;
+    ttlMillis = default.ttlMillis;
+    maxGarbageSize = default.maxGarbageSize;
+    logsEnabled = default.logsEnabled;
+    for (key => value in fields) {
+      key match {
+      | "enabled" ->
+        value match {
+        | SKJSON.CJBool(b) -> !enabled = b
+        | _ -> throw GCConfigParseException("enabled", "boolean")
+        }
+      | "ttlMillis" ->
+        value match {
+        | SKJSON.CJInt(n) -> !ttlMillis = n
+        | SKJSON.CJFloat(n) -> !ttlMillis = n.toInt()
+        | _ -> throw GCConfigParseException("ttlMillis", "number")
+        }
+      | "maxGarbageSize" ->
+        value match {
+        | SKJSON.CJNull() -> !maxGarbageSize = None()
+        | SKJSON.CJInt(n) ->
+          !maxGarbageSize = if (n < 0) None() else {
+            Some(n) // negative = unbounded
+          }
+        | SKJSON.CJFloat(n) ->
+          m = n.toInt();
+          !maxGarbageSize = if (m < 0) None() else Some(m)
+        | _ -> throw GCConfigParseException("maxGarbageSize", "number or null")
+        }
+      | "logsEnabled" ->
+        value match {
+        | SKJSON.CJBool(b) -> !logsEnabled = b
+        | _ -> throw GCConfigParseException("logsEnabled", "boolean")
+        }
+      | _ ->
+        void // unknown field, tolerated
+      }
+    };
+    GCConfig{enabled, ttlMillis, maxGarbageSize, logsEnabled}
+  }
+}
+
+// Helper to print the garbage collector's logs if those are enabled
+fun gcLog(config: GCConfig, msg: String): void {
+  if (config.logsEnabled) {
+    print_debug("[GC] " + msg)
+  }
+}
+
+// Sweeps the resource garbage collector queue, destroying every resource
+// whose TTL has expired.
+// Called from subscribe, createReactiveResource, and updateContext.
 fun checkGarbage(context: mutable SKStore.Context): void {
+  // Read the current GC config in the user-given lambda passed by
+  // TypeScript.
+  config = getGCConfig(context);
+
+  // Skip the sweep entirely when the GC is disabled.
+  if (!config.enabled) {
+    gcLog(config, "disabled, sweep skipped");
+    return void
+  };
+
+  // - garbageHdl: tombstones (session id -> orphan timestamp)
+  // - resourceHdl: active resource definitions (session id -> ResourceDef)
   garbageHdl = SKStore.EHandle(
     SKStore.SID::keyType,
     SKStore.IntFile::type,
@@ -1139,20 +1262,77 @@ fun checkGarbage(context: mutable SKStore.Context): void {
     ResourceDef::type,
     kResourceSessionDir,
   );
+
+  // get and freeze the current time once so every comparison in the sweep
+  // uses the same reference timestamp.
   time = Time.time_ms();
+
+  // Collect expired session ids first, destroy them in a second pass.
+  // Splitting the two passes avoids mutating the directory while iterating.
+  // A negative ttl disables time-based eviction: entries never expire.
   destroyed = mutable Vector[];
-  garbageHdl.items(context).each(kf -> {
-    kf.i1.next().each(f -> {
-      suppressed = f.value;
-      if (time - suppressed > kGarbageMillis) {
-        key = kf.i0;
-        destroyed.push(key);
-        resourceHdl.writeArray(context, key, Array[]);
-      }
-    })
-  });
+  if (config.ttlMillis >= 0) {
+    garbageHdl.items(context).each(kf -> {
+      kf.i1.next().each(f -> {
+        suppressed = f.value;
+        if (time - suppressed > config.ttlMillis) {
+          key = kf.i0;
+          destroyed.push(key);
+          resourceHdl.writeArray(context, key, Array[]);
+        }
+      })
+    });
+  };
+
+  // Erase the tombstones of everything we just destroyed.
   destroyed.each(key -> garbageHdl.writeArray(context, key, Array[]));
-  if (!destroyed.isEmpty()) context.update();
+
+  // Garbage max size eviction: if a max size is set in the config
+  // and the queue exceeds it, destroy the oldest entries (by creation timestamp)
+  // until we are back at the cap. Collect all entries, sort them by timestamp,
+  // take the K oldest, and remove them in a single pass.
+  // A negative size disables size-based eviction: entries never capacity-evicted.
+  config.maxGarbageSize match {
+  | Some(maxSize) ->
+    excess = garbageHdl.size(context) - maxSize;
+    if (excess > 0) {
+      // Snapshot the queue as (sid, timestamp) pairs.
+      entries = mutable Vector<(SKStore.SID, Int)>[];
+      garbageHdl.items(context).each(kf -> {
+        kf.i1.next().each(f -> {
+          entries.push((kf.i0, f.value))
+        })
+      });
+      // Oldest first
+      entries.sortBy(e ~> e.i1);
+      // Evict the K oldest
+      entries.take(excess).each(entry -> {
+        sid = entry.i0;
+        destroyed.push(sid);
+        resourceHdl.writeArray(context, sid, Array[]);
+        garbageHdl.writeArray(context, sid, Array[]);
+      })
+    }
+  | None() -> void
+  };
+
+  // Notify SKStore that the context changed, but only if we actually
+  // destroyed something.
+  if (!destroyed.isEmpty()) {
+    context.update();
+    gcLog(
+      config,
+      "sweep done | destroyed=" +
+        destroyed.size().toString() +
+        " | queue_size=" +
+        garbageHdl.size(context).toString(),
+    );
+    // Clear read paths accumulated at root level during instantiate/close.
+    // These paths are tracked by reactive mappers via save/restore, but
+    // root-level reads (in createReactiveResource and closeReactiveResource)
+    // leak otherwise.
+    context.!reads = SortedSet[];
+  };
 }
 
 fun updateContext(context: mutable SKStore.Context): void {

--- a/skipruntime-ts/skiplang/core/src/Utils.sk
+++ b/skipruntime-ts/skiplang/core/src/Utils.sk
@@ -3,6 +3,7 @@ module SkipRuntime;
 const kSessionDir: SKStore.DirName = SKStore.DirName::create(
   "/sk_prv/sessions/",
 );
+
 const kTokenDir: SKStore.DirName = SKStore.DirName::create("/sk_prv/tokens/");
 const kGraphDir: SKStore.DirName = SKStore.DirName::create("/sk_prv/graph/");
 const kResourceSessionDir: SKStore.DirName = SKStore.DirName::create(

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -772,6 +772,11 @@ fun closeResourceStreamOfRuntime(streams: SKJSON.CJArray): Float {
   }
 }
 
+@export("SkipRuntime_getSkipPersistentSize")
+fun getSkipPersistentSizeOfRuntime(): Int {
+  getSkipPersistentSize()
+}
+
 /************ Context ****************/
 
 @export("SkipRuntime_Context__createLazyCollection")

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -202,6 +202,7 @@ export interface FromWasm {
     streams: ptr<Internal.CJArray<Internal.CJString>>,
   ): Handle<Error>;
 
+  SkipRuntime_getSkipPersistentSize(): bigint;
   // Reducer
 
   SkipRuntime_createReducer<K1 extends Json, V1 extends Json>(
@@ -240,6 +241,7 @@ interface ToWasm {
   SkipRuntime_getContext(): Nullable<ptr<Internal.Context>>;
   SkipRuntime_getFork(): Nullable<ptr<Internal.String>>;
   SkipRuntime_getChangeManager(): number;
+  SkipRuntime_callGCConfigProvider(): ptr<Internal.CJObject>;
 
   // Mapper
 
@@ -707,6 +709,10 @@ export class WasmFromBinding implements FromBinding {
     );
   }
 
+  SkipRuntime_getSkipPersistentSize(): bigint {
+    return this.fromWasm.SkipRuntime_getSkipPersistentSize();
+  }
+
   SkipRuntime_createReducer<K1 extends Json, V1 extends Json>(
     ref: Handle<HandlerInfo<Reducer<K1, V1>>>,
   ): Pointer<Internal.Reducer> {
@@ -805,6 +811,10 @@ class LinksImpl implements Links {
 
   getChangeManager() {
     return this.tobinding.SkipRuntime_getChangeManager();
+  }
+
+  callGCConfigProvider(): ptr<Internal.CJObject> {
+    return toPtr(this.tobinding.SkipRuntime_callGCConfigProvider());
   }
 
   // Mapper
@@ -1126,6 +1136,8 @@ class Manager implements ToWasmManager {
     toWasm.SkipRuntime_getContext = links.getContext.bind(links);
     toWasm.SkipRuntime_getFork = links.getFork.bind(links);
     toWasm.SkipRuntime_getChangeManager = links.getChangeManager.bind(links);
+    toWasm.SkipRuntime_callGCConfigProvider =
+      links.callGCConfigProvider.bind(links);
 
     // Mapper
 


### PR DESCRIPTION
Adds a configurable GC sweep mechanism for orphan reactive resources, exposes Skip persistent memory (from palloc.c) usage as a metric, fixes a separate memory leak in the reactive read tracking, and ships a regression test that detects future memory leaks.

GC configuration
- gcConfig lambda on SkipService, read each sweep via the
  SkipRuntime_callGCConfigProvider FFI bridge so the config can react to the
  environment in real time
- fields: enabled, ttlMillis, maxGarbageSize, logsEnabled
- defaults change: maxGarbageSize now caps the queue at 100 (previously
  unbounded, TTL-only). Services that don't provide gcConfig get this cap.
- negative ttlMillis or maxGarbageSize disables the corresponding eviction
  criterion (never expires / unbounded)

Memory leak fix
- Context.reads is cleared at the end of each sweep; reads accumulated
  indefinitely otherwise, leaking memory.

Metrics and tooling
- getSkipPersistentSize exposed through the FFI chain as the memory metric
- stress test (gc-stress.ts) with a linear-regression slope check
- Makefile test-mem-stress target

Notes
- the instantiate-close-with-map sub-test fails on this branch alone;
it requires the fix-deleteddir-leak PR for the DeletedDir cleanup, and
passes once both are merged.
Therefore, the stress test (gc-stress.ts) isn't automatically called by
the CI yet because it would fail. I'll follow up to add that.


-----> Rebased on main (1813f196). Adapted to the type-safe service API from
c3405c93: gc-stress.ts now uses AnySkipService with inputs / InputDefinition
instead of the former two-parameter SkipService with initialData.