### PR TITLE
Bump NPM versions 0.0.21 -> 0.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6706,7 +6706,7 @@
       "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.22",
         "kafkajs": "^2.2.4"
       },
       "engines": {
@@ -6718,7 +6718,7 @@
       "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.22",
         "pg": "^8.13.1",
         "pg-format": "^1.0.4"
       },
@@ -6735,12 +6735,12 @@
       "version": "0.0.22",
       "hasInstallScript": true,
       "dependencies": {
-        "@skipruntime/core": "0.0.21"
+        "@skipruntime/core": "0.0.22"
       }
     },
     "skipruntime-ts/core": {
       "name": "@skipruntime/core",
-      "version": "0.0.21"
+      "version": "0.0.22"
     },
     "skipruntime-ts/examples": {
       "name": "skipruntime-examples",
@@ -6760,7 +6760,7 @@
       "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.22",
         "eventsource": "^2.0.2",
         "express": "^4.22.2"
       },
@@ -6775,7 +6775,7 @@
       "name": "@skiplabs/skip",
       "version": "0.0.21",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.22",
         "@skipruntime/helpers": "0.0.22",
         "@skipruntime/server": "0.0.22",
         "@skipruntime/wasm": "0.0.22"
@@ -6790,7 +6790,7 @@
       "name": "@skipruntime/server",
       "version": "0.0.22",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.22",
         "express": "^4.22.2"
       },
       "devDependencies": {
@@ -6809,7 +6809,7 @@
       "name": "@skipruntime/tests",
       "dependencies": {
         "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.22",
         "@skipruntime/helpers": "0.0.22",
         "@skipruntime/native": "0.0.22",
         "@skipruntime/wasm": "0.0.22",
@@ -6826,7 +6826,7 @@
       "name": "@skipruntime/wasm",
       "version": "0.0.22",
       "dependencies": {
-        "@skipruntime/core": "0.0.21"
+        "@skipruntime/core": "0.0.22"
       }
     },
     "sql/ts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6703,10 +6703,10 @@
     },
     "skipruntime-ts/adapters/kafka": {
       "name": "@skip-adapter/kafka",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.22",
+        "@skipruntime/core": "0.0.23",
         "kafkajs": "^2.2.4"
       },
       "engines": {
@@ -6715,10 +6715,10 @@
     },
     "skipruntime-ts/adapters/postgres": {
       "name": "@skip-adapter/postgres",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.22",
+        "@skipruntime/core": "0.0.23",
         "pg": "^8.13.1",
         "pg-format": "^1.0.4"
       },
@@ -6732,21 +6732,21 @@
     },
     "skipruntime-ts/addon": {
       "name": "@skipruntime/native",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "hasInstallScript": true,
       "dependencies": {
-        "@skipruntime/core": "0.0.22"
+        "@skipruntime/core": "0.0.23"
       }
     },
     "skipruntime-ts/core": {
       "name": "@skipruntime/core",
-      "version": "0.0.22"
+      "version": "0.0.23"
     },
     "skipruntime-ts/examples": {
       "name": "skipruntime-examples",
       "dependencies": {
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
         "better-sqlite3": "^11.7.2",
         "eventsource": "^2.0.2"
       },
@@ -6757,10 +6757,10 @@
     },
     "skipruntime-ts/helpers": {
       "name": "@skipruntime/helpers",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.22",
+        "@skipruntime/core": "0.0.23",
         "eventsource": "^2.0.2",
         "express": "^4.22.2"
       },
