### PR TITLE
Bump serialize-javascript override to >=7.0.5, dedup nested mocha copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3932,15 +3932,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4572,15 +4563,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4815,6 +4797,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "test": "npm run test --workspaces --if-present"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
Closes Dependabot alerts [#199](https://github.com/SkipLabs/skip/security/dependabot/199) ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq), high, patched 7.0.3) and [#341](https://github.com/SkipLabs/skip/security/dependabot/341) ([GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v), medium, patched 7.0.5) — both against `serialize-javascript` in the root `package-lock.json`.

## Root cause
The root `package.json` already had `overrides: { "serialize-javascript": "^7.0.3" }` (from #1206/#1219), but a later dependabot lockfile regeneration re-introduced a **nested** copy — `node_modules/mocha/node_modules/serialize-javascript@6.0.2` — that npm did not re-dedup against the override. 6.0.2 fails both advisories, reopening #199 and newly tripping #341.

`serialize-javascript` is a dev/test-only transitive, pulled by `mocha` (used by `skipruntime-ts/server` and `skipruntime-ts/tests`); it never reaches any shipped artifact.

## Fix
- Bump the override floor `^7.0.3` → `^7.0.5` so it satisfies **both** advisories (#199 needs ≥7.0.3, #341 needs ≥7.0.5).
- `npm update serialize-javascript --package-lock-only` collapses the nested mocha copy into a single hoisted `serialize-javascript@7.0.7`.
- The now-orphaned `randombytes` (only a dependency of serialize-javascript 6.x) is dropped — 7.x has no runtime deps.

## Verification
- Exhaustive scan of `package-lock.json`: exactly one `serialize-javascript` entry (`7.0.7`), no copy `< 7.0.5` anywhere.
- `randombytes` has no remaining consumers (correctly removed); `safe-buffer` retained (still used by express/content-disposition/etc.).
- `npm install --package-lock-only --dry-run` reports "up to date" — lockfile is self-consistent.
- Diff is surgical: only the serialize-javascript dedup, no unrelated lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)