### PR TITLE
Wait for the REST server port instead of sleeping in Bun example runner

### DIFF
--- a/skipruntime-ts/tests/examples/bun/run_examples.sh
+++ b/skipruntime-ts/tests/examples/bun/run_examples.sh
@@ -51,6 +51,21 @@ cleanup() {
 # Cleanup if Ctrl+C or abnormal exit
 trap cleanup EXIT INT TERM
 
+# Poll a local TCP port until it accepts a connection, returns 1 if the port is not up within the timeout.
+wait_for_port() {
+    local port="$1"
+    local i=0
+    while [ "$i" -lt 50 ]; do
+        if (exec 3<>"/dev/tcp/localhost/${port}") 2>/dev/null; then
+            exec 3>&- 3<&-
+            return 0
+        fi
+        sleep 0.2
+        i=$((i + 1))
+    done
+    return 1
+}
+
 run_one_example() {
     local name="$1"
     local out_file="/tmp/${name}-bun.out"
@@ -72,9 +87,16 @@ run_one_example() {
     if [ -f "$EXAMPLES_DIR/${name}-server.ts" ]; then
         bun run "$EXAMPLES_DIR/${name}-server.ts" >/dev/null &
         BG_PIDS+=($!)
+        # Client talks to the REST server; wait until it listens instead of
+        # racing it.
+        if ! wait_for_port 8082; then
+            echo "  [FAIL] timed out waiting for server port 8082"
+            cleanup
+            return 1
+        fi
+    else
+        sleep 3
     fi
-
-    sleep 3
 
     bun run "$EXAMPLES_DIR/${name}-client.ts" >"$out_file" 2>"$err_file"
     local client_status=$?

--- a/skipruntime-ts/tests/examples/bun/run_examples.sh
+++ b/skipruntime-ts/tests/examples/bun/run_examples.sh
@@ -55,12 +55,12 @@ trap cleanup EXIT INT TERM
 wait_for_port() {
     local port="$1"
     local i=0
-    while [ "$i" -lt 50 ]; do
+    while [ "$i" -lt 10 ]; do
         if (exec 3<>"/dev/tcp/localhost/${port}") 2>/dev/null; then
             exec 3>&- 3<&-
             return 0
         fi
-        sleep 0.2
+        sleep 1
         i=$((i + 1))
     done
     return 1


### PR DESCRIPTION
## Problem

The Bun runner waited a fixed 3s before each client. The database example
races under CI load: the server opens db.sqlite at module load while the
service opens the same file to seed data before runService. Launched in
parallel, the client could fire while the service still held the lock, so
the server's INSERT hit SQLITE_BUSY.

## Change

For examples with a -server.ts, poll the server port until it listens
instead of sleeping.

## Scope

Limited to -server examples (database, groups) since their port is constant
(8082). Others keep the sleep: their client hits the service streaming port,
which varies per example and isn't cleanly extractable today (remote.ts has
two). Specifying the port in each .ts would allow dropping the sleep
everywhere — left for a follow-up.