### PR TITLE
Override joi to ^18.2.1 in /www (Dependabot alert #320)

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -4169,19 +4169,52 @@
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@jest/schemas": {
@@ -5261,27 +5294,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -5310,6 +5322,12 @@
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -10797,16 +10815,21 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-tokens": {

--- a/www/package.json
+++ b/www/package.json
@@ -49,8 +49,10 @@
   "engines": {
     "node": ">=20"
   },
+  "//": "joi override: bridge-coverage for GHSA-q7cg-457f-vx79 (uncaught RangeError on recursive Joi.link()). @docusaurus/{types,utils-validation}@3.10.1 still constrain joi to ^17.9.2; facebook/docusaurus merged joi^18.1.2 to main 2026-05-09 (PR #11988) but it's only in canary builds (3.10.1-canary-6603+). Drop this once a Docusaurus stable release adopts joi^18.",
   "overrides": {
     "serialize-javascript": "^7.0.3",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "joi": "^18.2.1"
   }
 }


### PR DESCRIPTION
## Summary
Fixes Dependabot alert [#320](https://github.com/SkipLabs/skip/security/dependabot/320) — [GHSA-q7cg-457f-vx79](https://github.com/advisories/GHSA-q7cg-457f-vx79) (medium: joi has an uncaught RangeError on deeply nested input through recursive `Joi.link()` schemas, patched in 18.2.1).

joi@17.13.3 is a build-time-only transitive dep pulled into [www/](www/) by `@docusaurus/types@^17.9.2` and `@docusaurus/utils-validation@^17.9.2`. Patching requires a major version bump (17 → 18) — outside the parents' caret range — so a straight `npm update` can't reach it.

## Approach
Adds `joi: "^18.2.1"` to the existing `overrides` block in [www/package.json](www/package.json). Resolves to **18.2.1** in the lockfile (the patched version). Adds a top-level `"//"` comment explaining the override so it can be removed cleanly once Docusaurus stable adopts joi^18.

## Why an override is safe here
- **Upstream-validated compatibility**: [facebook/docusaurus PR #11988](https://github.com/facebook/docusaurus/pull/11988) merged the joi 17 → 18.1.2 bump into `main` on 2026-05-09. Docusaurus's own plugin-config validation works on joi 18.x; the bump just hasn't landed in a stable release yet (only canaries 3.10.1-canary-6603+).
- **Vulnerable code path is unused**: the advisory needs recursive `Joi.link()` schemas on attacker-controlled input. Docusaurus's only `Joi.link()` reference is **commented out** at `@docusaurus/plugin-content-docs/lib/sidebars/validation.js:89`. joi runs only at `docusaurus build` time on committed config/MDX/sidebars — never on network input.
- **Minimal joi 17 → 18 breaking changes**: the only real one is `engines.node >=20`, which is satisfied by `www/package.json`'s `"engines": { "node": ">=20" }`. No joi API used by docusaurus (`.object()`, `.string()`, `.extend()`, `.custom()`, …) was removed or had semantics changed.

## Verification
- `npm install --package-lock-only` resolves `joi@18.2.1` (single entry; no nested copies).
- `npm install` then `npm run build` in `www/` completes cleanly — server + client compile, og-image cards generated, static files produced in `build/`.

## Drop later
Once a Docusaurus stable release (3.10.2 / 3.11 / …) ships with joi^18 in `dependencies`, this override becomes redundant. The `"//"` comment documents the trigger condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)