### PR TITLE
Bump launch-editor to 2.14.1 in www (Dependabot #339)

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -10947,13 +10947,13 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/leven": {


### PR DESCRIPTION
## Summary
Closes Dependabot alert [#339](https://github.com/SkipLabs/skip/security/dependabot/339) — [GHSA-v6wh-96g9-6wx3](https://github.com/advisories/GHSA-v6wh-96g9-6wx3) / CVE-2026-53632 (**medium**: `launch-editor` NTLMv2 hash disclosure via UNC path handling on Windows). `www` had `launch-editor@2.13.2` (vulnerable range `<= 2.14.0`).

## Fix
`launch-editor` is a transitive dep of `webpack-dev-server` (`^2.6.1`), so a plain `npm update launch-editor --package-lock-only` bumps it to **2.14.1** within range — no override needed. Single-package, 4-line diff.

## Breaking-change check
Changelog 2.13.2 → 2.14.1:
- **v2.14.1**: `fix: reject UNC paths` (#138) — the security fix itself — plus non-major dep bumps.
- **v2.14.0**: `feat: add and improve package types` (additive), editor-path detection fixes (Trae casing, vscode path).

No breaking changes; the public API (launch an editor) is unchanged.

## Verification
- Fresh `npm install` → single `launch-editor@2.14.1`; no copy `<= 2.14.0`.
- Diff scoped to the one package; no lockfile drift.

`launch-editor` is dev-only tooling — `webpack-dev-server`'s click-to-open-in-editor overlay during `docusaurus start` — and the vuln is Windows/UNC-specific. It never runs in CI or reaches the shipped static site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)