### PR TITLE
Add skc --batch: compile many units in one process, sharing stdlib type-checking

### DIFF
--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -288,17 +288,12 @@ private class Config{
   // (dependencies, target, opt level, …) but different inputs, output, and
   // exported entry point.
   fun withUnit(inputs: Array<String>, output: String, mainFn: String): this {
-    exportAs = mutable UnorderedMap[];
-    exportAs.set(mainFn, "skip_main");
     this with {
       input_files => inputs,
       output => output,
-      exportedAsFunctions => exportAs.chill(),
+      exportedAsFunctions => UnorderedMap[mainFn => "skip_main"],
+      batch_mode => true,
     }
-  }
-
-  fun withBatchMode(): this {
-    this with {batch_mode => true}
   }
 }
 

--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -81,6 +81,7 @@ private class Config{
   preambles: Array<String>,
   canonize_paths: Bool,
   cwd: WorkingDirectory,
+  batch_mode: Bool = false,
 } {
   static fun make(results: Cli.ParseResults): this {
     optConfig = Optimize.Config::make(
@@ -281,6 +282,23 @@ private class Config{
 
   fun isWasm(): Bool {
     this.target.startsWith("wasm32");
+  }
+
+  // Derive a per-unit config for batch compilation: same shared settings
+  // (dependencies, target, opt level, …) but different inputs, output, and
+  // exported entry point.
+  fun withUnit(inputs: Array<String>, output: String, mainFn: String): this {
+    exportAs = mutable UnorderedMap[];
+    exportAs.set(mainFn, "skip_main");
+    this with {
+      input_files => inputs,
+      output => output,
+      exportedAsFunctions => exportAs.chill(),
+    }
+  }
+
+  fun withBatchMode(): this {
+    this with {batch_mode => true}
   }
 }
 

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -362,7 +362,10 @@ fun compile(
     skipExit(4); // Exit code used by g++ for no input files
   };
 
-  ensureCompatibleLLVMVersion();
+  // In batch mode the LLVM version is checked once, up front.
+  if (!config.batch_mode) {
+    ensureCompatibleLLVMVersion()
+  };
 
   getOrInitializeBackend(context).writeArray(
     context,
@@ -387,6 +390,38 @@ fun compile(
   );
 
   context.update()
+}
+
+// Compile many units in one process on a single SKStore context. The
+// dependencies (stdlib) are written once and left unchanged across units,
+// so the reactive engine types them only for the first unit and reuses that
+// typed result for the rest — where the ~64% stdlib type-checking cost of a
+// one-shot compile normally is. Each manifest line is:
+//   <output> <mainFn> <input.sk> [<input2.sk> ...]
+// (whitespace-separated), where <mainFn> is exported as skip_main.
+fun compile_batch(
+  base_config: Config.Config,
+  context: mutable SKStore.Context,
+  manifest_path: String,
+): void {
+  ensureCompatibleLLVMVersion();
+  config = base_config.withBatchMode();
+  lines = FileSystem.readTextFile(manifest_path).split("\n");
+  for (line in lines) {
+    parts = line.split(" ").filter(p -> !p.isEmpty()).collect(Array);
+    if (parts.isEmpty()) {
+      continue
+    };
+    if (parts.size() < 3) {
+      print_error(`Invalid batch manifest line: ${line}\n`);
+      skipExit(1)
+    };
+    output = parts[0];
+    mainFn = parts[1];
+    inputs = parts.drop(2);
+    unit_config = config.withUnit(inputs, output, mainFn);
+    compile(unit_config, context, inputs)
+  }
 }
 
 fun compile_llvm_ir(

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -405,7 +405,6 @@ fun compile_batch(
   manifest_path: String,
 ): void {
   ensureCompatibleLLVMVersion();
-  config = base_config.withBatchMode();
   lines = FileSystem.readTextFile(manifest_path).split("\n");
   for (line in lines) {
     parts = line.split(" ").filter(p -> !p.isEmpty()).collect(Array);
@@ -419,7 +418,7 @@ fun compile_batch(
     output = parts[0];
     mainFn = parts[1];
     inputs = parts.drop(2);
-    unit_config = config.withUnit(inputs, output, mainFn);
+    unit_config = base_config.withUnit(inputs, output, mainFn);
     compile(unit_config, context, inputs)
   }
 }

--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -94,6 +94,13 @@ fun main(): void {
         "Extra linker arguments (space separated).",
       ),
     )
+    .arg(
+      Cli.Arg::string("batch").about(
+        "Compile many units in one process, sharing stdlib type-checking. " +
+          "Argument is a manifest file with one unit per line: " +
+          "<output> <mainFn> <input.sk> [<input2.sk> ...].",
+      ),
+    )
     .arg(Cli.Arg::string("files").positional().repeatable())
     .parseArgs();
 
@@ -115,6 +122,8 @@ fun main(): void {
 
   config = Config.Config::make(results);
 
+  batchManifest = results.maybeGetString("batch");
+
   isInit = results.maybeGetString("init").isSome();
   if (isInit) {
     _ = SKStore.gContextInit(SKStore.Context::create{});
@@ -125,7 +134,10 @@ fun main(): void {
       SKStore.CStop(
         Some((context, _, _) ~> {
           try {
-            compile(config, context, config.input_files)
+            batchManifest match {
+            | Some(manifest) -> compile_batch(config, context, manifest)
+            | None() -> compile(config, context, config.input_files)
+            }
           } catch {
           | exn ->
             print_error(exn.getMessage());


### PR DESCRIPTION
## Summary

Implements #1296. Every one-shot `skc` re-type-checks the entire stdlib from source — ~64% of a compile (#1295), redone identically every time. `--batch <manifest>` compiles many units **on a single SKStore context**, so the stdlib is typed **once** and reused for the rest via the reactive engine's incremental memoization.

- `compile()` is already idempotent on a reused context (`getOrInitializeBackend` returns the existing dir; `FileCache.writeFiles` amortizes unchanged dependencies; `context.update()` re-types only the changed input). Batch just drives it in a loop over one context.
- Manifest is one unit per line: `<output> <mainFn> <input.sk> [<input2.sk> ...]`, where `<mainFn>` is exported as `skip_main`.
- New `Config.withUnit(inputs, output, mainFn)` derives a per-unit config from the shared base (same dependencies/target/opt-level); `Config.batch_mode` skips the per-unit LLVM-version check.

## Measured (this machine, `-O0 --no-inline`)

| units | batch | subprocess (N× `skc`) | speedup |
|--:|--:|--:|--:|
| 5 | 6.6 s | 24.1 s | **3.6×** |
| 30 | 18.2 s | ~147 s | **~8×** |

Marginal cost is ~500–700 ms/unit after the one-time ~3.15 s stdlib typing — i.e. the stdlib type-checking is paid once, not per file. Verified correct: 30/30 outputs match their `.exp`, and batch outputs are **byte-identical** to one-shot outputs (no cross-unit state leak).

## Behavior / scope

- A compile error is reported and **stops** at the failing unit (earlier units' outputs are already written) — build-style semantics; no context corruption since it exits.
- The non-batch path is unchanged (`batch_mode` defaults false; `--batch` is opt-in).
- Scope limit (by design): this shares typing **within one process**. Sharing across separate `skc` invocations (incremental single-file rebuilds) is the companion #1297 (persist the warm context).

## Follow-ups

- Continue-on-error with per-unit isolation (fork/COW) for test-runner use — needs the deferred-error handling explored in the old batch prototype.
- Wiring `skargo` / the test harness's subprocess-fallback path to use `--batch`.

## Test plan

- [x] 5- and 30-unit batches compile; every output matches `.exp`
- [x] batch outputs byte-identical to one-shot `skc`
- [x] compile error reports + stops at the failing unit
- [x] non-batch compile unchanged
- [ ] CI (full suite exercises the unchanged non-batch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