@@ -6773,24 +6773,24 @@
     },
     "skipruntime-ts/metapackage": {
       "name": "@skiplabs/skip",
-      "version": "0.0.21",
+      "version": "0.0.23",
       "dependencies": {
-        "@skipruntime/core": "0.0.22",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       },
       "optionalDependencies": {
-        "@skip-adapter/kafka": "0.0.22",
-        "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/native": "0.0.22"
+        "@skip-adapter/kafka": "0.0.23",
+        "@skip-adapter/postgres": "0.0.23",
+        "@skipruntime/native": "0.0.23"
       }
     },
     "skipruntime-ts/server": {
       "name": "@skipruntime/server",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "dependencies": {
-        "@skipruntime/core": "0.0.22",
+        "@skipruntime/core": "0.0.23",
         "express": "^4.22.2"
       },
       "devDependencies": {
@@ -6801,18 +6801,18 @@
         "tsx": "^4.19.3"
       },
       "optionalDependencies": {
-        "@skipruntime/native": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skipruntime/native": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       }
     },
     "skipruntime-ts/tests": {
       "name": "@skipruntime/tests",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/core": "0.0.22",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/native": "0.0.22",
-        "@skipruntime/wasm": "0.0.22",
+        "@skip-adapter/postgres": "0.0.23",
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/native": "0.0.23",
+        "@skipruntime/wasm": "0.0.23",
         "earl": "^1.3.0",
         "mocha": "^11.0.1",
         "pg": "^8.13.1"
@@ -6824,9 +6824,9 @@
     },
     "skipruntime-ts/wasm": {
       "name": "@skipruntime/wasm",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "dependencies": {
-        "@skipruntime/core": "0.0.22"
+        "@skipruntime/core": "0.0.23"
       }
     },
     "sql/ts": {

--- a/skipruntime-ts/adapters/kafka/package.json
+++ b/skipruntime-ts/adapters/kafka/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "kafkajs": "^2.2.4",
-    "@skipruntime/core": "0.0.21"
+    "@skipruntime/core": "0.0.22"
   }
 }

--- a/skipruntime-ts/adapters/kafka/package.json
+++ b/skipruntime-ts/adapters/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/kafka",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "kafkajs": "^2.2.4",
-    "@skipruntime/core": "0.0.22"
+    "@skipruntime/core": "0.0.23"
   }
 }

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "pg": "^8.13.1",
     "pg-format": "^1.0.4",
-    "@skipruntime/core": "0.0.21"
+    "@skipruntime/core": "0.0.22"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skip-adapter/postgres",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "pg": "^8.13.1",
     "pg-format": "^1.0.4",
-    "@skipruntime/core": "0.0.22"
+    "@skipruntime/core": "0.0.23"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.21"
+    "@skipruntime/core": "0.0.22"
   }
 }

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/native",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "gypfile": true,
   "type": "module",
   "exports": {
@@ -13,6 +13,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.22"
+    "@skipruntime/core": "0.0.23"
   }
 }

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/core",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",

--- a/skipruntime-ts/core/package.json
+++ b/skipruntime-ts/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/core",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -12,8 +12,8 @@
     "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
-    "@skipruntime/helpers": "0.0.22",
-    "@skipruntime/server": "0.0.22",
+    "@skipruntime/helpers": "0.0.23",
+    "@skipruntime/server": "0.0.23",
     "eventsource": "^2.0.2",
     "better-sqlite3": "^11.7.2"
   }

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/helpers",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "eventsource": "^2.0.2",
     "express": "^4.22.2",
-    "@skipruntime/core": "0.0.22"
+    "@skipruntime/core": "0.0.23"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15"

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "eventsource": "^2.0.2",
     "express": "^4.22.2",
-    "@skipruntime/core": "0.0.21"
+    "@skipruntime/core": "0.0.22"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.15"

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@skiplabs/skip",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "dependencies": {
-    "@skipruntime/core": "0.0.22",
-    "@skipruntime/server": "0.0.22",
-    "@skipruntime/helpers": "0.0.22",
-    "@skipruntime/wasm": "0.0.22"
+    "@skipruntime/core": "0.0.23",
+    "@skipruntime/server": "0.0.23",
+    "@skipruntime/helpers": "0.0.23",
+    "@skipruntime/wasm": "0.0.23"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.22",
-    "@skip-adapter/kafka": "0.0.22",
-    "@skip-adapter/postgres": "0.0.22"
+    "@skipruntime/native": "0.0.23",
+    "@skip-adapter/kafka": "0.0.23",
+    "@skip-adapter/postgres": "0.0.23"
   }
 }

