### PR TITLE
circleci: rerun-failed-tests for the compiler & skip-package-tests jobs

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -73,12 +73,17 @@ jobs:
       - run:
           name: Run compiler tests
           no_output_timeout: 30m
+          # run-sktest.sh wraps `skargo test` in `circleci tests run` so the
+          # "Rerun failed tests" button reruns only the failed test suites.
           command: |
             mkdir -p ~/test-results
+            root="$PWD"
             cd skiplang/compiler && make STAGE=1
-            PATH=$(realpath ./stage1/bin):$PATH skargo test --jobs 8 --junitxml ~/test-results/skc.xml
+            PATH=$(realpath ./stage1/bin):$PATH \
+              SKTEST_JOBS=8 SKTEST_JUNIT=$HOME/test-results/skc.xml \
+              "$root/bin/run-sktest.sh"
       - store_test_results:
-          path: ~/test-results/skc.xml
+          path: ~/test-results
 
   skdb:
     docker:
@@ -137,9 +142,14 @@ jobs:
           submodules: true
       - run:
           name: Run << parameters.dir >> tests
+          # run-sktest.sh wraps `skargo test` in `circleci tests run` so the
+          # "Rerun failed tests" button reruns only the failed test suites.
           command: |
             mkdir -p ~/test-results
-            cd << parameters.dir >> && skargo test --jobs 2 --junitxml ~/test-results/$(tr / - \<<< "<< parameters.dir >>").xml
+            root="$PWD"
+            cd << parameters.dir >>
+            SKTEST_JOBS=2 SKTEST_JUNIT=$HOME/test-results/$(tr / - \<<< "<< parameters.dir >>").xml \
+              "$root/bin/run-sktest.sh"
       - store_test_results:
           path: ~/test-results
 

--- a/bin/run-sktest.sh
+++ b/bin/run-sktest.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Run `skargo test` for the current package (cwd), wrapped in `circleci tests
+# run` under CircleCI so the "Rerun failed tests" button reruns only the test
+# suites that failed. Invoke from the package directory. Reads from the env:
+#   SKTEST_JUNIT  optional JUnit output path (forwarded as --junitxml)
+#   SKTEST_JOBS   optional parallelism    (forwarded as --jobs)
+#
+# The failed suite names reach the unchanged `skargo test` via SKTEST_FILTERS
+# (newline-separated), which the sktest harness reads; `skargo test --list`
+# enumerates the suites -- the JUnit `classname` CircleCI keys reruns on, since
+# sktest has no usable per-test source file.
+set -euo pipefail
+
+self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+args=()
+[ -n "${SKTEST_JOBS:-}" ] && args+=(--jobs "$SKTEST_JOBS")
+if [ -n "${SKTEST_JUNIT:-}" ]; then
+    args+=(--junitxml "$SKTEST_JUNIT")
+    mkdir -p "$(dirname "$SKTEST_JUNIT")"
+    # The JUnit reporter appends; drop any stale report so a re-run (or a
+    # multi-batch xargs) rewrites it cleanly instead of concatenating documents.
+    rm -f "$SKTEST_JUNIT"
+fi
+
+if [ -z "${CIRCLECI:-}" ]; then
+    # Local: run the whole suite directly.
+    exec skargo test "${args[@]}"
+fi
+
+if [ "$#" -eq 0 ]; then
+    # Orchestrator: enumerate suites (this also builds the test target once);
+    # `circleci tests run` picks which to run -- all of them normally, only the
+    # previously-failed ones on a rerun -- and re-invokes us with them as args.
+    suites=$(skargo test --list)
+    [ -n "$suites" ] || { echo "run-sktest.sh: no test suites found" >&2; exit 1; }
+    # -r: an empty rerun set is a no-op. -d '\n': split only on newlines (suite
+    # names are safe today, but this stops xargs word-splitting/quote-processing
+    # them). Single-quote $self so it survives the shell re-parse inside
+    # `circleci tests run`.
+    printf '%s\n' "$suites" \
+        | circleci tests run --command="xargs -r -d '\n' '$self'" --verbose
+else
+    # Inner: run only the given suites, passed to the harness via SKTEST_FILTERS.
+    SKTEST_FILTERS=$(printf '%s\n' "$@")
+    export SKTEST_FILTERS
+    exec skargo test "${args[@]}"
+fi

