### PR TITLE
Bump SQL server JDK from Temurin 20 (EOL) to 21 LTS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,12 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 20
+    - name: Set up JDK 21
       if: matrix.language == 'java-kotlin'
       uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: '20'
+        java-version: '21'
 
     - name: Install clang-20
       if: matrix.language == 'c-cpp'

--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -2,7 +2,11 @@ FROM skiplabs/skip AS base
 
 ARG TARGETARCH
 
-# Install system deps, Java 20 (Adoptium Temurin), and Gradle 9.3.1
+# Install system deps, Java 21 (Adoptium Temurin), and Gradle 9.3.1.
+# The .sdkman stub dirs below are a build-time sentinel that lets
+# sql/ts/tests/service_common.mk skip its SDKMAN install (Java here comes
+# from apt above). Its version string only has to match that Makefile — it
+# does not track the JDK version and is intentionally left at 20.0.2-tem.
 RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/root/.npm,sharing=locked \
@@ -11,7 +15,7 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
     echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" \
       > /etc/apt/sources.list.d/adoptium.list && \
     apt-get update && \
-    apt-get install -q -y --no-install-recommends curl sqlite3 unzip zip temurin-20-jdk && \
+    apt-get install -q -y --no-install-recommends curl sqlite3 unzip zip temurin-21-jdk && \
     npm install -g bun && \
     npx playwright install-deps && \
     curl -sL https://services.gradle.org/distributions/gradle-9.3.1-bin.zip -o /tmp/gradle.zip && \
@@ -23,7 +27,7 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
       /root/.sdkman/candidates/gradle && \
     touch /root/.sdkman/bin/sdkman-init.sh
 
-ENV JAVA_HOME=/usr/lib/jvm/temurin-20-jdk-${TARGETARCH}
+ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-${TARGETARCH}
 
 FROM base AS skdb
 

--- a/sql/server/core/Dockerfile
+++ b/sql/server/core/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:20
+FROM eclipse-temurin:21
 
 # Copy Gradle wrapper and build configs first (changes rarely)
 COPY sql/server/gradlew sql/server/gradle.properties /skdb/sql/server/

--- a/sql/server/core/build.gradle.kts
+++ b/sql/server/core/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(20)) } }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 tasks.named<Test>("test") {
   // Use JUnit Platform for unit tests.

--- a/sql/server/dev/Dockerfile
+++ b/sql/server/dev/Dockerfile
@@ -1,5 +1,5 @@
 FROM skiplabs/skdb AS skdb
-FROM eclipse-temurin:20 AS skgw
+FROM eclipse-temurin:21 AS skgw
 
 # Copy Gradle wrapper and build configs first (changes rarely)
 COPY sql/server/gradlew sql/server/gradle.properties /skdb/sql/server/
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
 # Build the development image by copying out artifacts
 ################################################################################
 
-FROM eclipse-temurin:20 AS dev
+FROM eclipse-temurin:21 AS dev
 
 WORKDIR /skdb
 

--- a/sql/server/pg/build.gradle.kts
+++ b/sql/server/pg/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(20)) } }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 spotless { kotlin { ktfmt("0.49") } }
 


### PR DESCRIPTION
## Summary

Temurin/OpenJDK 20 is a non-LTS release that stopped receiving security updates in 2023. This moves the SKDB SQL-server Java toolchain to **Temurin 21 LTS**, a natural follow-on to the base-image modernization in #1261.

Changes (all version-string bumps, no logic changes):
- `eclipse-temurin:20` → `:21` — server `core` and `dev` images
- `temurin-20-jdk` → `temurin-21-jdk` (Adoptium apt) + `JAVA_HOME` in `sql/Dockerfile`
- Gradle toolchain `languageVersion` `20` → `21` — `core` and `pg` modules
- CodeQL workflow's Kotlin-analysis JDK `20` → `21`

The Gradle wrapper stays at **8.1.1** — it runs fine on JDK 21 (verified), so no wrapper bump is needed.

### Note on the SDKMAN sentinel
The `.sdkman/candidates/java/20.0.2-tem` marker in `sql/Dockerfile` and `sql/ts/tests/service_common.mk` is **intentionally left at `20.0.2-tem`**. It is a build-time sentinel that lets the Makefile skip its SDKMAN install (the real JDK comes from apt), and it must match the already-published image that the `skdb-wasm` CI job runs in. A comment now documents this so future JDK bumps don't touch it. (An earlier revision bumped it and turned `skdb-wasm` red — `sdk: command not found` — because the published image still had the old sentinel dir.)

## Test plan

Verified locally (Docker, amd64):
- [x] `server-core` image builds on `eclipse-temurin:21` — Kotlin compiles, jars, `check` passes with wrapper 8.1.1
- [x] `dev` image `skgw` stage builds on `eclipse-temurin:21`
- [x] `temurin-21-jdk` installs from the Adoptium **noble** apt repo; `JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-amd64` resolves; `java -version` → `21.0.11 LTS`
- [ ] CI green