### PR TITLE
examples: sanitize user input in Flask log statements

### DIFF
--- a/examples/blogger/web_service/app.py
+++ b/examples/blogger/web_service/app.py
@@ -12,6 +12,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _safe_log(value):
+    """Strip CR/LF from user-controlled values to prevent log forgery."""
+    if value is None:
+        return None
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 def get_db():
     conn = psycopg2.connect(
         host="blogger_db",
@@ -66,7 +73,9 @@ def token_required(f):
             auth_header = request.headers["Authorization"]
             if auth_header.startswith("Bearer "):
                 token = auth_header.split(" ")[1]
-                logger.info(f"Token found in request: {token[:10]}...")
+                logger.info(
+                    f"Token found in request: {_safe_log(token[:10])}..."
+                )
 
         if not token:
             logger.warning("No token found in request")
@@ -96,7 +105,7 @@ def token_required(f):
 def login():
     data = request.json
     username = data.get("username")
-    logger.info(f"Login attempt for user: {username}")
+    logger.info(f"Login attempt for user: {_safe_log(username)}")
 
     with get_db() as db:
         with db.cursor() as cur:
@@ -105,7 +114,9 @@ def login():
                 (username, data.get("password")),
             )
             if cur.rowcount < 1:
-                logger.warning(f"Invalid credentials for user: {username}")
+                logger.warning(
+                    f"Invalid credentials for user: {_safe_log(username)}"
+                )
                 return jsonify({"message": "Invalid credentials"}), 401
             user = cur.fetchone()
             logger.info(f"User authenticated: {user[1]}")

--- a/examples/cache_invalidation/web_service/app.py
+++ b/examples/cache_invalidation/web_service/app.py
@@ -22,6 +22,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _safe_log(value):
+    """Strip CR/LF from user-controlled values to prevent log forgery."""
+    if value is None:
+        return None
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 def get_db():
     conn = psycopg2.connect(
         host="invalidation_db",
@@ -76,7 +83,9 @@ def token_required(f):
             auth_header = request.headers["Authorization"]
             if auth_header.startswith("Bearer "):
                 token = auth_header.split(" ")[1]
-                logger.info(f"Token found in request: {token[:10]}...")
+                logger.info(
+                    f"Token found in request: {_safe_log(token[:10])}..."
+                )
 
         if not token:
             logger.warning("No token found in request")
@@ -106,7 +115,7 @@ def token_required(f):
 def login():
     data = request.json
     username = data.get("username")
-    logger.info(f"Login attempt for user: {username}")
+    logger.info(f"Login attempt for user: {_safe_log(username)}")
 
     with get_db() as db:
         with db.cursor() as cur:
@@ -115,7 +124,9 @@ def login():
                 (username, data.get("password")),
             )
             if cur.rowcount < 1:
-                logger.warning(f"Invalid credentials for user: {username}")
+                logger.warning(
+                    f"Invalid credentials for user: {_safe_log(username)}"
+                )
                 return jsonify({"message": "Invalid credentials"}), 401
             user = cur.fetchone()
             logger.info(f"User authenticated: {user[1]}")


### PR DESCRIPTION
## Summary
- Fixes [code scanning alerts #19-24](https://github.com/SkipLabs/skip/security/code-scanning?query=is%3Aopen+rule%3Apy%2Flog-injection) (`py/log-injection`): the blogger and cache_invalidation example Flask apps logged `username` (from the request JSON body) and the JWT `token` (from the `Authorization` header) without stripping CR/LF, letting a caller forge new log lines.
- Adds a small `_safe_log` helper in each app that strips `\r`/`\n` and applies it at the three flagged call sites in each file (token prefix, login attempt, invalid credentials).

## Test plan
- [ ] CodeQL re-scan clears alerts #19-24
- [ ] Log lines still render normally for benign usernames/tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)