### PR TITLE
Override ws to >=8.21.0 in www (Dependabot #335, #336)

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -18871,27 +18871,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -19091,16 +19070,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/www/package.json
+++ b/www/package.json
@@ -53,6 +53,7 @@
   "overrides": {
     "serialize-javascript": "^7.0.3",
     "uuid": "^11.1.1",
-    "joi": "^18.2.1"
+    "joi": "^18.2.1",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary
Closes Dependabot alerts [#335](https://github.com/SkipLabs/skip/security/dependabot/335) and [#336](https://github.com/SkipLabs/skip/security/dependabot/336) — [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) / CVE-2026-48779 (**high**: `ws` memory-exhaustion DoS from a high volume of tiny fragments/data chunks forcing OOM).

## Root cause
The advisory has per-major affected ranges. Two `ws` copies in `www/package-lock.json` were affected:

| copy | version | pulled by | affected range | patched |
|---|---|---|---|---|
| `node_modules/ws` | 7.5.10 | `webpack-bundle-analyzer@4.10.2` (`ws ^7.3.1`) | `>=7.0.0 <7.5.11` | 7.5.11 |
| `…/webpack-dev-server/node_modules/ws` | 8.20.1 | `webpack-dev-server@5.2.5` (`ws ^8.18.0`) | `>=8.0.0 <8.21.0` | 8.21.0 |

#335 and #336 are those two copies.

## Fix
Add `"ws": "^8.21.0"` to the existing `www` `overrides`. Both copies collapse to a single hoisted **`ws@8.21.0`**.

Forcing `webpack-bundle-analyzer` (which declares `ws ^7.3.1`) onto ws 8 is safe — its own current major, `webpack-bundle-analyzer@5.3.0`, depends on `ws ^8.19.0`, so upstream already runs the same analyzer-server code on ws 8. Only the Node floor (`>=10`) and a couple of defaults changed between ws 7 and 8, none touching its `WebSocketServer` usage.

Both consumers (`webpack-dev-server`, `webpack-bundle-analyzer`) are dev/build-time tooling (`docusaurus start` / bundle analysis); `ws` never reaches the shipped static site.

## Verification
- `npm install` then `npm ls ws` → single `ws@8.21.0` (one `overridden`, one `deduped`); no other copies.
- Exhaustive scan of the lockfile: no `ws` in any advisory range (`<5.2.5`, `6.0–6.2.4`, `7.0–7.5.11`, `8.0–8.21.0`).
- Diff is surgical — only the `ws` dedup, no unrelated lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)