### PR TITLE
circleci: rerun-failed-tests for the skipruntime mocha job

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -185,7 +185,7 @@ jobs:
             cd skipruntime-ts/tests/native_addon_unreleased
             ./run.sh
       - store_test_results:
-          path: ~/test-results/skipruntime.xml
+          path: ~/test-results
 
   skipruntime-bun:
     docker:

--- a/skipruntime-ts/tests/.mocharc.json
+++ b/skipruntime-ts/tests/.mocharc.json
@@ -1,4 +1,3 @@
 {
-  "spec": ["./dist/**/*.spec.js"],
   "timeout": 30000
 }

--- a/skipruntime-ts/tests/junit-spec-reporter.cjs
+++ b/skipruntime-ts/tests/junit-spec-reporter.cjs
@@ -1,0 +1,148 @@
+"use strict";
+
+// A self-contained mocha reporter (no external dependencies).
+//
+// It extends mocha's built-in `spec` reporter so the normal console output is
+// preserved, and additionally writes a JUnit XML report in which every
+// `<testcase>` carries a `file` attribute set to the *relative* spec-file path.
+//
+// CircleCI's "rerun failed tests" (`circleci tests run`) keys reruns on that
+// `file` attribute and feeds it back to `xargs mocha <file>`, so it must be a
+// runnable spec path matching what `circleci tests glob` produces. The stock
+// mocha-junit-reporter only records `file` on `<testsuite>` and sets
+// `<testcase classname>` to the test title, neither of which CircleCI can rerun
+// on -- hence this reporter. The XML shape mirrors what sktest emits (see
+// skiplang/sktest/src/reporter.sk).
+//
+// Output path (first non-empty wins): $MOCHA_FILE, then the `mochaFile`
+// reporter option, then ./test-results.xml.
+
+const fs = require("fs");
+const path = require("path");
+const Mocha = require("mocha");
+
+const Spec = Mocha.reporters.Spec;
+const { EVENT_TEST_PASS, EVENT_TEST_FAIL, EVENT_TEST_PENDING, EVENT_RUN_END } =
+  Mocha.Runner.constants;
+
+// Drop code points that are forbidden in XML 1.0 (every C0 control except tab,
+// LF and CR) -- no escaping can legalize them, so a raw ESC (from ANSI-coloured
+// assertion diffs), NUL, etc. in an error message/stack would otherwise make
+// the whole report unparseable and break CircleCI's rerun tracking.
+function stripInvalidXml(s) {
+  // eslint-disable-next-line no-control-regex
+  return String(s).replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, "");
+}
+
+function escapeAttr(s) {
+  return stripInvalidXml(s)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\r/g, "&#13;")
+    .replace(/\n/g, "&#10;")
+    .replace(/\t/g, "&#9;");
+}
+
+function escapeText(s) {
+  return stripInvalidXml(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// Full suite path minus the test's own title, e.g. "outer inner".
+function suiteTitle(test) {
+  return test.titlePath().slice(0, -1).join(" ");
+}
+
+// Spec-file path relative to cwd (the tests package dir), so it matches the
+// `circleci tests glob` output and is runnable as `mocha <file>`.
+function relFile(test) {
+  const abs = test.file || (test.parent && test.parent.file) || "";
+  return abs ? path.relative(process.cwd(), abs) : "";
+}
+
+function JUnitSpecReporter(runner, options) {
+  // Keep mocha's default spec console output.
+  Spec.call(this, runner, options);
+
+  const results = [];
+  const reporterOptions = (options && options.reporterOptions) || {};
+  const outFile =
+    process.env.MOCHA_FILE || reporterOptions.mochaFile || "test-results.xml";
+
+  runner.on(EVENT_TEST_PASS, (test) => results.push({ test, state: "passed" }));
+  runner.on(EVENT_TEST_FAIL, (test, err) =>
+    results.push({ test, state: "failed", err }),
+  );
+  runner.on(EVENT_TEST_PENDING, (test) =>
+    results.push({ test, state: "pending" }),
+  );
+
+  runner.on(EVENT_RUN_END, () => {
+    // Group by spec file so each <testsuite> maps to one runnable file.
+    const byFile = new Map();
+    for (const r of results) {
+      const file = relFile(r.test);
+      if (!byFile.has(file)) byFile.set(file, []);
+      byFile.get(file).push(r);
+    }
+
+    const totalTests = results.length;
+    const totalFailures = results.filter((r) => r.state === "failed").length;
+    const totalTime = results.reduce(
+      (acc, r) => acc + (r.test.duration || 0) / 1000,
+      0,
+    );
+
+    const lines = ['<?xml version="1.0" encoding="UTF-8"?>'];
+    lines.push(
+      `<testsuites name="Mocha Tests" tests="${totalTests}" failures="${totalFailures}" time="${totalTime}">`,
+    );
+
+    for (const [file, group] of byFile) {
+      const failures = group.filter((r) => r.state === "failed").length;
+      const skipped = group.filter((r) => r.state === "pending").length;
+      const time = group.reduce(
+        (acc, r) => acc + (r.test.duration || 0) / 1000,
+        0,
+      );
+      lines.push(
+        `  <testsuite name="${escapeAttr(file)}" file="${escapeAttr(file)}" tests="${group.length}" failures="${failures}" skipped="${skipped}" time="${time}">`,
+      );
+
+      for (const r of group) {
+        const test = r.test;
+        lines.push(
+          `    <testcase name="${escapeAttr(test.title)}" classname="${escapeAttr(suiteTitle(test))}" file="${escapeAttr(file)}" time="${(test.duration || 0) / 1000}">`,
+        );
+        if (r.state === "failed") {
+          const err = r.err || {};
+          const message = err.message || String(err);
+          lines.push(
+            `      <failure message="${escapeAttr(message)}" type="${escapeAttr(err.name || "Error")}">${escapeText(err.stack || message)}</failure>`,
+          );
+        } else if (r.state === "pending") {
+          lines.push("      <skipped/>");
+        }
+        lines.push("    </testcase>");
+      }
+
+      lines.push("  </testsuite>");
+    }
+
+    lines.push("</testsuites>");
+
+    fs.mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
+    fs.writeFileSync(outFile, lines.join("\n") + "\n");
+  });
+}
+
+// Preserve Spec's prototype so mocha treats this as a proper reporter.
+JUnitSpecReporter.prototype = Object.create(Spec.prototype);
+JUnitSpecReporter.prototype.constructor = JUnitSpecReporter;
+
+module.exports = JUnitSpecReporter;

--- a/skipruntime-ts/tests/package.json
+++ b/skipruntime-ts/tests/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint src/",
-    "test": "mocha"
+    "test": "./run-mocha.sh"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/skipruntime-ts/tests/run-mocha.sh
+++ b/skipruntime-ts/tests/run-mocha.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Run the skipruntime mocha unit-test suite.
+#
+# In CircleCI (CIRCLECI is set) the suite is wrapped in `circleci tests run` so
+# the "Rerun failed tests" button reruns only the spec files that failed, and a
+# JUnit report is emitted (via junit-spec-reporter.cjs) for CircleCI to track
+# failures. `circleci tests run` re-invokes this script with the (failed, on a
+# rerun) spec files as arguments, taking the runner branch below. Everywhere
+# else -- local `npm test` / `make test` -- we run the whole suite with mocha's
+# default spec reporter.
+#
+# NB: .mocharc.json must NOT set `spec`. mocha 11 *merges* positional spec files
+# with a configured `spec`, so a configured glob would make every rerun re-run
+# the whole suite. The spec glob lives here instead.
+set -euo pipefail
+
+cd "$(dirname "$0")" || exit 1
+self="$PWD/$(basename "$0")"
+specs="dist/**/*.spec.js"
+
+if [ -n "${CIRCLECI:-}" ] && [ -z "${SKIPRUNTIME_TESTS_INNER:-}" ]; then
+    # Orchestrator: let `circleci tests run` pick the specs (all of them
+    # normally, only the previously-failed ones on a rerun).
+    mkdir -p "$HOME/test-results"
+    export SKIPRUNTIME_TESTS_INNER=1
+    # A single fixed report path is fine: the spec set is one xargs batch, so
+    # one mocha run writes it. store_test_results ingests the whole directory.
+    export MOCHA_FILE="$HOME/test-results/skipruntime.xml"
+    files=$(circleci tests glob "$specs")
+    # Fail loudly rather than pass green with zero tests if nothing matched
+    # (e.g. dist not built); `circleci tests run` would otherwise no-op.
+    [ -n "$files" ] || { echo "run-mocha.sh: no spec files matched '$specs' (is dist built?)" >&2; exit 1; }
+    # -r: an empty rerun set is a no-op rather than a full re-run. Single-quote
+    # $self so it survives the shell re-parse inside `circleci tests run`.
+    printf '%s\n' "$files" \
+        | circleci tests run --command="xargs -r '$self'" --verbose
+else
+    # Runner: the given spec files, or the whole suite if none were passed.
+    # junit-spec-reporter.cjs also prints mocha's normal spec output, so use it
+    # whenever a JUnit report is wanted (CI); plain spec reporter otherwise.
+    reporter="spec"
+    [ -n "${MOCHA_FILE:-}" ] && reporter="./junit-spec-reporter.cjs"
+    if [ "$#" -eq 0 ]; then
+        exec npx mocha --reporter "$reporter" "$specs"
+    else
+        exec npx mocha --reporter "$reporter" "$@"
+    fi
+fi


### PR DESCRIPTION
Advances #1155 (staged follow-up to #1305, which did the skdb-wasm/playwright job). Converts the **skipruntime** job's mocha unit tests to CircleCI's [Rerun failed tests](https://circleci.com/docs/guides/test/rerun-failed-tests/), so a rerun re-runs only the spec files that failed.

### Design — CI stays a thin `make test-skipruntime-ts`
Mirroring the skdb-wasm approach, all the logic lives in a script the build already invokes, not in the CI YAML:

- **`skipruntime-ts/tests/run-mocha.sh`** (new) is what `npm test` now runs. It self-dispatches:
  - Local / non-CircleCI → `mocha` over the whole suite with the spec reporter (unchanged behaviour).
  - CircleCI → wraps the run in `circleci tests glob 'dist/**/*.spec.js' | circleci tests run --command="xargs -r '<self>'"` and turns on the JUnit reporter.
  - Re-invoked by `circleci tests run` with spec-file args (initial run and reruns) → runs just those files.
- **`skipruntime-ts/tests/junit-spec-reporter.cjs`** (new) is a small, **zero-dependency** reporter that extends mocha's `spec` reporter (so console output is preserved) and writes JUnit in which every `<testcase>` carries `file="<relative spec path>"` — the identifier CircleCI keys reruns on. (The stock `mocha-junit-reporter` only puts `file` on `<testsuite>` and sets `<testcase classname>` to the test title, neither of which CircleCI can rerun on.)
- `.circleci/base.yml`: only `store_test_results` changes (→ the `~/test-results` directory it now actually populates). The job command is untouched.

### Two subtleties handled
- **mocha 11 merges** positional spec files with a configured `.mocharc` `spec`, which would make every rerun re-run the *whole* suite — so `spec` is removed from `.mocharc.json` and the glob lives in `run-mocha.sh` (verified: with no config `spec`, `mocha dist/b.spec.js` runs only b).
- This also **fixes the `store_test_results` upload**, which pointed at a `skipruntime.xml` the reporter-less run never produced (a silent no-op).

### From the adversarial review (all fixed/handled)
- Reporter **strips XML-forbidden control chars** (e.g. ESC from ANSI-coloured assertion diffs) so a failure message can't produce unparseable XML and break rerun tracking.
- `run-mocha.sh` **fails loudly if the spec glob matches nothing** (dist not built) instead of passing green with zero tests.
- `$self` is **single-quoted** inside `--command` to survive an odd checkout path.
- A reviewer finding that `store_test_results` needs `when: always` was **refuted** (CircleCI runs the store step after a failed `circleci tests run`, per its documented pattern — which the repo already relies on).

### Scope / remaining
`skipruntime-bun` is untouched (separate job, calls mocha directly via `.mocharc.bun.json`, no `store_test_results`). The compiler / skip-package-tests (skargo/sktest) jobs are still a separate follow-up (sktest needs a run-only-these-files mode + bootstrap).

### Validation
- `circleci config validate` passes; `run-mocha.sh` is shellcheck-clean.
- Reporter verified with mocha 11.1.0: emits `file=` per `<testcase>`, console output intact, and (post-fix) produces well-formed XML even when a failure message contains NUL/ESC/VT/FF.
- Every `run-mocha.sh` branch exercised end-to-end (stubbed `circleci`, real mocha, ESM specs matching tsc output): local full run, CI initial (both specs → JUnit), CI rerun (only the failed spec), empty-glob guard (exits non-zero), spaced checkout path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
