### PR TITLE
ci: extend code analysis (CodeQL actions + security-extended + actionlint)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,26 @@
+name: actionlint
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install and run actionlint
+        shell: bash
+        run: |
+          bash <(curl --proto '=https' --tlsv1.2 -sSf \
+            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash)
+          ./actionlint -color

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
           build-mode: manual
         - language: java-kotlin
           build-mode: manual
+        - language: actions
+          build-mode: none
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,6 +65,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        queries: security-extended
 
     - name: Build C runtime (manual c-cpp)
       if: matrix.language == 'c-cpp'


### PR DESCRIPTION
## Summary
Three small commits extending CI code analysis coverage:

1. **`ci(codeql): add actions language`** — enables CodeQL scanning of GitHub Actions workflow files. Catches script-injection via untrusted inputs in `run:` blocks, missing permissions, and similar workflow-security issues.
2. **`ci(codeql): use security-extended query suite`** — switches from the default query suite to `security-extended`, which adds lower-precision queries that still turn up real issues. Easy to scope per-language later if any one becomes too noisy.
3. **`ci: add actionlint workflow`** — adds [actionlint](https://github.com/rhysd/actionlint) as a separate workflow that runs on changes under `.github/workflows/`. Catches what CodeQL doesn't: deprecated syntax, typos in event/job/step keys, shellcheck on `run:` blocks, glob/regex mistakes.

## Test plan
- [ ] CodeQL workflow runs successfully for all 5 languages (now includes `actions`)
- [ ] actionlint workflow runs and lints cleanly (verified locally)
- [ ] Any new alerts surfaced by `security-extended` get triaged separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)