### PR TITLE
Fix code scanning alert no. 25: world-writable file creation

### DIFF
--- a/skiplang/prelude/runtime/runtime64_specific.cpp
+++ b/skiplang/prelude/runtime/runtime64_specific.cpp
@@ -501,7 +501,18 @@ int64_t SKIP_numThreads() {
 void SKIP_string_to_file(char* str, char* file) {
   sk_string_check_c_safe(file);
 
-  FILE* out = fopen(file, "w");
+  int fd = open(file, O_WRONLY | O_CREAT | O_TRUNC,
+                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  if (fd < 0) {
+    perror("open");
+    exit(EXIT_FAILURE);
+  }
+  FILE* out = fdopen(fd, "w");
+  if (out == NULL) {
+    close(fd);
+    perror("fdopen");
+    exit(EXIT_FAILURE);
+  }
   size_t size = SKIP_String_byteSize(str);
   while (size != 0) {
     size_t written = fwrite(str, 1, size, out);


### PR DESCRIPTION
## Summary
- Fixes [code scanning alert #25](https://github.com/SkipLabs/skip/security/code-scanning/25) (`cpp/world-writable-file-creation`).
- `SKIP_string_to_file` used `fopen(file, "w")`, which creates files with mode `0666` filtered only by the process `umask`. Replaced with `open(O_WRONLY | O_CREAT | O_TRUNC, 0644)` + `fdopen()` so the file is never world-writable regardless of umask, and added the missing error handling on the create/open paths.

## Test plan
- [ ] CI green (CodeQL alert 25 should be marked fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)