### PR TITLE
Fix TOCTOU race on credentials file in skdb-cli (CodeQL js/file-system-race)

### DIFF
--- a/sql/ts/src/skdb-cli.ts
+++ b/sql/ts/src/skdb-cli.ts
@@ -227,14 +227,21 @@ if (values.dev) {
 } else {
   // using the local `credsFileName` file
 
-  if (!fs.existsSync(credsFileName)) {
-    fs.mkdirSync(skdbDir, { recursive: true });
-    fs.writeFileSync(credsFileName, JSON.stringify({}));
-  }
+  fs.mkdirSync(skdbDir, { recursive: true });
 
   // credentials file schema:
   // {host: { database: { accessKey: privateKey }}}
-  creds = JSON.parse(fs.readFileSync(credsFileName).toString());
+  // Read the file directly, treating a missing file as empty credentials.
+  // Checking for existence first would race with the read/writes below
+  // (CodeQL js/file-system-race).
+  try {
+    creds = JSON.parse(fs.readFileSync(credsFileName).toString());
+  } catch (ex: unknown) {
+    if ((ex as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw ex;
+    }
+    creds = {};
+  }
   hostCreds = creds[values.host as string] ?? {};
   creds[values.host as string] = hostCreds;
   dbCreds = hostCreds[values.db as string] ?? {};


### PR DESCRIPTION
## Summary

Fixes the two open high-severity **`js/file-system-race`** code-scanning alerts (#7, #8) in `sql/ts/src/skdb-cli.ts`.

The CLI checked `fs.existsSync(credsFileName)` and then later wrote the file with `fs.writeFileSync(credsFileName, ...)`. CodeQL pairs that existence *check* with the subsequent *writes* (lines 232 and 254) as a time-of-check/time-of-use race: the file could change between the check and the writes.

## Change

Remove the existence check entirely:

- Read the credentials file directly and fall back to an empty set on `ENOENT` — race-free, and exactly the behaviour the check was emulating.
- Keep `mkdirSync(skdbDir, { recursive: true })`, now unconditional. It is idempotent and is **not** a file-state check, so it does not reintroduce the race, and it preserves the directory guarantee that every write path (`add-cred`, `create-db`, `create-user`) relied on.

Removing the only existence check on the path clears both alerts (`readFileSync` is a "use", not a "check", so it cannot become a replacement check).

## Verification

- The changed snippet type-checks under `--strict` with `@types/node`.
- No `existsSync` on `credsFileName` remains.
- Read-only invocations no longer leave behind an empty credentials file; the error/exit behaviour for missing or invalid credentials is unchanged.

## Note

The CodeQL workflow runs on `workflow_dispatch` / weekly `schedule` (not per-PR), so #7 and #8 will clear after CodeQL next analyzes `main` — or sooner via a manual "Run workflow" dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)