### PR TITLE
compiler: backend mapper emits errors as output, not from the reactive computation

### DIFF
--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -194,6 +194,22 @@ fun ensureCompatibleLLVMVersion(): void {
 
 class TickConfigFile(value: (Int, Config.Config)) extends SKStore.File
 
+// Sink of the backend mapper: for each unit, the compile errors it produced
+// (empty/absent on success). The mapper *emits its outcome* here rather than
+// reporting errors from inside the reactive computation; `compile()` reads it
+// back after `update()` and decides what to do.
+const backendSinkDirName: SKStore.DirName = SKStore.DirName::create(
+  "/backendSink/",
+);
+const backendSinkDir: SKStore.EHandle<
+  SKStore.UnitID,
+  SkipError.ErrorsFile,
+> = SKStore.EHandle(
+  SKStore.UnitID::keyType,
+  SkipError.ErrorsFile::type,
+  backendSinkDirName,
+);
+
 fun getOrInitializeBackend(context: mutable SKStore.Context): SKStore.EagerDir {
   backendDirName = SKStore.DirName::create("/backend/");
   context.unsafeMaybeGetEagerDir(backendDirName) match {
@@ -229,22 +245,26 @@ fun getOrInitializeBackend(context: mutable SKStore.Context): SKStore.EagerDir {
   );
 
   _ = backendDir.map(
-    SKStore.SID::keyType,
-    TickConfigFile::type,
+    SKStore.UnitID::keyType,
+    SkipError.ErrorsFile::type,
     context,
-    SKStore.DirName::create("/backendSink/"),
-    (context, _writer, _key, values) ~> {
+    backendSinkDirName,
+    (context, writer, key, values) ~> {
       (_, conf) = values.first.value;
 
       context.getGlobal("ERRORS") match {
       | None() -> void
       | Some(errors) ->
-        SkipError.printErrorsAndExit(
-          SkipError.ErrorsFile::type(errors).value.reversed().toArray(),
-          file -> {
-            FileCache.fileDir.unsafeGetArray(context, file)[0].value
-          },
-        )
+        // A compile error: emit it as this unit's outcome and stop. Reporting
+        // (or, in batch mode, recovering) is `compile()`'s job — doing control
+        // flow from inside the reactive mapper would corrupt the context.
+        writer.set(
+          key,
+          SkipError.ErrorsFile(
+            SkipError.ErrorsFile::type(errors).value.reversed(),
+          ),
+        );
+        return void
       };
 
       if (conf.check) {
@@ -389,7 +409,18 @@ fun compile(
     make_input_source_path,
   );
 
-  context.update()
+  context.update();
+
+  // The backend mapper records any compile errors as this unit's outcome in
+  // `/backendSink/` (absent on success). Report them here, out of the reactive
+  // computation.
+  backendSinkDir.maybeGet(context, SKStore.UnitID::singleton) match {
+  | Some(ef) if (!ef.value.isEmpty()) ->
+    SkipError.printErrorsAndExit(ef.value.toArray(), file -> {
+      FileCache.fileDir.unsafeGetArray(context, file)[0].value
+    })
+  | _ -> void
+  }
 }
 
 // Compile many units in one process on a single SKStore context. The


### PR DESCRIPTION
## Summary

The reactive `/backendSink/` mapper used to report compile errors by calling `printErrorsAndExit` from **inside** the reactive computation. Doing control flow — and in the error path, throwing — from within a mapper is a footgun: it can leave the SKStore context in an inconsistent state.

This makes the mapper **emit its outcome** instead: on a compile error it writes the unit's `ErrorsFile` to `/backendSink/` (and writes nothing on success). `compile()` reads that back after `context.update()` and reports the errors *out* of the reactive computation.

Pure refactor — no behavior change:
- Same errors printed, same exit code (2), same "no output on failure".
- Reuses the existing `SkipError.ErrorsFile` / `printErrorsAndExit`; no new error types.
- The mapper stops doing process control; `compile()` owns the decision.

It also gives batch continue-on-error (#1299) a clean per-unit outcome to branch on, instead of a side-channel global.

## Verified

Rebuilt `stage1` and exercised every path with the new `skc`:
- **Valid non-batch** compile → runs, correct output.
- **Non-batch compile error** → the type error is printed and exit is 2, via the moved `printErrorsAndExit`; no binary produced.
- **Valid batch** → all units built and run correctly.
- **Batch with an error** → stops at the first failure (exit 2), units before it built — unchanged from `main`.

## Test plan

- [x] non-batch valid + compile-error paths
- [x] batch valid + error paths
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)