### PR TITLE
Bump eventsource to v4 in helpers and examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1490,13 +1490,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
-    "node_modules/@types/eventsource": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
-      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/express": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
@@ -2958,12 +2951,24 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expand-template": {
@@ -5778,11 +5783,10 @@
         "@skipruntime/helpers": "0.0.23",
         "@skipruntime/server": "0.0.23",
         "better-sqlite3": "^11.7.2",
-        "eventsource": "^2.0.2"
+        "eventsource": "^4.0.0"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.12",
-        "@types/eventsource": "^1.1.15"
+        "@types/better-sqlite3": "^7.6.12"
       }
     },
     "skipruntime-ts/helpers": {
@@ -5791,11 +5795,8 @@
       "license": "MIT",
       "dependencies": {
         "@skipruntime/core": "0.0.23",
-        "eventsource": "^2.0.2",
+        "eventsource": "^4.0.0",
         "express": "^4.22.2"
-      },
-      "devDependencies": {
-        "@types/eventsource": "^1.1.15"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/skipruntime-ts/examples/database-client.ts
+++ b/skipruntime-ts/examples/database-client.ts
@@ -1,6 +1,6 @@
 // TODO: Remove once global `EventSource` makes it out of experimental
 // in nodejs LTS.
-import EventSource from "eventsource";
+import { EventSource } from "eventsource";
 import { fetchJSON } from "@skipruntime/helpers";
 
 /*

--- a/skipruntime-ts/examples/groups-client.ts
+++ b/skipruntime-ts/examples/groups-client.ts
@@ -1,6 +1,6 @@
 // TODO: Remove once global `EventSource` makes it out of experimental
 // in nodejs LTS.
-import EventSource from "eventsource";
+import { EventSource } from "eventsource";
 import { fetchJSON } from "@skipruntime/helpers";
 import { sleep } from "./utils.js";
 

--- a/skipruntime-ts/examples/package.json
+++ b/skipruntime-ts/examples/package.json
@@ -8,13 +8,12 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@types/eventsource": "^1.1.15",
     "@types/better-sqlite3": "^7.6.12"
   },
   "dependencies": {
     "@skipruntime/helpers": "0.0.23",
     "@skipruntime/server": "0.0.23",
-    "eventsource": "^2.0.2",
+    "eventsource": "^4.0.0",
     "better-sqlite3": "^11.7.2"
   }
 }

--- a/skipruntime-ts/examples/utils.ts
+++ b/skipruntime-ts/examples/utils.ts
@@ -1,6 +1,6 @@
 // TODO: Remove once global `EventSource` makes it out of experimental
 // in nodejs LTS.
-import EventSource from "eventsource";
+import { EventSource } from "eventsource";
 
 import type { Json } from "@skipruntime/core";
 import { SkipServiceBroker } from "@skipruntime/helpers";
@@ -25,9 +25,9 @@ export async function subscribe(
     evSource.addEventListener("update", (e: MessageEvent<string>) => {
       console.log("Update", e.data);
     });
-    evSource.onerror = (e: MessageEvent<string>) => {
+    evSource.addEventListener("error", (e: MessageEvent<string>) => {
       console.log("Error", e);
-    };
+    });
     return evSource;
   });
 }

--- a/skipruntime-ts/helpers/package.json
+++ b/skipruntime-ts/helpers/package.json
@@ -17,11 +17,8 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "eventsource": "^2.0.2",
+    "eventsource": "^4.0.0",
     "express": "^4.22.2",
     "@skipruntime/core": "0.0.23"
-  },
-  "devDependencies": {
-    "@types/eventsource": "^1.1.15"
   }
 }

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -1,6 +1,6 @@
 // TODO: Remove once global `EventSource` makes it out of experimental
 // in nodejs LTS.
-import EventSource from "eventsource";
+import { EventSource } from "eventsource";
 
 import type {
   Context,
@@ -88,7 +88,7 @@ export class SkipExternalService implements ExternalService {
         const updates = JSON.parse(e.data) as Entry<Json, Json>[];
         callbacks.update(updates, false).catch(console.error);
       });
-      evSource.addEventListener("error", (e) => {
+      evSource.addEventListener("error", (e: MessageEvent<unknown>) => {
         if (this.resources.has(instance)) callbacks.error(e.data);
         else reject(e.data as Error);
       });


### PR DESCRIPTION
v4 changes the import shape (named export) and uses standard event listeners instead of the onerror property. Drop the obsolete @types/eventsource since v4 ships its own types.