### PR TITLE
Bump examples to the freshly-published package versions

### DIFF
--- a/examples/blogger/reactive_service/package-lock.json
+++ b/examples/blogger/reactive_service/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/core": "0.0.21",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skip-adapter/postgres": "0.0.23",
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.2",
@@ -258,12 +258,12 @@
       }
     },
     "node_modules/@skip-adapter/postgres": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.22.tgz",
-      "integrity": "sha512-QR0p0pEmaPy9ZarFZzB27d11UoZHGCkJY7zl9F851RNVjyxCaO69Ks+07K/F4NwgS2teIKFvDdk6nsoTO/ZNHA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@skip-adapter/postgres/-/postgres-0.0.23.tgz",
+      "integrity": "sha512-NeuvZ/eN7pGuPkasLe+2SCusOdGSwNyVOOcHbQspN/GVvyBUjs+H9d/yYNqpQUjPMIf+XlVeu41tkdvhyIInHA==",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.23",
         "pg": "^8.13.1",
         "pg-format": "^1.0.4"
       },
@@ -292,17 +292,17 @@
       "license": "MIT"
     },
     "node_modules/@skipruntime/core": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.21.tgz",
-      "integrity": "sha512-sFmH+HUfp1/A+Ixo24BuILas9rigzqgIPnLLDiJOmL1OOJZNtk5e2sH1ez8npjpMkr4tguNPf/nwOVbimU3P+A=="
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@skipruntime/core/-/core-0.0.23.tgz",
+      "integrity": "sha512-Z2redCcLTsA7h9x9dI4nCx6VAnygKf7vysERE3QRkHYIX+2356aEou+rd/gMqU2UuEOfO7ACOhpSsO8kqJDPaA=="
     },
     "node_modules/@skipruntime/helpers": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.22.tgz",
-      "integrity": "sha512-NJi11LZpg3x7OUfJJR0xANZOtRVI0dT1DtCq4kuRBfqnb9uPJzMvb24AWckgIXc/S1N5WeToQ84t0Mwg6jbGhQ==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@skipruntime/helpers/-/helpers-0.0.23.tgz",
+      "integrity": "sha512-5qjtvR9P1wtabAOHXzPAK2x9rLOobHOWYGRetbI0N1W0LiQT11t4JNf4AroLrd4neTux67xGXGIggX1SssFcBQ==",
       "license": "MIT",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.23",
         "eventsource": "^2.0.2",
         "express": "^4.22.2"
       },
@@ -311,34 +311,34 @@
       }
     },
     "node_modules/@skipruntime/native": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.22.tgz",
-      "integrity": "sha512-vCWrJfuFkX2Z+eELPw5bmnfVqxlkqWsn2BrayPlBspGrqqqgclQfoijqyot+8kmSapkKKRydS5eM1hv8Ut/vPA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.23.tgz",
+      "integrity": "sha512-t3Jb8LLat6/NTV8xnIRbAMD11aDVJ0XfFmRivDj5EOYmoMvre5RqwIqPzfi2RpWeZFdx9sIYnsaouVgLCDoBmQ==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "@skipruntime/core": "0.0.21"
+        "@skipruntime/core": "0.0.23"
       }
     },
     "node_modules/@skipruntime/server": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.22.tgz",
-      "integrity": "sha512-9slHlsqRSxxRlAGAsb9eEOLsgt5r8C+Ctgnz7A6UCBCmST49Nb5XGGjTwuDc6uJfigeond3nT2TLGAiJ0w8H4A==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@skipruntime/server/-/server-0.0.23.tgz",
+      "integrity": "sha512-28xz3nE/jlpPjrfwB+VUO/Lsf4v41mu0pUuEEdwAKTZv9xv3/SVU+B57iceZBa0fOLvXEA84vj8m+ax1O3Pv8A==",
       "dependencies": {
-        "@skipruntime/core": "0.0.21",
+        "@skipruntime/core": "0.0.23",
         "express": "^4.22.2"
       },
       "optionalDependencies": {
-        "@skipruntime/native": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skipruntime/native": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       }
     },
     "node_modules/@skipruntime/wasm": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.22.tgz",
