### PR TITLE
Bump js-yaml to patched versions in www and cache_invalidation/www

### DIFF
--- a/examples/cache_invalidation/www/package.json
+++ b/examples/cache_invalidation/www/package.json
@@ -24,5 +24,10 @@
     "typescript-eslint": "^8.59.4",
     "vite": "^6.4.3",
     "vue-tsc": "^2.1.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "^4.2.0"
+    }
   }
 }

--- a/examples/cache_invalidation/www/pnpm-lock.yaml
+++ b/examples/cache_invalidation/www/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: ^4.2.0
+
 importers:
 
   .:
@@ -848,8 +851,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.2.0:
@@ -1276,7 +1279,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -1883,7 +1886,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -9654,9 +9654,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10839,9 +10839,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Summary
Addresses Dependabot alerts [344](https://github.com/SkipLabs/skip/security/dependabot/344), [345](https://github.com/SkipLabs/skip/security/dependabot/345), [346](https://github.com/SkipLabs/skip/security/dependabot/346) — [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) / CVE-2026-53550 (**medium**: `js-yaml` quadratic-complexity DoS in merge-key handling via repeated aliases). The advisory has two ranges: `4.0.0–4.1.1` → patched **4.2.0**, and `< 3.15.0` → patched **3.15.0**.

## Fix

**`www/package-lock.json`** (npm, alerts 345 + 346) — two affected copies; a plain `npm update js-yaml --package-lock-only` bumps both:
- `js-yaml` 4.1.1 → **4.3.0** (via `cosmiconfig`, `@docusaurus/*`; `^4.1.0`)
- `gray-matter`'s nested `js-yaml` 3.14.2 → **3.15.0** (the 3.x backport)

**`examples/cache_invalidation/www`** (pnpm, alert 344) — `js-yaml` 4.1.1 via `@eslint/eslintrc`. Added a `pnpm.overrides` `js-yaml: ^4.2.0` and regenerated with **pnpm 10** (matches the lockfile's serializer, so the `libc` platform tags on the rollup native optional deps are preserved — older pnpm drops them, which would matter for the alpine/musl Docker build). Resolves to **4.3.0**.

## Breaking-change check
- **3.15.0** is a pure security backport (`maxTotalMergeKeys`).
- **4.2.0/4.3.0** add the merge-key / `maxDepth` DoS guards plus one behavior change: underscores in numeric scalars (`1_000`) are no longer parsed as numbers ([#627](https://github.com/nodeca/js-yaml/pull/627)). Verified **no** YAML/frontmatter in `www` or the examples uses underscore-separated numeric literals, so this does not affect us.

## Verification
- `www`: `npm ls js-yaml` → 4.3.0 (deduped) + 3.15.0; no copy in either vulnerable range.
- `cache_invalidation/www`: `pnpm install` resolves `js-yaml@4.3.0`; diff is the override header + the single js-yaml entry (all 13 `libc` tags preserved, no unrelated churn).

js-yaml is build-time only (docs frontmatter/config parsing, eslint config loading); it never reaches shipped output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)