### PR TITLE
Fix fast-checks on Noble: --break-system-packages for fmt-py black install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ fmt-js: # Keep in sync with bin/git_hooks/check_format.sh
 
 .PHONY: fmt-py
 fmt-py: # Keep in sync with bin/git_hooks/check_format.sh
-	pip install -q black==$(BLACK_VERSION) && black --quiet --line-length 80 .
+	pip install -q --break-system-packages black==$(BLACK_VERSION) && black --quiet --line-length 80 .
 
 .PHONY: fmt
 fmt: fmt-sk fmt-c fmt-js fmt-py # Keep in sync with bin/git_hooks/check_format.sh


### PR DESCRIPTION
Fixes #1293.

`fast-checks` is red on `main` and every PR: the `fmt-py` Make target runs a system-wide `pip install black`, which Ubuntu 24.04 (Noble) refuses under PEP 668 (`externally-managed-environment`). This surfaced once the `skiplabs/*` CI images were regenerated onto the Noble base from #1261.

One-line fix mirroring the `bin/apt-install.sh` change already made in #1261:

```make
-	pip install -q black==$(BLACK_VERSION) && black --quiet --line-length 80 .
+	pip install -q --break-system-packages black==$(BLACK_VERSION) && black --quiet --line-length 80 .
```

`--break-system-packages` is safe here: CI runs in throwaway containers, and the git-hook path (`bin/git_hooks/check_format.sh`) only checks the installed version rather than installing.

See #1293 for the full failure log and root cause.