### PR TITLE
circleci: adopt `circleci tests run` for skdb-wasm (rerun failed tests)

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -106,11 +106,9 @@ jobs:
       - run:
           name: Run wasm skdb tests
           no_output_timeout: 15m
-          command: |
-            mkdir -p ~/test-results
-            make test-wasm
+          command: make test-wasm
       - store_test_results:
-          path: ~/test-results/skdb-wasm.xml
+          path: ~/test-results
 
   skip-package-build:
     docker:

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -35,7 +35,7 @@ run-test:
 	cd ts/tests && make ROOT_DIR=${SCRIPT_DIR} -f service_common.mk
 	cd ts/tests && make ROOT_DIR=${SCRIPT_DIR} -f service_server.mk
 	cd ts/tests && make ROOT_DIR=${SCRIPT_DIR} -f service_mux.mk
-	cd ts/tests && npx playwright test --reporter=line
+	cd ts/tests && ./run-playwright.sh
 
 .PHONY: test
 test: install-test run-test

--- a/sql/ts/tests/run-playwright.sh
+++ b/sql/ts/tests/run-playwright.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run the skdb wasm playwright test suite.
+#
+# In CircleCI (CIRCLECI is set) the suite is wrapped in `circleci tests run` so
+# the "Rerun failed tests" button reruns only the spec files that failed, and a
+# JUnit report is emitted for CircleCI to track failures. `circleci tests run`
+# re-invokes this script with the (failed, on a rerun) spec files as arguments,
+# taking the runner branch below. Everywhere else -- local `make test` -- we run
+# the whole suite directly with the line reporter.
+set -euo pipefail
+
+cd "$(dirname "$0")" || exit 1
+self="$PWD/$(basename "$0")"
+
+if [ -n "${CIRCLECI:-}" ] && [ -z "${SKDB_WASM_TESTS_INNER:-}" ]; then
+    # Orchestrator: let `circleci tests run` pick the specs (all of them
+    # normally, only the previously-failed ones on a rerun).
+    mkdir -p "$HOME/test-results"
+    export SKDB_WASM_TESTS_INNER=1
+    export PLAYWRIGHT_JUNIT_OUTPUT_NAME="$HOME/test-results/skdb-wasm.xml"
+    # -r: an empty rerun set is a no-op rather than a full re-run.
+    circleci tests glob "*.play.ts" \
+        | circleci tests run --command="xargs -r $self" --verbose
+else
+    # Runner: the given spec files, or the whole suite if none were passed.
+    reporter="line"
+    [ -n "${PLAYWRIGHT_JUNIT_OUTPUT_NAME:-}" ] && reporter="line,junit"
+    exec npx playwright test --reporter="$reporter" "$@"
+fi


### PR DESCRIPTION
Advances #1155 — adapt CI to CircleCI's [Rerun failed tests](https://circleci.com/docs/guides/test/rerun-failed-tests/) feature.

That feature requires a test job to (1) `store_test_results`, (2) emit JUnit XML with a `file`/`classname` attribute, and (3) run tests through `circleci tests run --command="xargs …"`. On a rerun, `circleci tests run` ignores the piped glob and instead feeds the previously-failed filenames on stdin, which `xargs` turns into positional args for the runner.

This PR converts the **skdb-wasm** (playwright) job, which is the cleanest fit and also fixes a latent bug.

### Design: the CI job still just runs `make test-wasm`
Rather than expand the build into the CI YAML, the rerun wrapping lives in `sql/ts/tests/run-playwright.sh` — the single place that owns how these tests run — and `make run-test` already calls it (one-line Makefile change). The script self-dispatches:

- **Local / non-CircleCI** → `npx playwright test --reporter=line` (whole suite). Unchanged behaviour.
- **CircleCI, initial invocation** → wraps the suite in `circleci tests glob "*.play.ts" | circleci tests run --command='xargs -r <self>'` and turns on the JUnit reporter via `PLAYWRIGHT_JUNIT_OUTPUT_NAME`.
- **CircleCI, re-invoked by `circleci tests run`** (with spec files as args, on the initial run and on reruns) → runs playwright on just those files.

So `.circleci/base.yml` goes back to `command: make test-wasm`; the only CI change is `store_test_results` now pointing at the `~/test-results` dir it actually populates.

### Why it reruns the right files
Playwright's JUnit reporter records the spec file as each testcase's `classname` (e.g. `node.play.ts`) — what CircleCI uses to rerun only the failed files — and it's also a valid playwright file filter, so a rerun runs `run-playwright.sh node.play.ts`. This also fixes the `store_test_results` upload, which previously pointed at a `skdb-wasm.xml` the `--reporter=line` run never produced (a silent no-op).

### Scope / follow-ups
Staged intentionally. Remaining jobs need more than config plumbing:
- **skipruntime (mocha):** mocha's JUnit reporters put the spec path only on `<testsuite>` and set testcase `classname` to the *test title*, which would make `xargs mocha "<title>"` fail on rerun. Needs a small custom reporter to expose a testcase-level file identifier.
- **compiler / skip-package-tests (skargo/sktest):** sktest's filter is a single substring on `suite.name` with no "run only these files" mode, so file-level rerun needs a sktest/skargo change + bootstrap.

### Validation
- `circleci config validate` passes on the assembled config (base.yml + a workflow scheduling `skdb-wasm`).
- `run-playwright.sh` is shellcheck-clean under the repo's `check-sh` flags.
- Smoke-tested the real script for every path: local ⇒ `--reporter=line` (all specs); CI initial ⇒ orchestrate ⇒ `--reporter=line,junit browser.play.ts node.play.ts`; CI rerun (only `node.play.ts` failed) ⇒ `--reporter=line,junit node.play.ts`; empty set ⇒ `xargs -r` no-op; and the `SKDB_WASM_TESTS_INNER` guard makes re-orchestration (recursion) impossible.
- An earlier CI run of this job uploaded real per-test results with `classname` = the spec file, confirming the rerun feature has the identifier it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)