### PR TITLE
Relax engines.node to >=20.0.0 on helpers and adapters

### DIFF
--- a/skipruntime-ts/adapters/kafka/package.json
+++ b/skipruntime-ts/adapters/kafka/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "description": "Adapter providing reactive access to Apache Kafka from the Skip runtime",
   "engines": {
-    "node": ">=22.6.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "kafkajs": "^2.2.4",

--- a/skipruntime-ts/adapters/postgres/package.json
+++ b/skipruntime-ts/adapters/postgres/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "description": "Adapter providing reactive access to PostgreSQL from the Skip runtime",
   "engines": {
-    "node": ">=22.6.0 <23.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "pg": "^8.13.1",

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "description": "",
   "engines": {
-    "node": ">=22.6.0 <23.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "eventsource": "^2.0.2",


### PR DESCRIPTION
## Summary

Three published workspace packages declare an `engines.node` field that
under-counts the platforms they actually support:

| Package | Before | After |
|---|---|---|
| `@skipruntime/helpers` | `>=22.6.0 <23.0.0` | `>=20.0.0` |
| `@skip-adapter/postgres` | `>=22.6.0 <23.0.0` | `>=20.0.0` |
| `@skip-adapter/kafka` | `>=22.6.0` | `>=20.0.0` |

Installing any of them on Node != 22.x produces `npm warn EBADENGINE` —
and a hard failure under `npm install --engine-strict` — even though the
code uses only Node 18+ APIs and runs cleanly on Node 20, 22, 24, and 25.

The constraint was committed at package creation (bcacca313, Oct 2024)
with no justification, then propagated into the two adapters. The other
published `@skipruntime/*` packages (`core`, `native`, `wasm`, `server`)
declare no `engines` field.

## Why `>=20.0.0`

Source audit of `skipruntime-ts/helpers/src/*.ts`:

| API used | Available since |
|---|---|
| `Headers` global | Node 18.0.0 |
| `fetch` global | Node 18.0.0 (stable 21+) |
| `AbortSignal.timeout` | Node 17.3.0 |
| `URLSearchParams`, `setInterval` | long-available |
| TS emit target ES2021 | ~Node 14 |

The adapters (`postgres`, `kafka`) only touch `process.exit` / `process.on`
plus their respective driver libraries — no Node-22-specific APIs.

Node 18 is technically the API floor, but went LTS EOL on 2025-04-30.
`>=20.0.0` is the smallest currently-supported Node, matches
`www/package.json` (`>=20`), and removes the spurious `<23.0.0` upper
bound.

## Testing

The three modified packages were built and `npm pack`ed off this branch,
then installed and exercised in `node:{18,20,22,24,25}-slim` containers.

1. **Smoke test against the helpers public API, on each supported Node major.**
   In `node:{20,22,24,25}-slim`, ran:
   \`\`\`
   npm install --engine-strict <helpers.tgz> <core.tgz>
   \`\`\`
   followed by a script that constructs a local `http.createServer`,
   round-trips JSON through `fetchJSON` (exercising `fetch`,
   `AbortSignal.timeout`, `Headers.get`), calls `defaultParamEncoder`
   (exercising `URLSearchParams`), and constructs a `SkipServiceBroker`.
   All four Node majors completed install with no EBADENGINE warning
   and the smoke script ran to completion.

2. **Engines floor is actually enforced.**
   Same install on `node:18-slim` with `--engine-strict` fails as
   intended:
   \`\`\`
   npm error code EBADENGINE
   npm error notsup Required: {"node":">=20.0.0"}
   npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
   \`\`\`

3. **Pre-fix bug reproduces.**
   Installing the unfixed published `@skipruntime/helpers@0.0.19`
   tarball on `node:25-slim` produces the warning text quoted in #859:
   \`\`\`
   npm warn EBADENGINE   required: { node: '>=22.6.0 <23.0.0' },
   npm warn EBADENGINE   current:  { node: 'v25.9.0', npm: '11.12.1' }
   \`\`\`

Closes #859.

## Test plan

- [ ] `npm install` at the repo root resolves cleanly against the refreshed lockfile