### PR TITLE
runtime: drop debug stdout print when SKIP_CAPACITY is set

### DIFF
--- a/skiplang/prelude/runtime/palloc.c
+++ b/skiplang/prelude/runtime/palloc.c
@@ -564,9 +564,6 @@ void sk_create_mapping(char* fileName, size_t icapacity) {
   ginfo->fileName = (fileName != NULL) ? persistent_fileName : NULL;
   ginfo->contexts = NULL;
   *gid = 1;
-  if (icapacity != DEFAULT_CAPACITY) {
-    printf("CAPACITY SET TO: %ld\n", icapacity);
-  }
   *capacity = icapacity;
   *pconsts = NULL;
 


### PR DESCRIPTION
## Summary

`sk_create_mapping` in [skiplang/prelude/runtime/palloc.c:567-569](skiplang/prelude/runtime/palloc.c#L567-L569) printed `CAPACITY SET TO: <bytes>` to **stdout** for every Skip process started with a non-default capacity.

This was harmless until #1246 set `SKIP_CAPACITY` on gen2 CI jobs to avoid `MAP FAILED` OOMs. Now every Skip process emits the line, and the skdb diff tests (`test/diff/*.sql`) — which compare runtime stdout to `.expected` golden files — fail on every test.

Observed in [job 16738](https://app.circleci.com/pipelines/github/SkipLabs/skip/4522/workflows/523a19b3-8783-4f62-a2c2-3a188b0e0716/jobs/16738) (skdb on `large.gen2`, `SKIP_CAPACITY=6G` → `6442450944`):

```
CAPACITY SET TO: 6442450944
04 - test/diff/select1_views.sql (part-2):              FAILED
...
```

Repeated for ~40 diff tests. The skdb workflow has been silently broken for any PR that triggers it (most don't, because of generate_config.sh's per-package diff heuristic; this PR triggered it because it touches a `skiplang/prelude/` file).

## Fix

Remove the print. If anyone needs to confirm the runtime's capacity at startup, `/proc/self/maps` or the `--capacity` CLI flag echo are cleaner channels — stdout is reserved for program output that golden-file tests can rely on.

## Test plan

- [ ] After merge, a PR that touches `skiplang/prelude/` and triggers `skdb` should now pass.
- [ ] `compiler` and `skipruntime` (also affected, since they run with `SKIP_CAPACITY=12G` / `6G`) should remain green — they don't compare stdout, so they weren't failing visibly, but the line was still being emitted and cluttering logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)