-      "integrity": "sha512-HnS7MwLpTL3tSfNmsePKTqAhn6rXGeOcJGvdUd4riEOr6cE2+DxObCniwI4l2UZvMUXLP9+leG2TLFty8TIhaw==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@skipruntime/wasm/-/wasm-0.0.23.tgz",
+      "integrity": "sha512-pGWMOsKLOyMPX3vY32kt6wXMmtZWSQ/PJi2GydlP8JFgdqSRco3IbFrkVgwT9jRW0vt9VTxr3HpIuxlSSGrRUw==",
       "dependencies": {
-        "@skipruntime/core": "0.0.21"
+        "@skipruntime/core": "0.0.23"
       }
     },
     "node_modules/@stylistic/eslint-plugin-js": {

--- a/examples/blogger/reactive_service/package.json
+++ b/examples/blogger/reactive_service/package.json
@@ -14,11 +14,11 @@
   "license": "MIT",
   "description": "Reactive blogger service using Skip runtime",
   "dependencies": {
-    "@skipruntime/core": "0.0.21",
-    "@skipruntime/wasm": "0.0.22",
-    "@skipruntime/server": "0.0.22",
-    "@skipruntime/helpers": "0.0.22",
-    "@skip-adapter/postgres": "0.0.22"
+    "@skipruntime/core": "0.0.23",
+    "@skipruntime/wasm": "0.0.23",
+    "@skipruntime/server": "0.0.23",
+    "@skipruntime/helpers": "0.0.23",
+    "@skip-adapter/postgres": "0.0.23"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.2",

--- a/examples/cache_invalidation/edge_service/package.json
+++ b/examples/cache_invalidation/edge_service/package.json
@@ -14,11 +14,11 @@
   "license": "MIT",
   "description": "Reactive cache service using Skip runtime",
   "dependencies": {
-    "@skipruntime/core": "0.0.21",
-    "@skipruntime/wasm": "0.0.22",
-    "@skipruntime/server": "0.0.22",
-    "@skipruntime/helpers": "0.0.22",
-    "@skip-adapter/postgres": "0.0.22"
+    "@skipruntime/core": "0.0.23",
+    "@skipruntime/wasm": "0.0.23",
+    "@skipruntime/server": "0.0.23",
+    "@skipruntime/helpers": "0.0.23",
+    "@skip-adapter/postgres": "0.0.23"
   },
   "devDependencies": {
     "@skiplabs/eslint-config": "^0.0.2",

--- a/examples/cache_invalidation/edge_service/pnpm-lock.yaml
+++ b/examples/cache_invalidation/edge_service/pnpm-lock.yaml
@@ -4,28 +4,25 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  path-to-regexp: ^0.1.13
-
 importers:
 
   .:
     dependencies:
       '@skip-adapter/postgres':
-        specifier: 0.0.22
-        version: 0.0.22
+        specifier: 0.0.23
+        version: 0.0.23
       '@skipruntime/core':
-        specifier: 0.0.21
-        version: 0.0.21
+        specifier: 0.0.23
+        version: 0.0.23
       '@skipruntime/helpers':
-        specifier: 0.0.22
-        version: 0.0.22
+        specifier: 0.0.23
+        version: 0.0.23
       '@skipruntime/server':
-        specifier: 0.0.22
-        version: 0.0.22
+        specifier: 0.0.23
+        version: 0.0.23
       '@skipruntime/wasm':
-        specifier: 0.0.22
-        version: 0.0.22
+        specifier: 0.0.23
+        version: 0.0.23
     devDependencies:
       '@skiplabs/eslint-config':
         specifier: ^0.0.2
@@ -116,8 +113,8 @@ packages:
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
 
-  '@skip-adapter/postgres@0.0.22':
-    resolution: {integrity: sha512-QR0p0pEmaPy9ZarFZzB27d11UoZHGCkJY7zl9F851RNVjyxCaO69Ks+07K/F4NwgS2teIKFvDdk6nsoTO/ZNHA==}
+  '@skip-adapter/postgres@0.0.23':
+    resolution: {integrity: sha512-NeuvZ/eN7pGuPkasLe+2SCusOdGSwNyVOOcHbQspN/GVvyBUjs+H9d/yYNqpQUjPMIf+XlVeu41tkdvhyIInHA==}
     engines: {node: '>=22.6.0 <23.0.0'}
 
   '@skiplabs/eslint-config@0.0.2':
@@ -126,21 +123,21 @@ packages:
   '@skiplabs/tsconfig@0.0.3':
     resolution: {integrity: sha512-PALwao9q5j6Y6WtNbAjG/nroQEtOI3nn+uEjFqNbyg+UJQ7HzZ2Z/2AIq3DFEam2419p6xfLAePSI7PnUhcrIQ==}
 
-  '@skipruntime/core@0.0.21':
-    resolution: {integrity: sha512-sFmH+HUfp1/A+Ixo24BuILas9rigzqgIPnLLDiJOmL1OOJZNtk5e2sH1ez8npjpMkr4tguNPf/nwOVbimU3P+A==}
+  '@skipruntime/core@0.0.23':
+    resolution: {integrity: sha512-Z2redCcLTsA7h9x9dI4nCx6VAnygKf7vysERE3QRkHYIX+2356aEou+rd/gMqU2UuEOfO7ACOhpSsO8kqJDPaA==}
 
-  '@skipruntime/helpers@0.0.22':
-    resolution: {integrity: sha512-NJi11LZpg3x7OUfJJR0xANZOtRVI0dT1DtCq4kuRBfqnb9uPJzMvb24AWckgIXc/S1N5WeToQ84t0Mwg6jbGhQ==}
+  '@skipruntime/helpers@0.0.23':
+    resolution: {integrity: sha512-5qjtvR9P1wtabAOHXzPAK2x9rLOobHOWYGRetbI0N1W0LiQT11t4JNf4AroLrd4neTux67xGXGIggX1SssFcBQ==}
     engines: {node: '>=22.6.0 <23.0.0'}
 
-  '@skipruntime/native@0.0.22':
-    resolution: {integrity: sha512-vCWrJfuFkX2Z+eELPw5bmnfVqxlkqWsn2BrayPlBspGrqqqgclQfoijqyot+8kmSapkKKRydS5eM1hv8Ut/vPA==}
+  '@skipruntime/native@0.0.23':
+    resolution: {integrity: sha512-t3Jb8LLat6/NTV8xnIRbAMD11aDVJ0XfFmRivDj5EOYmoMvre5RqwIqPzfi2RpWeZFdx9sIYnsaouVgLCDoBmQ==}
 
-  '@skipruntime/server@0.0.22':
-    resolution: {integrity: sha512-9slHlsqRSxxRlAGAsb9eEOLsgt5r8C+Ctgnz7A6UCBCmST49Nb5XGGjTwuDc6uJfigeond3nT2TLGAiJ0w8H4A==}
+  '@skipruntime/server@0.0.23':
+    resolution: {integrity: sha512-28xz3nE/jlpPjrfwB+VUO/Lsf4v41mu0pUuEEdwAKTZv9xv3/SVU+B57iceZBa0fOLvXEA84vj8m+ax1O3Pv8A==}
 
-  '@skipruntime/wasm@0.0.22':
-    resolution: {integrity: sha512-HnS7MwLpTL3tSfNmsePKTqAhn6rXGeOcJGvdUd4riEOr6cE2+DxObCniwI4l2UZvMUXLP9+leG2TLFty8TIhaw==}
+  '@skipruntime/wasm@0.0.23':
+    resolution: {integrity: sha512-pGWMOsKLOyMPX3vY32kt6wXMmtZWSQ/PJi2GydlP8JFgdqSRco3IbFrkVgwT9jRW0vt9VTxr3HpIuxlSSGrRUw==}
 
   '@stylistic/eslint-plugin-js@4.4.1':
     resolution: {integrity: sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==}
@@ -928,9 +925,9 @@ snapshots:
 
   '@sindresorhus/base62@1.0.0': {}
 
-  '@skip-adapter/postgres@0.0.22':
+  '@skip-adapter/postgres@0.0.23':
     dependencies:
-      '@skipruntime/core': 0.0.21
+      '@skipruntime/core': 0.0.23
       pg: 8.21.0
       pg-format: 1.0.4
     transitivePeerDependencies:
@@ -949,34 +946,34 @@ snapshots:
 
   '@skiplabs/tsconfig@0.0.3': {}
 
-  '@skipruntime/core@0.0.21': {}
+  '@skipruntime/core@0.0.23': {}
 
-  '@skipruntime/helpers@0.0.22':
+  '@skipruntime/helpers@0.0.23':
     dependencies:
-      '@skipruntime/core': 0.0.21
+      '@skipruntime/core': 0.0.23
       eventsource: 2.0.2
       express: 4.22.2
     transitivePeerDependencies:
       - supports-color
 
-  '@skipruntime/native@0.0.22':
+  '@skipruntime/native@0.0.23':
     dependencies:
-      '@skipruntime/core': 0.0.21
+      '@skipruntime/core': 0.0.23
     optional: true
 
-  '@skipruntime/server@0.0.22':
+  '@skipruntime/server@0.0.23':
     dependencies:
-      '@skipruntime/core': 0.0.21
+      '@skipruntime/core': 0.0.23
       express: 4.22.2
     optionalDependencies:
-      '@skipruntime/native': 0.0.22
-      '@skipruntime/wasm': 0.0.22
+      '@skipruntime/native': 0.0.23
+      '@skipruntime/wasm': 0.0.23
     transitivePeerDependencies:
       - supports-color
 
-  '@skipruntime/wasm@0.0.22':
+  '@skipruntime/wasm@0.0.23':
     dependencies:
-      '@skipruntime/core': 0.0.21
+      '@skipruntime/core': 0.0.23
 
   '@stylistic/eslint-plugin-js@4.4.1(eslint@10.4.0)':
     dependencies:

--- a/examples/chatroom/reactive_service/package.json
+++ b/examples/chatroom/reactive_service/package.json
@@ -9,11 +9,11 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/core": "0.0.21",
-    "@skipruntime/wasm": "0.0.22",
-    "@skipruntime/server": "0.0.22",
-    "@skipruntime/helpers": "0.0.22",
-    "@skip-adapter/kafka": "0.0.22",
+    "@skipruntime/core": "0.0.23",
+    "@skipruntime/wasm": "0.0.23",
+    "@skipruntime/server": "0.0.23",
+    "@skipruntime/helpers": "0.0.23",
+    "@skip-adapter/kafka": "0.0.23",
     "kafkajs": "^2.2.4"
   },
   "devDependencies": {

--- a/examples/chatroom/web_service/package.json
+++ b/examples/chatroom/web_service/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/helpers": "0.0.22",
+    "@skipruntime/helpers": "0.0.23",
     "express": "^4.21.1",
     "kafkajs": "^2.2.4"
   },

--- a/examples/hackernews/reactive_service/package.json
+++ b/examples/hackernews/reactive_service/package.json
@@ -9,11 +9,11 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@skipruntime/core": "0.0.21",
-    "@skipruntime/wasm": "0.0.22",
-    "@skipruntime/server": "0.0.22",
-    "@skipruntime/helpers": "0.0.22",
-    "@skip-adapter/postgres": "0.0.22"
+    "@skipruntime/core": "0.0.23",
+    "@skipruntime/wasm": "0.0.23",
+    "@skipruntime/server": "0.0.23",
+    "@skipruntime/helpers": "0.0.23",
+    "@skip-adapter/postgres": "0.0.23"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,11 +343,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/core": "0.0.21",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skip-adapter/postgres": "0.0.23",
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.2",
@@ -357,121 +357,12 @@
         "typescript": "^5.0.0"
       }
     },
