### PR TITLE
Add SKStore.withForkedContext for isolated per-call computations

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1939,6 +1939,34 @@ fun withRegionValue<T>(f: () ~> T): T {
   }
 }
 
+// Run `f` on a throwaway copy-on-write clone of `context`, inside a fresh
+// region. The clone isolates any mutations `f` makes (they never touch
+// `context`), and the region reclaims the clone's memory when `f` returns —
+// so repeated use does not accumulate state. Only `f`'s return value is
+// copied out. This is the read-only-base + per-call fork pattern without the
+// named-fork registry.
+fun withForkedContext<T>(
+  context: mutable Context,
+  f: (mutable Context) ~> T,
+): T {
+  optSaved: ?Obstack = None();
+  try {
+    !optSaved = Some(newObstack());
+    saved = optSaved.fromSome();
+    fresult = f(context.mclone());
+    destroyObstackWithValue(saved, fresult)
+  } catch {
+  | exn ->
+    optSaved match {
+    | Some(saved) ->
+      cexn = destroyObstackWithValue(saved, exn);
+      replaceExn(cexn);
+      throw cexn
+    | None() -> throw exn
+    }
+  }
+}
+
 /*
   Use with caution!!!
   If f if a unnamed closure, It can only capture variables from ancestors obstack of saved.

--- a/skiplang/prelude/tests/skfs/TestWithForkedContext.sk
+++ b/skiplang/prelude/tests/skfs/TestWithForkedContext.sk
@@ -1,0 +1,29 @@
+/*****************************************************************************/
+/* Testing withForkedContext: run on a throwaway forked context, isolated
+   from the base, with the result copied out. */
+/*****************************************************************************/
+
+module alias T = SKTest;
+
+module SKStoreTest;
+
+@test
+fun testWithForkedContext(): void {
+  context = SKStore.Context::mcreate{};
+  context.setGlobal("k", SKStore.StringFile("base"));
+
+  // Run on a fork: mutate the fork's state and return a value derived from it.
+  result = SKStore.withForkedContext(context, ctx ~> {
+    ctx.setGlobal("k", SKStore.StringFile("fork"));
+    SKStore.StringFile::type(ctx.getGlobal("k").fromSome()).value + "!"
+  });
+
+  // The fork's return value is copied out of the region.
+  T.expectEq(result, "fork!", "withForkedContext returns the fork's result");
+
+  // The base context is untouched by the fork's mutation.
+  base = SKStore.StringFile::type(context.getGlobal("k").fromSome()).value;
+  T.expectEq(base, "base", "withForkedContext isolates the base context")
+}
+
+module end;


### PR DESCRIPTION
## Summary

Adds `SKStore.withForkedContext<T>(context, f: (mutable Context) ~> T): T` — a combinator that runs `f` on a throwaway copy-on-write clone of a context inside a fresh region:

- **Isolated:** any mutations `f` makes are on the clone; the base `context` is never touched.
- **Bounded memory:** the region reclaims the clone's memory when `f` returns, so running many computations against one base doesn't accumulate state. Only `f`'s return value is copied out.

It's the read-only-base + per-call fork pattern using the primitives `fork()` is built on (`mclone` + an obstack region), without the named-fork registry — a good fit for running many independent computations against one warm base (e.g. compiling many files that share a typed stdlib; see the stacked batch PR that uses it).

## Test

`TestWithForkedContext` sets a global on the base, mutates it on a fork, and checks that (a) the fork's derived result is copied out and (b) the base global is unchanged — verifying both the return-value copy-out and the isolation. (Verified standalone: prints `fork! base`.)

## Test plan

- [x] `testWithForkedContext` — fork result copied out; base isolated
- [ ] CI (`prelude` runs the skfs tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
