### PR TITLE
circleci: harden run-playwright.sh rerun orchestration

### DIFF
--- a/sql/ts/tests/run-playwright.sh
+++ b/sql/ts/tests/run-playwright.sh
@@ -18,9 +18,14 @@ if [ -n "${CIRCLECI:-}" ] && [ -z "${SKDB_WASM_TESTS_INNER:-}" ]; then
     mkdir -p "$HOME/test-results"
     export SKDB_WASM_TESTS_INNER=1
     export PLAYWRIGHT_JUNIT_OUTPUT_NAME="$HOME/test-results/skdb-wasm.xml"
-    # -r: an empty rerun set is a no-op rather than a full re-run.
-    circleci tests glob "*.play.ts" \
-        | circleci tests run --command="xargs -r $self" --verbose
+    files=$(circleci tests glob "*.play.ts")
+    # Fail loudly rather than pass green with zero tests if nothing matched;
+    # `circleci tests run` would otherwise no-op.
+    [ -n "$files" ] || { echo "run-playwright.sh: no spec files matched '*.play.ts'" >&2; exit 1; }
+    # -r: an empty rerun set is a no-op rather than a full re-run. Single-quote
+    # $self so it survives the shell re-parse inside `circleci tests run`.
+    printf '%s\n' "$files" \
+        | circleci tests run --command="xargs -r '$self'" --verbose
 else
     # Runner: the given spec files, or the whole suite if none were passed.
     reporter="line"


### PR DESCRIPTION
Small follow-up to #1305 (skdb-wasm rerun-failed-tests). The adversarial review of the sibling `run-mocha.sh` change (#1307) surfaced two latent gaps that `run-playwright.sh` shares:

- **Empty glob passes green.** If `circleci tests glob "*.play.ts"` matches nothing (specs renamed / dist not built), `circleci tests run` receives an empty list and no-ops, so the wrapped step exits 0 with **zero tests run** — a silently green job. This now fails loudly. (`xargs -r` still keeps a genuinely-empty *rerun* set a no-op.)
- **`$self` unquoted in `--command`.** It is interpolated into a string that `circleci tests run` re-parses through a shell, so a checkout path containing spaces would word-split it. Now single-quoted.

Both are defensive — the current checkout path is clean and the specs exist — but they make the orchestration robust and keep it consistent with `run-mocha.sh` (#1307), which ships with the same guards.

Verified: shellcheck-clean; stub test confirms an empty glob now exits non-zero and a non-empty glob still runs playwright with the spec files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)