-    "examples/blogger/reactive_service/node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config/node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -530,7 +421,7 @@
       "version": "50.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
       "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
-      "dev": true,
+      "extraneous": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.50.2",
@@ -551,33 +442,6 @@
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
-    "examples/blogger/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
-      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.20"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@stylistic/eslint-plugin-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
-      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
     "examples/blogger/reactive_service/node_modules/@types/node": {
       "version": "20.17.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
@@ -586,68 +450,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "examples/blogger/reactive_service/node_modules/undici-types": {
@@ -662,11 +464,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/core": "0.0.21",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skip-adapter/postgres": "0.0.23",
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.2",
@@ -676,121 +478,12 @@
         "typescript": "^5.8.3"
       }
     },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config/node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -849,7 +542,7 @@
       "version": "50.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
       "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
-      "dev": true,
+      "extraneous": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.50.2",
@@ -870,33 +563,6 @@
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
-    "examples/cache_invalidation/edge_service/node_modules/@skipruntime/native": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
-      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.20"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@stylistic/eslint-plugin-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
-      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
     "examples/cache_invalidation/edge_service/node_modules/@types/node": {
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
@@ -905,68 +571,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/typescript": {
@@ -995,11 +599,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/kafka": "0.0.22",
-        "@skipruntime/core": "0.0.21",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
-        "@skipruntime/wasm": "0.0.22",
+        "@skip-adapter/kafka": "0.0.23",
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
+        "@skipruntime/wasm": "0.0.23",
         "kafkajs": "^2.2.4"
       },
       "devDependencies": {
@@ -1008,604 +612,21 @@
         "@types/node": "^22.10.0"
       }
     },