--- a/skipruntime-ts/metapackage/package.json
+++ b/skipruntime-ts/metapackage/package.json
@@ -2,7 +2,7 @@
   "name": "@skiplabs/skip",
   "version": "0.0.21",
   "dependencies": {
-    "@skipruntime/core": "0.0.21",
+    "@skipruntime/core": "0.0.22",
     "@skipruntime/server": "0.0.22",
     "@skipruntime/helpers": "0.0.22",
     "@skipruntime/wasm": "0.0.22"

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -19,7 +19,7 @@
     "tsx": "^4.19.3"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.21",
+    "@skipruntime/core": "0.0.22",
     "express": "^4.22.2"
   },
   "optionalDependencies": {

--- a/skipruntime-ts/server/package.json
+++ b/skipruntime-ts/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/server",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "exports": {
     ".": "./dist/src/server.js"
@@ -19,11 +19,11 @@
     "tsx": "^4.19.3"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.22",
+    "@skipruntime/core": "0.0.23",
     "express": "^4.22.2"
   },
   "optionalDependencies": {
-    "@skipruntime/native": "0.0.22",
-    "@skipruntime/wasm": "0.0.22"
+    "@skipruntime/native": "0.0.23",
+    "@skipruntime/wasm": "0.0.23"
   }
 }

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -16,7 +16,7 @@
     "earl": "^1.3.0",
     "mocha": "^11.0.1",
     "pg": "^8.13.1",
-    "@skipruntime/core": "0.0.21",
+    "@skipruntime/core": "0.0.22",
     "@skipruntime/helpers": "0.0.22",
     "@skipruntime/native": "0.0.22",
     "@skipruntime/wasm": "0.0.22",

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -16,10 +16,10 @@
     "earl": "^1.3.0",
     "mocha": "^11.0.1",
     "pg": "^8.13.1",
-    "@skipruntime/core": "0.0.22",
-    "@skipruntime/helpers": "0.0.22",
-    "@skipruntime/native": "0.0.22",
-    "@skipruntime/wasm": "0.0.22",
-    "@skip-adapter/postgres": "0.0.22"
+    "@skipruntime/core": "0.0.23",
+    "@skipruntime/helpers": "0.0.23",
+    "@skipruntime/native": "0.0.23",
+    "@skipruntime/wasm": "0.0.23",
+    "@skip-adapter/postgres": "0.0.23"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skipruntime/wasm",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "exports": {
     ".": {
@@ -15,6 +15,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.22"
+    "@skipruntime/core": "0.0.23"
   }
 }

--- a/skipruntime-ts/wasm/package.json
+++ b/skipruntime-ts/wasm/package.json
@@ -15,6 +15,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@skipruntime/core": "0.0.21"
+    "@skipruntime/core": "0.0.22"
   }
 }


### PR DESCRIPTION
## Summary

Uniform patch bump across the published `@skipruntime/*` and `@skip-adapter/*` workspace packages, plus the `@skiplabs/skip` metapackage, with internal cross-deps updated and the root lockfile refreshed. Follows the convention from b19ed2b7c.

- `@skipruntime/core`: 0.0.21 -> 0.0.23 (catches up from the 0.0.22 alignment in the first commit, then bumped with everyone else)
- `@skipruntime/{helpers,wasm,native,server}`: 0.0.22 -> 0.0.23
- `@skip-adapter/{kafka,postgres}`: 0.0.22 -> 0.0.23
- `@skiplabs/skip` (metapackage): 0.0.21 -> 0.0.23

Split into two commits for reviewability:
1. Align `@skipruntime/core` 0.0.21 -> 0.0.22 to match the rest of the workspace.
2. Uniform 0.0.22 -> 0.0.23 bump across all published workspace packages.

Examples and other standalone consumers (`examples/*`, `packages/{dev,react}`, `sql/ts/{bun,vitejs}`) intentionally still pin to the previously-published versions; they will be updated in a follow-up after these new versions land on the registry.

## Test plan

- [ ] CI green
- [ ] `npm install` at the repo root resolves cleanly against the refreshed lockfile