### PR TITLE
Wrap the frontend/IR phase in runCompilerPhase

### DIFF
--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -293,16 +293,21 @@ fun getOrInitializeBackend(context: mutable SKStore.Context): SKStore.EagerDir {
                 )))
       );
 
-      env = OuterIstToIR.createIR(
-        context,
-        conf,
-        shouldDisasm,
-        shouldRuntimeExport,
-        outerIst,
-        converter,
-        constsProj,
-        defsProj,
-      );
+      // The frontend (naming/typing of the stdlib) is computed lazily and
+      // realized here as createIR forces the typed defs, so this phase
+      // dominates compile time.
+      env = runCompilerPhase("frontend+ir", () -> {
+        OuterIstToIR.createIR(
+          context,
+          conf,
+          shouldDisasm,
+          shouldRuntimeExport,
+          outerIst,
+          converter,
+          constsProj,
+          defsProj,
+        )
+      });
 
       !env = createOptimizedFunctions(context, env, conf);
       defs = runCompilerPhase("native/create_asm_graph", () -> {


### PR DESCRIPTION
## Summary

Every compilation phase is already wrapped in `runCompilerPhase` (`native/compile`, `native/create_asm_graph`, `native/link`, `native/write_sklib`, `outer/makeOuter`, …) — except `OuterIstToIR.createIR`, which forces the lazily-computed stdlib naming/typing and dominates compile time. Wrap it as the `frontend+ir` phase so the phase instrumentation is complete.

This is a **no-op today** — `runCompilerPhase` is currently a pass-through stub — but it means the dominant phase is covered once that hook is enabled (stacked PR #1291).

## Test plan

- [ ] CI green (pure refactor; behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
