### PR TITLE
Bump http-proxy-middleware to 2.0.10 in www

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -10222,9 +10222,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",


### PR DESCRIPTION
## Summary
Addresses Dependabot alert [342](https://github.com/SkipLabs/skip/security/dependabot/342) — [GHSA-64mm-vxmg-q3vj](https://github.com/advisories/GHSA-64mm-vxmg-q3vj) / CVE-2026-55602 (**medium**: `http-proxy-middleware` `router` host+path substring matching allows a Host-header-driven backend routing bypass).

The advisory has three per-major ranges; the one that applies here is `>= 0.16.0, < 2.0.10` → patched **2.0.10**. `www` had `http-proxy-middleware@2.0.9`.

## Fix
Transitive dep of `webpack-dev-server` (`^2.0.9`), so a plain `npm update http-proxy-middleware --package-lock-only` bumps it to **2.0.10** within range — no override needed. Single-package, 3-line diff.

## Breaking-change check
2.0.10's only code change is [`fix: harden proxy-table matching to prevent routing bypass` (#1268)](https://github.com/chimurai/http-proxy-middleware/pull/1268) — the security fix itself — plus a CI publish chore. The public API is unchanged; semver-patch.

## Verification
- Fresh `npm install` → single `http-proxy-middleware@2.0.10`; no copy in any advisory range (`0.16.0–2.0.10`, `3.0.0–3.0.6`, `4.0.0–4.1.0`).
- Diff scoped to the one package.

Dev-only tooling — `webpack-dev-server`'s proxy during `docusaurus start`; never runs in CI or reaches the shipped static site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)