-    "examples/chatroom/reactive_service/node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
-      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.20"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@stylistic/eslint-plugin-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
-      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/eslint-plugin-jsdoc": {
-      "version": "50.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
-      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.50.2",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.4.1",
-        "escape-string-regexp": "^4.0.0",
-        "espree": "^10.3.0",
-        "esquery": "^1.6.0",
-        "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.2",
-        "spdx-expression-parse": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "examples/hackernews/reactive_service": {
       "name": "reactive-hackernews-leader",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@skip-adapter/postgres": "0.0.22",
-        "@skipruntime/core": "0.0.21",
-        "@skipruntime/helpers": "0.0.22",
-        "@skipruntime/server": "0.0.22",
-        "@skipruntime/wasm": "0.0.22"
+        "@skip-adapter/postgres": "0.0.23",
+        "@skipruntime/core": "0.0.23",
+        "@skipruntime/helpers": "0.0.23",
+        "@skipruntime/server": "0.0.23",
+        "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
         "@skiplabs/eslint-config": "^0.0.2",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^22.10.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skipruntime/native": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@skipruntime/native/-/native-0.0.21.tgz",
-      "integrity": "sha512-p5w9A30DnRKtpyhJE6SX1fMGLj60/WcTsNXC4ia7gx0Iz+xdvt8VeQIZx+MQ9i80fmA8FOlT9CmwQaWfD0vTrA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@skipruntime/core": "0.0.20"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@stylistic/eslint-plugin-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.13.0.tgz",
-      "integrity": "sha512-GPPDK4+fcbsQD58a3abbng2Dx+jBoxM5cnYjBM4T24WFZRZdlNSKvR19TxP8CPevzMOodQ9QVzNeqWvMXzfJRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/eslint-plugin-jsdoc": {
-      "version": "50.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
-      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.50.2",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.4.1",
-        "escape-string-regexp": "^4.0.0",
-        "espree": "^10.3.0",
-        "esquery": "^1.6.0",
-        "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.2",
-        "spdx-expression-parse": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
-      "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.6",
-        "@typescript-eslint/types": "^8.11.0",
-        "comment-parser": "1.4.1",
-        "esquery": "^1.6.0",
-        "jsdoc-type-pratt-parser": "~4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -3425,16 +2446,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/comment-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4625,16 +3636,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/json-buffer": {


### PR DESCRIPTION
## Summary

Stacked on #1255. Now that the 0.0.23 bumps in #1255 are live on npm, point the example apps at them so they consume the new releases:

- `@skipruntime/core`: 0.0.21 -> 0.0.23
- `@skipruntime/{helpers,wasm,native,server}`: 0.0.22 -> 0.0.23
- `@skip-adapter/{kafka,postgres}`: 0.0.22 -> 0.0.23

Touches every `examples/*/package.json` that references our packages (`reactive_service` in all four examples, plus `chatroom/web_service` for `@skipruntime/helpers`).

Regenerates the two tracked standalone lockfiles (`examples/blogger/reactive_service/package-lock.json`, `examples/cache_invalidation/edge_service/pnpm-lock.yaml`) plus the root workspace `package-lock.json` to match. The root lockfile picks up a sizeable cleanup as the old 0.0.21/0.0.22 transitive entries are no longer needed once every example resolves to 0.0.23.

The `cache_invalidation` pnpm-lock.yaml is regenerated with pnpm 11.4.0, which no longer echoes `pnpm.overrides` into the lockfile's `overrides:` section; the override is still read from `package.json` and `path-to-regexp` still resolves to 0.1.13.

## Test plan

- [ ] Wait for #1255 to merge first (so this PR's diff against main shrinks to just the examples bump)
- [ ] CI green
- [ ] `npm install` in each example resolves cleanly against the refreshed lockfiles