### PR TITLE
docs(blog): replace dead Discord invite in three posts

### DIFF
--- a/www/blog/chat_with_react_vite.md
+++ b/www/blog/chat_with_react_vite.md
@@ -56,7 +56,7 @@ One or two cool things you will want to try:
  - integrating your user-management system
  - integrating an AI agent to discuss into the chat
 
-We have a [Discord server](https://discord.gg/2nzP2PZj), why don't you swing by and say hi, ask a question or two?
+We have a [Discord server](https://discord.gg/ss4zxfgUBH), why don't you swing by and say hi, ask a question or two?
 
 
 ## What's Next?

--- a/www/blog/create_skip_service_announcement.md
+++ b/www/blog/create_skip_service_announcement.md
@@ -101,7 +101,7 @@ As of today, we are already on our way to improving and augmenting the number of
 
 [^1]: not a typo ;-)
 
-We have a [Discord server](https://discord.gg/2nzP2PZj), why don't you swing by and say hi?
+We have a [Discord server](https://discord.gg/ss4zxfgUBH), why don't you swing by and say hi?
 
 ## What's Next?
 

--- a/www/blog/scaling.md
+++ b/www/blog/scaling.md
@@ -125,4 +125,4 @@ examples and demos!
 We're also happy to help you scale out your reactive service using Skip, either
 by adapting these tools to your environment or advising on your setup.  Reach
 out and show us what you're building, or come join the
-[Discord](https://discord.gg/2nzP2PZj)!
+[Discord](https://discord.gg/ss4zxfgUBH)!


### PR DESCRIPTION
discord.gg/2nzP2PZj is no longer a working invite. All current skipruntime-ts package READMEs use discord.gg/ss4zxfgUBH as the canonical invite to the Skip Framework community server; align the three blog posts on it. Same server, working link.