--- a/skiplang/sktest/extra/src/host.sk
+++ b/skiplang/sktest/extra/src/host.sk
@@ -7,16 +7,33 @@ fun signal_name(code: Int): String {
   }
 }
 
+// A test runs unless a filter excludes it. `suiteFilters` (from SKTEST_FILTERS,
+// i.e. the JUnit `classname` suite names `circleci tests run` feeds back on a
+// rerun) selects whole suites by EXACT name -- substring matching there would
+// over-select suites whose name is a prefix of another (e.g. "Typechecking" vs
+// "Typechecking/Exhaustiveness"). `nameFilter` is the positional convenience
+// filter and keeps its historical substring-on-`suite.name` behavior.
+fun matchesFilters(
+  testSuite: String,
+  testName: String,
+  suiteFilters: readonly Sequence<String>,
+  nameFilter: String,
+): Bool {
+  (suiteFilters.size() == 0 || suiteFilters.any(s -> s == testSuite)) &&
+    (nameFilter == "" || `${testSuite}.${testName}`.contains(nameFilter))
+}
+
 fun each_assigned_test(
   tests: readonly Map<String, readonly Sequence<Test>>,
-  filter: String,
+  suiteFilters: readonly Sequence<String>,
+  nameFilter: String,
   njobs: Int,
   f: (Int, String, Test) -> void,
 ): void {
   i = 0;
   for (testSuite in tests.keys()) {
     for (test in tests[testSuite]) {
-      if (!`${testSuite}.${test.name}`.contains(filter)) {
+      if (!matchesFilters(testSuite, test.name, suiteFilters, nameFilter)) {
         continue
       };
       !i = i + 1;
@@ -27,54 +44,68 @@ fun each_assigned_test(
 
 fun assign_all_tests(
   tests: readonly Map<String, readonly Sequence<Test>>,
-  filter: String,
+  suiteFilters: readonly Sequence<String>,
+  nameFilter: String,
   njobs: Int,
 ): Array<Array<(String, Test)>> {
   assigned = Array::fillBy(njobs, _ -> mutable Vector[]);
-  each_assigned_test(tests, filter, njobs, (rank, testSuite, test) -> {
-    assigned[rank].push((testSuite, test))
-  });
+  each_assigned_test(
+    tests,
+    suiteFilters,
+    nameFilter,
+    njobs,
+    (rank, testSuite, test) -> {
+      assigned[rank].push((testSuite, test))
+    },
+  );
   assigned.map(v -> v.toArray())
 }
 
 untracked fun test_job(
   tests: readonly Map<String, readonly Sequence<Test>>,
-  filter: String,
+  suiteFilters: readonly Sequence<String>,
+  nameFilter: String,
   njobs: Int,
   rank: Int,
 ): void {
   stdout = mutable IO.File(Posix.dup(IO.stdout().fileno));
-  each_assigned_test(tests, filter, njobs, (r, testSuite, test) -> {
-    if (r == rank) {
-      stdout_file = Posix.mkstemp(Path.join(Environ.temp_dir(), "XXXXXX"));
-      Posix.dup2(stdout_file.fileno, IO.stdout().fileno);
-      stderr_file = Posix.mkstemp(Path.join(Environ.temp_dir(), "XXXXXX"));
-      Posix.dup2(stderr_file.fileno, IO.stderr().fileno);
+  each_assigned_test(
+    tests,
+    suiteFilters,
+    nameFilter,
+    njobs,
+    (r, testSuite, test) -> {
+      if (r == rank) {
+        stdout_file = Posix.mkstemp(Path.join(Environ.temp_dir(), "XXXXXX"));
+        Posix.dup2(stdout_file.fileno, IO.stdout().fileno);
+        stderr_file = Posix.mkstemp(Path.join(Environ.temp_dir(), "XXXXXX"));
+        Posix.dup2(stderr_file.fileno, IO.stderr().fileno);
 
-      res = run_test(
-        test,
-        TestResult{
-          name => test.name,
-          suite => testSuite,
-          file => test.file,
-          line => test.lineno,
-        },
-      );
+        res = run_test(
+          test,
+          TestResult{
+            name => test.name,
+            suite => testSuite,
+            file => test.file,
+            line => test.lineno,
+          },
+        );
 
-      flushStdout();
-      _ = Posix.lseek(stdout_file.fileno, 0, Posix.SeekSet());
-      _ = Posix.lseek(stderr_file.fileno, 0, Posix.SeekSet());
-      !res = res with {
-        stdout => stdout_file.read_to_string().fromSuccess(),
-        stderr => stderr_file.read_to_string().fromSuccess(),
-      };
+        flushStdout();
+        _ = Posix.lseek(stdout_file.fileno, 0, Posix.SeekSet());
+        _ = Posix.lseek(stderr_file.fileno, 0, Posix.SeekSet());
+        !res = res with {
+          stdout => stdout_file.read_to_string().fromSuccess(),
+          stderr => stderr_file.read_to_string().fromSuccess(),
+        };
 
-      stdout_file.close();
-      stderr_file.close();
+        stdout_file.close();
+        stderr_file.close();
 
-      stdout.write_all((res.toJSON() + "\n").bytes()).fromSuccess();
-    }
-  });
+        stdout.write_all((res.toJSON() + "\n").bytes()).fromSuccess();
+      }
+    },
+  );
   skipExit(0)
 }
 
@@ -109,6 +140,18 @@ untracked fun expectStdout(
   expectEq(actual, expected)
 }
 
+// Parse the newline-separated suite names in SKTEST_FILTERS (blank entries
+// dropped). An empty result means "no suite restriction".
+fun parseSuiteFilters(env: ?String): Array<String> {
+  result = mutable Vector<String>[];
+  env.each(s ->
+    for (part in s.split("\n")) {
+      if (part != "") result.push(part)
+    }
+  );
+  result.toArray()
+}
+
 untracked fun test_harness(
   tests: readonly Map<String, readonly Sequence<Test>>,
 ): void {
@@ -136,14 +179,31 @@ untracked fun test_harness(
         .short("v")
         .about("Use verbose output"),
     )
+    .arg(
+      Cli.Arg::bool("list").about(
+        "List the test suites (one per line) and exit, without running them",
+      ),
+    )
     .help()
     .parseArgs();
 
-  filter = args.maybeGetString("filter").default("");
+  // Suite filters come from SKTEST_FILTERS (the suite names `circleci tests run`
+  // feeds back on a rerun) and select whole suites by exact name; the positional
+  // filter is a substring convenience. Both empty = run everything.
+  suiteFilters = parseSuiteFilters(Environ.varOpt("SKTEST_FILTERS"));
+
+  if (args.getBool("list")) {
+    tests.keys().each(print_string);
+    skipExit(0)
+  };
+
+  // Subprocesses receive both filters via the environment (they are re-exec'd
+  // with no argv), so read the positional filter from SKTEST_FILTER there.
   Environ.varOpt("SKTEST_RANK") match {
   | Some(rank) ->
     test_job(
       tests,
+      suiteFilters,
       Environ.var("SKTEST_FILTER"),
       Environ.var("SKTEST_JOBS").toInt(),
       rank.toInt(),
@@ -158,8 +218,9 @@ untracked fun test_harness(
     reporters.push(mutable XmlTestReporter{output => Some(path)})
   );
 
+  nameFilter = args.maybeGetString("filter").default("");
   njobs = args.getInt("jobs");
-  expected_tests = assign_all_tests(tests, filter, njobs);
+  expected_tests = assign_all_tests(tests, suiteFilters, nameFilter, njobs);
 
   procs = Array::fillBy(njobs, rank -> {
     Posix.Popen::create{
@@ -167,7 +228,8 @@ untracked fun test_harness(
       env => Map[
         "SKTEST_RANK" => rank.toString(),
         "SKTEST_JOBS" => njobs.toString(),
-        "SKTEST_FILTER" => filter,
+        "SKTEST_FILTERS" => suiteFilters.join("\n"),
+        "SKTEST_FILTER" => nameFilter,
       ],
       stdout => true,
       stderr => true,

--- a/skiplang/sktest/src/reporter.sk
+++ b/skiplang/sktest/src/reporter.sk
@@ -212,12 +212,19 @@ mutable class XmlTestReporter{
         )}" tests="${numTests}" failures="${numFailures}" errors="${numErrors}" time="${time}">`,
       );
       for (res in results) {
+        // Only emit `file`/`line` when we have a real source location. The
+        // harness leaves file="unknown"/line=-1 for tests it can't locate;
+        // emitting that would make CI test-splitting/rerun key every test on the
+        // bogus "unknown" file instead of falling back to `classname`.
+        fileAttr = if (res.file == "" || res.file == "unknown") {
+          ""
+        } else {
+          ` file="${escapeAttr(res.file)}" line="${res.line}"`
+        };
         this.writeLine(
-          `    <testcase name="${escapeAttr(res.name)}" file="${escapeAttr(
-            res.file,
-          )}" line="${res.line}" time="${res.time}" classname="${escapeAttr(
-            res.suite,
-          )}">`,
+          `    <testcase name="${escapeAttr(res.name)}"${fileAttr} time="${
+            res.time
+          }" classname="${escapeAttr(res.suite)}">`,
         );
         if (res.stdout != "") {
           this.writeLine(


### PR DESCRIPTION
Completes #1155 — adapts the remaining test jobs (`compiler` and `skip-package-tests`) to CircleCI's [Rerun failed tests](https://circleci.com/docs/guides/test/rerun-failed-tests/), joining the already-merged `skdb-wasm` (#1305) and `skipruntime` (#1307) jobs. A rerun now re-runs only the test **suites** that failed.

### Self-contained — no image rebuild, no bootstrap
The whole change lives in the **sktest library** (recompiled from source into every test binary) plus a CI wrapper. `skargo`'s CLI is untouched, so the `skip-package-tests` job — which runs on the image's stage0/bootstrap skargo — gets it immediately; that skargo already forwards `--list`/`--junitxml`/filter. (Verified by driving the whole flow through the local stage0 skargo.)

### Three commits
1. **`sktest: omit the placeholder file attribute from JUnit output`** — the harness never sets a test's source location, so every `<testcase>` carried `file="unknown"`; CI keys reruns on `file` when present, which would map every test to one bogus file. Now emitted only when real, so consumers fall back to `classname` (the suite).
2. **`sktest: add --list and per-suite filtering to the harness`** — `--list` enumerates suites; `SKTEST_FILTERS` (newline-separated suite names, inherited across the subprocess fan-out) restricts the run to those suites, matched **exactly** (so `Typechecking` doesn't drag in `Typechecking/Exhaustiveness`). The positional `filter` keeps its substring behaviour.
3. **`circleci: rerun only the failed sktest suites`** — `bin/run-sktest.sh` wraps `skargo test` in `circleci tests run`: it enumerates suites with `--list` and feeds the failed ones back through `SKTEST_FILTERS` on a rerun.

### Granularity
Rerun is **suite-level** (a failed test re-runs its module/suite). sktest has no per-test source location (the `#forEachFunction` macro exposes only name), and adding one would mean a ~10-file compiler change + bootstrap for marginal benefit — so suite-level is the honest, self-contained choice.

### Validation
Built and run with the real toolchain (stage1 **and** stage0/image skargo):
- `--list` enumerates suites; `SKTEST_FILTERS` selects them exactly (semver: one suite = 18/27; a non-suite substring = 0; multi = 27); positional substring filter and no-filter unchanged (backward-compatible).
- Full `run-sktest.sh` orchestrator + rerun through stage0 skargo: initial 27 → rerun of one suite = 9, JUnit well-formed and `classname`-keyed.
- An adversarial review flagged substring over-selection (fixed → exact match; the compiler's `Typechecking`/`Typechecking/Exhaustiveness` pair is real), `xargs` word-splitting (fixed → `-d '\n'`), and JUnit append-corruption on re-run (fixed → `rm -f` stale report). `circleci config validate`, `shellcheck`, `skfmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
