### PR TITLE
Bump dev/CI base image to Ubuntu 24.04; declare @skipruntime/native platform constraints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS skiplang-base
+FROM ubuntu:24.04 AS skiplang-base
 
 ARG TARGETARCH
 

--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -36,7 +36,7 @@ for step in "${steps[@]}"; do
         skiplang-build-deps)
             _ensure_base_deps
             wget -qO /etc/apt/keyrings/llvm.asc https://apt.llvm.org/llvm-snapshot.gpg.key
-            echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
+            echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
             apt-get update
             apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION make openssh-client
 
@@ -62,7 +62,8 @@ for step in "${steps[@]}"; do
             apt-get install -q -y --no-install-recommends clang-format-$LLVM_VERSION docker.io docker-buildx parallel pip shellcheck
             # Version from requirements-dev.txt (check repo root, then /tmp for docker builds)
             BLACK_VERSION=$(grep '^black==' requirements-dev.txt /tmp/requirements-dev.txt 2>/dev/null | head -1 | cut -d'=' -f3)
-            pip install black=="${BLACK_VERSION:-26.1.0}"
+            # --break-system-packages: Ubuntu 24.04+ enforces PEP 668; safe in a throwaway container image
+            pip install --break-system-packages black=="${BLACK_VERSION:-26.1.0}"
             update-alternatives --auto clang
             ;;
         other-dev-tools)

--- a/skipruntime-ts/addon/package.json
+++ b/skipruntime-ts/addon/package.json
@@ -3,6 +3,16 @@
   "version": "0.0.23",
   "gypfile": true,
   "type": "module",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
   "exports": {
     ".": "./dist/index.js"
   },


### PR DESCRIPTION
## Summary

Scoped down from the original Ubuntu-24.04 **+ Debian-Trixie** bump after review feedback.

- **Bump the dev/CI toolchain image to Ubuntu 24.04 (Noble LTS)** — `Dockerfile` + `bin/apt-install.sh` (LLVM apt repo `jammy` → `noble`, and `--break-system-packages` for the `black` install since Noble enforces PEP 668). This is the build/CI image only.
- **Declare platform constraints on `@skipruntime/native`** — add `os`/`cpu`/`libc` to `package.json` so npm refuses installation on Windows/macOS/musl/non-amd64-arm64 hosts and, via `@skiplabs/skip`'s `optionalDependencies`, falls back to `@skipruntime/wasm`. This encodes the runtime's *existing* platform support and is independent of any glibc version.

**Intentionally _not_ changed:** `skiplang/Dockerfile` stays on Debian Bookworm. The glibc floor of the distributed `libskipruntime.so` comes solely from that image (via `skipruntime-ts/Dockerfile` → `skiplang-bin-builder`), so keeping it on Bookworm preserves the current broad-compatibility floor. The Ubuntu bump does not affect it.

## Test plan

- [x] `skiplang-base` stage builds on `ubuntu:24.04`; LLVM 20 installs from `apt.llvm.org/noble` (verified locally)
- [x] `pip install black` fails on 24.04 with `externally-managed-environment`; `--break-system-packages` resolves it (verified locally)
- [x] Full `skip` target builds end-to-end on Noble, incl. the full `apt-install.sh` chain (verified locally)
- [ ] CI green