### PR TITLE
compiler: fix skc --batch crashing on frontend errors (naming/expand/fatal)

### DIFF
--- a/skiplang/compiler/src/skipError.sk
+++ b/skiplang/compiler/src/skipError.sk
@@ -120,6 +120,33 @@ fun isBatchMode(context: mutable SKStore.Context): Bool {
   context.getGlobal("BATCH_MODE").isSome()
 }
 
+// Report errors that abort the current compile. In one-shot mode this prints
+// them and exits the process (the historical behavior). In batch mode we must
+// not exit — but we also must not carry on: the phases that reach here abort
+// the whole compile in one-shot mode, and the later phases rely on that, so
+// continuing runs them on inconsistent state and trips an invariant. Instead
+// we abort just this unit with a recoverable failure carrying the same
+// rendered errors; its throwaway forked context is torn down safely by
+// withForkedContext, leaving the shared base pristine for the remaining units.
+fun printErrorsOrRecover<T>(
+  context: mutable SKStore.Context,
+  errors: Array<SkipErrorException>,
+): T {
+  get_file = file -> {
+    FileCache.fileDir.unsafeGetArray(context, file)[0].value
+  };
+  if (isBatchMode(context)) {
+    throw CompileFailureException{
+      message => errorsToString(
+        errors.map(x -> x.errors).flatten().collect(Vector),
+        get_file,
+      ),
+    }
+  } else {
+    printErrorsAndExit(errors, get_file)
+  }
+}
+
 fun keepErrors(
   _phase: Int,
   context: mutable SKStore.Context,
@@ -142,26 +169,18 @@ fun keepErrors(
 }
 
 fun catchErrors(
-  phase: Int,
+  _phase: Int,
   context: mutable SKStore.Context,
   f: () -> void,
 ): void {
-  // In batch mode, collect errors instead of exiting, so a failing unit
-  // doesn't terminate the shared process.
-  if (isBatchMode(context)) {
-    keepErrors(phase, context, f)
-  } else {
-    try {
-      f()
-    } catch {
-    | err @ SkipError.SkipErrorException _ ->
-      printErrorsAndExit(Array[err], file -> {
-        FileCache.fileDir.unsafeGetArray(context, file)[0].value
-      })
-    | exn ->
-      debug(exn);
-      throw exn
-    }
+  try {
+    f()
+  } catch {
+  | err @ SkipError.SkipErrorException _ ->
+    printErrorsOrRecover(context, Array[err])
+  | exn ->
+    debug(exn);
+    throw exn
   }
 }
 
@@ -404,13 +423,16 @@ fun fatalError<T>(
   msg: String,
   fix: ?Fix = None(),
 ): T {
-  printErrorsAndExit(
+  // Like the `catchErrors` path, `fatalError` aborts the whole compile in
+  // one-shot mode; route it through `printErrorsOrRecover` so it becomes a
+  // recoverable per-unit failure in batch mode instead of exiting the process.
+  printErrorsOrRecover(
+    context,
     Array[
       SkipErrorException{
         errors => Vector[Error{traces => List[(pos, msg)], fix}],
       },
     ],
-    file -> FileCache.fileDir.unsafeGetArray(context, file)[0].value,
   );
 }
 


### PR DESCRIPTION
## Summary

`skc --batch` (continue-on-error, #1301) **crashes on invalid inputs that a one-shot `skc` handles cleanly**. Compiling the compiler's own 826 `invalid_tests/` through one `--batch` process aborts almost immediately with `Invariant violation: assert` (or a silent `exit 2` with no failure summary), losing every remaining unit.

Minimal repro — `invalid_tests/typechecking/overridable7.sk` (a "cannot override a final method" error):

```
skc -O0 --no-inline -o /tmp/x  invalid_tests/typechecking/overridable7.sk   # clean error, exit 2
echo "/tmp/x main invalid_tests/typechecking/overridable7.sk" > m
skc --batch m -O0 --no-inline                                               # Invariant violation: assert
```

## Root cause

#1301 made batch mode *continue* past a unit's compile error so the shared context can serve later units. That is safe for **typing** errors (`keepErrors`, which the pipeline already defers — the `/backendSink/` mapper checks `ERRORS` before codegen). It is **not** safe for the earlier phases:

- `catchErrors` (naming, expand, …) was changed to *collect and continue* in batch mode (delegating to `keepErrors`). But in one-shot mode those phases abort the whole compile via `printErrorsAndExit`, and the phases that run after them rely on that. Collecting the error and carrying on runs them on inconsistent state → `invariant` trips.
- `fatalError` (e.g. "Unbound class") calls `printErrorsAndExit` **directly**, so in batch mode it `skipExit`s the whole process mid-batch, killing every remaining unit.

## Fix

Add `SkipError.printErrorsOrRecover`: in one-shot mode it prints + exits (unchanged); in **batch mode** it raises a recoverable `CompileFailureException` carrying the same rendered errors, aborting **just this unit**. Its throwaway forked context is torn down safely by `SKStore.withForkedContext` (#1304) — the `catch` there destroys the fork's obstack even on exception — so the shared base stays pristine for the remaining units, and this exactly mirrors one-shot's "stop at the first error" semantics (so the per-unit error text still matches what generated the `.exp_err` goldens).

`catchErrors` and `fatalError` now both route through it. `keepErrors` (typing) is unchanged. No one-shot behavior changes — the batch-mode branch is the only new path.

## Verified (rebuilt stage1)

- **The 826 `invalid_tests/` in one `--batch` process:** was — aborted at the 2nd unit with an invariant; now — **all 826 compile-and-fail cleanly, 0 invariant violations, `Batch compilation failed: 826`**.
- **Error-text parity:** for a sample spanning every category (syntax, typechecking, exhaustiveness, expand, visibility, runtime), each unit's batch error output equals its one-shot `skc` stderr (modulo a trailing newline the harness already `.trim()`s).
- **No regression:** one-shot valid compile + run, one-shot invalid (prints error, exit 2, no binary), and valid `--batch` (produces + runs binaries, exit 0) all unchanged.

## Why it matters / unblocks

This is a prerequisite for #1300 (batching the compiler test harness's invalid-test subprocess path): that path can only batch the invalid set once `--batch` survives every invalid unit. It's also a correctness fix in its own right — `--batch` should never crash on input a one-shot compile reports cleanly.

## Test plan

- [x] 826 invalid tests batch cleanly (no invariant; all reported)
- [x] per-unit error parity vs one-shot across all categories
- [x] one-shot + valid-batch paths unregressed
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
