### PR TITLE
docs: clean up staleness across READMEs, user docs, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ You can also join our [Discord](https://discord.gg/bsnXyw2F9P) to ask any questi
 
 ## License
 
-SKDB is [MIT licensed](./LICENSE).
+Skip is [MIT licensed](./LICENSE).

--- a/examples/blogger/www/README.md
+++ b/examples/blogger/www/README.md
@@ -1,4 +1,4 @@
-# www-vue
+# blogger-vue
 
 ## Project setup
 
@@ -6,24 +6,30 @@
 npm install
 ```
 
-### Compiles and hot-reloads for development
+### Run the development server (hot-reload)
 
 ```
-npm run serve
+npm run dev
 ```
 
-### Compiles and minifies for production
+### Build for production
 
 ```
 npm run build
 ```
 
-### Lints and fixes files
+### Preview the production build
+
+```
+npm run preview
+```
+
+### Lint
 
 ```
 npm run lint
 ```
 
-### Customize configuration
+### Configuration
 
-See [Configuration Reference](https://cli.vuejs.org/config/).
+See the [Vite configuration reference](https://vite.dev/config/).

--- a/examples/cache_invalidation/www/README.md
+++ b/examples/cache_invalidation/www/README.md
@@ -17,10 +17,13 @@ Vue.js 3 frontend for the Reactive Blogger example application, demonstrating re
 pnpm install
 
 # Development server with hot reload
-pnpm run serve
+pnpm run dev
 
 # Build for production
 pnpm run build
+
+# Preview the production build
+pnpm run preview
 
 # Lint and fix files
 pnpm run lint
@@ -56,4 +59,4 @@ eventSource.onmessage = (event) => {
 
 The application is configured to work with the Docker Compose setup. For local development, ensure the Flask API is running on the expected port.
 
-See [Vue CLI Configuration Reference](https://cli.vuejs.org/config/) for build customization options.
+See the [Vite configuration reference](https://vite.dev/config/) for build customization options.

--- a/skiplang/docs/SKStore.md
+++ b/skiplang/docs/SKStore.md
@@ -12,7 +12,6 @@ The way to create a `DirName` is by using the primitive `DirName::create`.
 A directory name must start and finish with a slash; if it doesn't, an exception is thrown.
 The names are not used directly when manipulating directories, however, they come in handy when trying to debug the state that the system is in.
 One can navigate all the reactive values using familiar primitives (such as cd, ls etc ...).
-[comment]: <> (Can they? I've never seen that in the code and wasn't aware of any interactive shell-like thing)
 
 ## Input directories
 

--- a/skipruntime-ts/server/README.md
+++ b/skipruntime-ts/server/README.md
@@ -6,7 +6,7 @@ See the [docs](https://skiplabs.io/docs/api/server) for more details.
 
 ## Installation
 
-Install directly using npm (`npm i @skipruntime/helpers`), or along with other
+Install directly using npm (`npm i @skipruntime/server`), or along with other
 components of the runtime by installing the
 [`@skiplabs/skip`](https://www.npmjs.com/package/@skiplabs/skip) meta-package
 (`npm i @skiplabs/skip`)

--- a/sql/ts/README.md
+++ b/sql/ts/README.md
@@ -3,6 +3,5 @@
 Relative to `/path/to/skdb_repo/sql/ts/` (i.e. the directory with this README
 in):
 
-TO REWRITE
-
-1. Run the CLI: `cd ../../build/packages/skdb && npm run cli -- <args>`
+1. Build: `npm run build`
+2. Run the CLI: `npm run cli -- <args>`

--- a/www/docs/client.md
+++ b/www/docs/client.md
@@ -64,7 +64,7 @@ useEffect(() => {
   stream.addEventListener("update", (e: MessageEvent<string>) => {
     const updates = JSON.parse(e.data);
     const updatedFoo = ...; // update "foo" using `updates`
-    setFoo(updatedfoo);
+    setFoo(updatedFoo);
   });
   return () => {
     stream.close();

--- a/www/docs/deploying.md
+++ b/www/docs/deploying.md
@@ -16,7 +16,7 @@ Skip is agnostic to your choice of reverse proxy, but it is important that it is
 
 You can build and run your reactive service using Docker Compose and the following `Dockerfile` to expose the necessary ports and initialize the service.
 ```
-FROM node:lts-alpine3.19
+FROM node:lts-alpine
 WORKDIR /app
 COPY package.json package.json
 RUN npm install

--- a/www/docs/externals.md
+++ b/www/docs/externals.md
@@ -178,7 +178,7 @@ The frequency of those requests is an important consideration, depending on the 
 
 ### Custom external resources/services
 
-If more control is required or your external system does not fit this form, then the `ExternalService` and `ExternalResource` interfaces both support extensions to define arbitrary logic for `subscribe`/`unsubscribe`-ing from services and `open`/`close`-ing resource.
+If more control is required or your external system does not fit this form, then the `ExternalService` interface can be extended to define arbitrary logic for `subscribe`/`unsubscribe`-ing from external resources. `PolledExternalService` is one such extension.
 
 For example, your service can keep track of open resources and combine requests to the external service if it supports batched requests, reducing request load and potentially allowing more optimized execution in the non-reactive system.
 Similarly, an external relational database may support some limited form of reactivity/listening, such as PostgreSQL's `pg_notify`; in that case, a custom Skip `ExternalService` can interpret those updates into a form suitable for use within the Skip framework.


### PR DESCRIPTION
## Summary

Full-repo audit of markdown / doc files turned up nine concrete staleness issues. Each is fixed in its own commit so review and revert are granular.

### What changed

| # | Commit | Fix |
|---|---|---|
| 1 | `docs(client)` | `setFoo(updatedfoo)` → `updatedFoo` (typo in SSE update-handler snippet) |
| 2 | `docs(server)` | Install command `npm i @skipruntime/helpers` → `@skipruntime/server` (copy-paste from helpers README) |
| 3 | `docs(readme)` | "SKDB is MIT licensed" → "Skip is MIT licensed" (legacy project name in license footer) |
| 4 | `docs(skstore)` | Dropped a `[comment]: <>` reviewer comment left in the published SKStore doc |
| 5 | `docs(examples/blogger)` | `www/README.md` retargeted at Vite (`dev: vite`) instead of Vue CLI (`npm run serve`) |
| 6 | `docs(examples/cache_invalidation)` | Same Vite migration for the `www/README.md` |
| 7 | `docs(deploying)` | `node:lts-alpine3.19` → `node:lts-alpine` so the example doesn't go stale on every Alpine bump |
| 8 | `docs(externals)` | Removed reference to the removed `ExternalResource` interface and (nonexistent) `open`/`close` methods; reframe extension story around `ExternalService` + `PolledExternalService` |
| 9 | `docs(sql/ts)` | Replaced `TO REWRITE` placeholder with the actual `npm run build` + `npm run cli` steps; old `../../build/packages/skdb` path is gone |

### What was checked but **not** changed

- All other top-level docs (`INSTALL.md`, `HACKING.md`, `CHANGELOG.md`), all `www/docs/*.md` user docs, all example top-level READMEs, all skipruntime-ts package READMEs, RFCs, and blog posts were spot-checked against current source and are accurate.
- The auto-generated `www/docs/api/` tree is `.gitignore`d at the repo root — those files are never committed and regenerate from TS source on every `www` build, so they're not part of the audit surface. (The TSDoc in `skipruntime-ts/server/src/server.ts` and elsewhere is already correct.)

## Test plan

- [ ] Spot-check each commit's diff renders as intended in the GitHub PR view
- [ ] `cd www && npm run start` and navigate to `/docs/client`, `/docs/externals`, `/docs/deploying` — confirm the rendered pages now show the fixed text
- [ ] `cd examples/blogger/www && npm install && npm run dev` works (the README now documents this)
- [ ] `cd sql/ts && npm run build && npm run cli -- --help` works (the README now documents this)
- [ ] No CI failures (only `.md` files changed; no compile/test impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
