### PR TITLE
docs(readme): add Contents TOC and surface Skiplang + SKDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This repository contains the Skip Framework for building reactive backend servic
 - [Skip Framework](#skip-framework)
 - [Skiplang toolchain](#skiplang-toolchain)
 - [SKDB](#skdb)
-- [Examples](#examples)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -51,6 +50,11 @@ See the [getting started guide](https://skiplabs.io/docs/getting_started) to wal
 
 See our documentation [here](https://skiplabs.io/docs) for introductions to the core concepts, components, and features of the Skip framework, or dive into the [API docs](https://skiplabs.io/docs/api/core) for comprehensive explanations of our TypeScript interfaces and abstractions.
 
+### Examples
+
+Some small examples of reactive services are [available](./skipruntime-ts/examples), demonstrating patterns of reactive programming.
+Another [example](./examples/hackernews) is designed to serve as an example of how to deploy and configure a reactive service, using Docker compose to package and orchestrate a backend complete with a reactive service, database, backend web service, and reverse proxy.
+
 ## Skiplang toolchain
 
 The Skip Framework's native runtime is implemented in Skiplang. The compiler, runtime, and surrounding tools (`skargo`, `sktest`, …) live under [`skiplang/`](./skiplang). See [INSTALL.md](./INSTALL.md) for instructions on building the toolchain from source.
@@ -58,11 +62,6 @@ The Skip Framework's native runtime is implemented in Skiplang. The compiler, ru
 ## SKDB
 
 SKDB is a reactive SQL database, part of the Skip ecosystem. The TypeScript client is published as the [`skdb`](https://www.npmjs.com/package/skdb) NPM package; sources for the client, server, and runtime live under [`sql/`](./sql).
-
-## Examples
-
-Some small examples of reactive services are [available](./skipruntime-ts/examples), demonstrating patterns of reactive programming.
-Another [example](./examples/hackernews) is designed to serve as an example of how to deploy and configure a reactive service, using Docker compose to package and orchestrate a backend complete with a reactive service, database, backend web service, and reverse proxy.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,26 @@
   </p>
 </div>
 
+This repository contains the Skip Framework for building reactive backend services, the Skiplang toolchain that powers its native runtime, and SKDB, a reactive SQL database built on Skip.
+
+## Contents
+
+- [Skip Framework](#skip-framework)
+- [Skiplang toolchain](#skiplang-toolchain)
+- [SKDB](#skdb)
+- [Examples](#examples)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Skip Framework
+
 Skip is an open-source framework for building _reactive_ backend services.
 
 It is based on a custom-built native backend for efficient reactive computation, allowing your system to deliver up-to-date and correct results without requiring any bug-prone manual dependency tracking and updating.
 
 TypeScript interfaces and abstractions are provided so that you can write a reactive service using standard tools while also taking advantage of the Skip framework's abstractions for efficient reactivity.
 
-## Installation
+### Installation
 
 To get started, install the skip NPM package:
 
@@ -34,9 +47,17 @@ The native runtime does not have this limitation, but it is currently only avail
 From there, you're ready to start building a reactive service!
 See the [getting started guide](https://skiplabs.io/docs/getting_started) to walk through some of Skip's core concepts by example and get up to speed.
 
-## Documentation
+### Documentation
 
 See our documentation [here](https://skiplabs.io/docs) for introductions to the core concepts, components, and features of the Skip framework, or dive into the [API docs](https://skiplabs.io/docs/api/core) for comprehensive explanations of our TypeScript interfaces and abstractions.
+
+## Skiplang toolchain
+
+The Skip Framework's native runtime is implemented in Skiplang. The compiler, runtime, and surrounding tools (`skargo`, `sktest`, …) live under [`skiplang/`](./skiplang). See [INSTALL.md](./INSTALL.md) for instructions on building the toolchain from source.
+
+## SKDB
+
+SKDB is a reactive SQL database, part of the Skip ecosystem. The TypeScript client is published as the [`skdb`](https://www.npmjs.com/package/skdb) NPM package; sources for the client, server, and runtime live under [`sql/`](./sql).
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The root README only spoke to the Skip Framework, but the repo is a monorepo with three layered components:

- **Skip Framework** — TypeScript reactive backend framework (`skipruntime-ts/`)
- **Skiplang toolchain** — the language, compiler, runtime, and surrounding tools (`skiplang/`)
- **SKDB** — reactive SQL database built on Skip (`sql/`)

Restructure the root README so a reader landing on the repo can find all three.

### What changed

| # | Commit | Fix |
|---|---|---|
| 1 | `docs(readme): add Contents TOC and surface Skiplang + SKDB` | One-line intro names all three components. Add a small `## Contents` list. Existing framework content moves under `## Skip Framework` (subheads `### Installation`, `### Documentation`). Add brief sections for Skiplang toolchain (pointing at `skiplang/` and INSTALL.md) and SKDB (pointing at `sql/` and the npm `skdb` package). |
| 2 | `docs(readme): nest Examples under Skip Framework` | Examples are framework-specific, so `## Examples` becomes `### Examples` under Skip Framework and drops from the top-level Contents list. |

### Verification

- All cross-links checked against `origin/main`: logo, LICENSE, INSTALL.md, `skiplang/`, `sql/`, `skipruntime-ts/examples`, `examples/hackernews` all exist.
- NPM package claims (`@skiplabs/skip`, `@skipruntime/wasm`, `@skipruntime/native`, `skdb`) match the actual `package.json` names in the workspace.
- "Wasm installed by default" matches the metapackage's required-vs-optional deps split.
- "native is Node-only" matches the `gypfile: true` build in `skipruntime-ts/addon/package.json`.
- "works with both node and bun" matches `bun run` targets in `skipruntime-ts/Makefile`.

## Test plan

- [ ] GitHub's README rendering shows the new TOC links and they jump to the right sections
- [ ] No claims describe behavior or paths that don't exist in `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)