### PR TITLE
Report per-phase compiler timing under SKC_TIME_PHASES

### DIFF
--- a/skiplang/compiler/src/skipUtils.sk
+++ b/skiplang/compiler/src/skipUtils.sk
@@ -71,7 +71,9 @@ fun shouldDebugSymbol(_symbolName: String): Bool {
 //   value
 // }
 
-fun runCompilerPhase<T>(_phaseName: String, phase: () -> T): T {
+fun runCompilerPhase<T>(phaseName: String, phase: () -> T): T {
+  // Kept for future per-phase debugging/profiling (memory statistics,
+  // pass result dumps, profile-path recording):
   // if (config.debug || config.profile) {
   //   reportMemoryStatistics(`${phaseName} start`);
   //   (elapsedTime, result) = timeOperation(phase);
@@ -102,7 +104,19 @@ fun runCompilerPhase<T>(_phaseName: String, phase: () -> T): T {
   //  | None() -> phase()
   //  }
   //  }
-  phase()
+  //
+  // When SKC_TIME_PHASES is set, emit a "##TIME## <phase> <ns>" line to
+  // stderr per phase. Gated so there is no overhead on the normal path.
+  if (Environ.varOpt("SKC_TIME_PHASES").isNone()) {
+    phase()
+  } else {
+    // Monotonic (steady_clock), nanosecond-resolution elapsed time.
+    start = Time.time_ns();
+    result = phase();
+    elapsed = Time.time_ns() - start;
+    print_error(`##TIME## ${phaseName} ${elapsed}\n`);
+    result
+  }
 }
 
 /*


### PR DESCRIPTION
## Summary

Revive the `runCompilerPhase` timing hook so `skc` can report a per-phase breakdown of compile time.

`runCompilerPhase` has been a dead stub — a commented-out body that just calls `phase()` — even though the pipeline wraps every phase in it (`native/compile`, `native/create_asm_graph`, `native/link`, `native/write_sklib`, `outer/makeOuter`, and now `frontend+ir`). This makes it real: when `SKC_TIME_PHASES` is set, it emits a `##TIME## <phase> <ns>` line to stderr per phase. With the env var unset it is a plain `phase()` call — **zero overhead** (the timing calls are gated behind the check).

- Uses `Time.time_ns()` — a monotonic (steady_clock), nanosecond-resolution clock meant for measuring elapsed time — rather than the wall-clock `time_ms()`. Sub-millisecond phases that previously rounded to `0` are now visible.
- The commented-out `config.debug`/`config.profile` scaffold (memory statistics, pass dumps, profile-path recording) is **kept** as a roadmap for future per-phase debugging/profiling.

The missing `frontend+ir` wrap (around `OuterIstToIR.createIR`, the dominant phase) landed separately in #1292; this PR builds on it.

## Usage

```
SKC_TIME_PHASES=1 skc -o /tmp/x.bin foo.sk
##TIME## frontend+ir 114809237
##TIME## native/create_asm_graph 38159820
##TIME## native/link 628824709
...
```

Aggregate across a run however you like (e.g. `SKC_TIME_PHASES=1 skargo test 2>&1 | grep '##TIME##'`).

## Provenance

The timing hook was originally part of #1136, whose batch-compilation approach is otherwise superseded. Deliberately scoped to the **compiler-side** hook — mechanism-independent, touches no test-harness files.

## Test plan

- [x] `SKC_TIME_PHASES=1 skc …` emits one `##TIME## <phase> <ns>` line per phase (sub-ms phases visible)
- [x] Unset env var → no output, no behavior change
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
