### PR TITLE
sql/server: use Files.createTempFile for notify pipe

### DIFF
--- a/sql/server/core/src/main/kotlin/core/Skdb.kt
+++ b/sql/server/core/src/main/kotlin/core/Skdb.kt
@@ -277,13 +277,19 @@ class Skdb(val name: String, private val dbPath: String) {
       table: String,
       callback: () -> Unit,
   ) {
-    val notifyFile = File.createTempFile("notify", table)
-    // TODO: notifyFile.deleteOnExit() -- need to unsubscribe first
+    val notifyFile = Files.createTempFile("notify", table)
+    // TODO: Files.delete(notifyFile) on shutdown -- need to unsubscribe first
 
     val connection =
         blockingRun(
             ProcessBuilder(
-                ENV.skdbPath, "subscribe", table, "--data", dbPath, "--notify", notifyFile.path))
+                ENV.skdbPath,
+                "subscribe",
+                table,
+                "--data",
+                dbPath,
+                "--notify",
+                notifyFile.toString()))
 
     if (!connection.exitSuccessfully()) {
       throw RuntimeException("Notify failed")
@@ -294,7 +300,7 @@ class Skdb(val name: String, private val dbPath: String) {
     val t =
         Thread({
           while (true) {
-            val now = Files.readString(notifyFile.toPath())
+            val now = Files.readString(notifyFile)
             if (now != tick) {
               tick = now
               callback()


### PR DESCRIPTION
## Summary
- `Skdb.notify` created its temp notify file via `java.io.File.createTempFile`, which on POSIX systems produces `-rw-r--r--` — exposing the file's contents to any other local user with access to the shared tmp dir.
- Switched to `java.nio.file.Files.createTempFile`, which creates the file with `-rw-------` by default, and adjusted the two call sites that consumed it as a `File`.

Fixes the CodeQL alert [`java/local-temp-file-or-directory-information-disclosure`](https://github.com/SkipLabs/skip/security/code-scanning/28).

## Test plan
- [ ] CI green (gradle build of `sql/server:core`)
- [ ] Existing notify subscriber tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)