### PR TITLE
skc/tests: batch the invalid-test suite via sharded skc --batch

### DIFF
--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -499,7 +499,14 @@ fun compile_batch(
       )
     } catch {
     | err @ SkipError.CompileFailureException _ ->
-      print_error(err.getMessage());
+      msg = err.getMessage();
+      print_error(msg);
+      // Also record this unit's errors next to its (unwritten) output, so a
+      // caller driving many units can attribute failures per unit without
+      // parsing the interleaved stderr stream. A successful unit writes its
+      // artifact at `output` and no `.err`; a failed one writes `.err` and no
+      // artifact, giving an unambiguous per-unit signal.
+      FileSystem.writeTextFile(output + ".err", msg);
       !failures = failures + 1
     | exn -> throw exn
     }

--- a/skiplang/compiler/tests/tests.sk
+++ b/skiplang/compiler/tests/tests.sk
@@ -40,6 +40,9 @@ private fun genValidTest(basename: String, mainFn: String): void {
   T.expectEq(actual, expected)
 }
 
+// Compile a single invalid test in its own `skc` subprocess. Used when batching
+// is disabled (see `main`); the default path reads pre-batched results instead
+// (`runInvalidFromBatch`).
 private fun genInvalidTest(basename: String): void {
   p = System.subprocess(
     compile_cmd(Array[basename + ".sk"], basename + ".bin"),
@@ -55,6 +58,90 @@ private fun genInvalidTest(basename: String): void {
   expected = FileSystem.readTextFile(basename + ".exp_err").trim();
 
   T.expectEq(actual, expected)
+}
+
+// Invalid tests are compiled together, up front, via `skc --batch` (see
+// `batchCompileInvalid`), which shares the stdlib type-check across them. Each
+// unit's result lands in a scratch dir: a binary at its output path if it
+// compiled, or `<output>.err` diagnostics if it failed. Here we just read that
+// result — no per-test `skc`.
+
+// Deterministic scratch dir for batch-compiled test outputs, shared between
+// the parent (which runs the batches) and the re-exec'd workers (which read
+// the results). The parent recreates it each run, so there are no stale
+// artifacts, and both derive the same path from `Environ.temp_dir()`.
+private fun batchOutDir(): String {
+  Path.join(Environ.temp_dir(), "skc_test_batch")
+}
+
+// Path a batch unit writes for `basename`: its binary on success, or
+// `<path>.err` (the rendered diagnostics) on failure.
+private fun batchOutput(basename: String): String {
+  Path.join(batchOutDir(), basename.split("/").join("_") + ".bin")
+}
+
+private fun runInvalidFromBatch(basename: String): void {
+  output = batchOutput(basename);
+  if (FileSystem.exists(output)) {
+    // It produced an artifact — an invalid test must fail to compile.
+    T.fail("Expected compile error")
+  };
+  // NOTE: The `.trim()` is needed because error messages seem to currently
+  // have an extra newline. The `.err` sidecar holds the same rendered errors a
+  // one-shot `skc` writes to stderr, so this matches the old comparison.
+  actual = FileSystem.readTextFile(output + ".err").trim();
+  expected = FileSystem.readTextFile(basename + ".exp_err").trim();
+
+  T.expectEq(actual, expected)
+}
+
+// Compile every invalid test once, up front, sharing the stdlib type-check
+// across them via `skc --batch`. The set is sharded into `njobs` manifests run
+// as parallel `skc --batch` processes (each still types the stdlib only once),
+// which recovers the parallelism the per-test subprocess path had while paying
+// the ~64% stdlib type-check cost a handful of times instead of ~800. `njobs`
+// is the harness's own job count (see the `test_harness` call in `main`), so
+// `skargo test -j N` scales the batch exactly as it scales the test run. Runs
+// in the parent only, before `test_harness` forks the per-test workers; the
+// workers then read each unit's result from `batchOutDir()`.
+private fun batchCompileInvalid(
+  basenames: readonly Sequence<String>,
+  njobs: Int,
+  shouldRun: (String, String) ~> Bool,
+): void {
+  outDir = batchOutDir();
+  // Fresh dir each run: no stale binaries/diagnostics from a previous run.
+  _ = system(`rm -rf '${outDir}' && mkdir -p '${outDir}'`);
+
+  shards = Array::fillBy(njobs, _ -> mutable Vector<String>[]);
+  i = 0;
+  for (b in basenames) {
+    // Only compile tests that will actually run (e.g. under a `--filter`); the
+    // suite/name is derived the same way it is when registering the test.
+    (suite, name) = b.stripPrefix("invalid_tests/").splitLast("/");
+    if (!shouldRun(suite, name)) continue;
+    // Manifest line: `<output> <mainFn> <input.sk>`. mainFn is irrelevant since
+    // the compile must fail; the input stays CWD-relative so the paths embedded
+    // in the diagnostics match the `.exp_err` goldens.
+    shards[i % njobs].push(`${batchOutput(b)} main ${b}.sk`);
+    !i = i + 1
+  };
+
+  cmds = mutable Vector<String>[];
+  for ((si, shard) in shards.items()) {
+    if (!shard.isEmpty()) {
+      manifest = Path.join(outDir, `shard_${si}.manifest`);
+      FileSystem.writeTextFile(manifest, shard.join("\n"));
+      // `--batch` exits 2 when units fail (expected here) and prints their
+      // errors to stderr; we read results from the scratch dir, so discard it.
+      cmds.push(`skc --batch '${manifest}' -O0 --no-inline >/dev/null 2>&1`)
+    }
+  };
+
+  if (!cmds.isEmpty()) {
+    // Run the shards concurrently and wait for all of them.
+    _ = System.subprocess(Array["sh", "-c", cmds.join(" & ") + " & wait"])
+  }
 }
 
 // Split a module name into (suite, testName) at the underscore that
@@ -98,11 +185,19 @@ private macro fun addExpTestFunctions(
 untracked fun main(): void {
   tests = mutable Map[];
 
+  // Escape hatches for the fast paths, both compiling one `skc` per test:
+  //   SKC_SUBPROCESS=1 — force *all* tests to subprocess mode (no @exptest,
+  //                      no invalid-test batch).
+  //   SKC_NO_BATCH=1   — keep @exptest for valid tests, but disable just the
+  //                      invalid-test batch (compile each invalid test on its
+  //                      own, as before batching).
+  subprocessMode = Environ.varOpt("SKC_SUBPROCESS").isSome();
+  batchDisabled = subprocessMode || Environ.varOpt("SKC_NO_BATCH").isSome();
+
   // Discover @exptest-annotated functions. These are present when all
   // test .sk files are compiled into this binary (i.e. when `tests` is
   // not set in Skargo.toml, so Skargo auto-discovers all files in tests/).
-  // Set SKC_SUBPROCESS=1 to force all tests to use subprocess mode.
-  coveredModules = if (Environ.varOpt("SKC_SUBPROCESS").isNone()) {
+  coveredModules = if (!subprocessMode) {
     addExpTestFunctions(tests)
   } else {
     Set[]
@@ -148,22 +243,43 @@ untracked fun main(): void {
       );
   };
 
-  // Invalid tests always use subprocess mode (they must fail to compile).
+  // Invalid tests (which must fail to compile) are, by default, compiled
+  // together via `skc --batch` rather than one `skc` per test (see
+  // `batchCompileInvalid`); each test then just reads its pre-batched result.
+  // When batching is disabled, fall back to compiling each in its own `skc`.
   invalidTests = FileSystem.readFilesRecursive("./invalid_tests", fn ->
     fn.endsWith(".exp_err")
   );
 
+  invalidBasenames = mutable Vector<String>[];
   for (testFile in invalidTests) {
     basename = testFile.stripSuffix(".exp_err");
+    invalidBasenames.push(basename);
     (testSuite, testName) = basename
       .stripPrefix("invalid_tests/")
       .splitLast("/");
+    testFunc: untracked () ~> void = if (batchDisabled) {
+      () ~> genInvalidTest(basename)
+    } else {
+      () ~> runInvalidFromBatch(basename)
+    };
     tests
       .getOrAdd(testSuite, () -> mutable Vector[])
-      .push(T.Test{name => testName, func => () ~> genInvalidTest(basename)})
+      .push(T.Test{name => testName, func => testFunc})
   };
+  invalidUnits = invalidBasenames.collect(Array);
 
-  T.test_harness(tests)
+  // Unless batching is disabled, compile the invalid set once, up front,
+  // sharing the stdlib type-check via `skc --batch`. `test_harness` runs this
+  // in the parent after parsing its args and before forking the workers,
+  // passing its own job count — so the batch shards at the same parallelism the
+  // workers run at. The workers (which re-exec this binary) then just read each
+  // unit's result from the scratch dir.
+  T.test_harness(tests, (njobs, shouldRun) ~> {
+    if (!batchDisabled && !invalidUnits.isEmpty()) {
+      batchCompileInvalid(invalidUnits, njobs, shouldRun)
+    }
+  })
 }
 
 module end;

--- a/skiplang/sktest/extra/src/host.sk
+++ b/skiplang/sktest/extra/src/host.sk
@@ -161,6 +161,14 @@ fun parseSuiteFilters(env: ?String): Array<String> {
 
 untracked fun test_harness(
   tests: readonly Map<String, readonly Sequence<Test>>,
+  // Called once in the parent, after the arguments are parsed and before the
+  // worker processes are forked. A harness can use it to prepare shared test
+  // artifacts in parallel (e.g. batch-compiling inputs) with the same
+  // parallelism the workers will run at. It receives the resolved job count and
+  // a predicate `(suite, name) -> will this test run` (the same filter the
+  // workers apply), so the preparation covers exactly the tests that will run.
+  parent_setup: untracked (Int, (String, String) ~> Bool) ~> void = (_, _) ~>
+    void,
 ): void {
   args = Cli.Command("tests")
     .about("Run tests")
@@ -227,6 +235,13 @@ untracked fun test_harness(
 
   nameFilter = args.maybeGetString("filter").default("");
   njobs = args.getInt("jobs");
+
+  // Parent-only, before forking: give the harness a chance to prepare shared
+  // artifacts for the workers to read (only for the tests that will run).
+  parent_setup(njobs, (suite, name) ~>
+    matchesFilters(suite, name, suiteFilters, nameFilter)
+  );
+
   expected_tests = assign_all_tests(tests, suiteFilters, nameFilter, njobs);
 
   procs = Array::fillBy(njobs, rank -> {

--- a/skiplang/sktest/extra/src/wasm32.sk
+++ b/skiplang/sktest/extra/src/wasm32.sk
@@ -1,6 +1,13 @@
 module SKTest;
 
-fun test_harness(tests: readonly Map<String, readonly Sequence<Test>>): void {
+fun test_harness(
+  tests: readonly Map<String, readonly Sequence<Test>>,
+  // Kept signature-compatible with the host harness; wasm runs tests serially,
+  // so this is invoked once with a job count of 1 (and a run-everything
+  // predicate — no wasm harness prepares artifacts through this hook).
+  parent_setup: untracked (Int, (String, String) ~> Bool) ~> void = (_, _) ~>
+    void,
+): void {
   args = Cli.Command("tests")
     .about("Run tests")
     .arg(
@@ -40,6 +47,7 @@ fun test_harness(tests: readonly Map<String, readonly Sequence<Test>>): void {
   args.maybeGetString("junitxml").each(path ->
     reporters.push(mutable XmlTestReporter{output => Some(path)})
   );
+  parent_setup(1, (_, _) ~> true);
   filter = args.maybeGetString("filter").default("");
   strict = args.getBool("strict");
   valid = (name, filter) ->


### PR DESCRIPTION
## Summary

Implements #1300 (compiler test harness). The suite runs valid tests in-process via `@exptest`, but the **826 `invalid_tests/`** (which must fail to compile) each spawned a fresh `skc` — re-type-checking the stdlib (~64% of a compile, #1295) 826 times. This batches them through `skc --batch` (#1298/#1301), so the stdlib is type-checked a handful of times instead of ~800.

Builds on the batch continue-on-error work (#1301) and the frontend-error robustness fix (#1313) that made `--batch` survive every invalid unit.

## How

- **sktest** — `test_harness` gains an optional `parent_setup` hook, invoked once **in the parent, after the args are parsed and before the workers are forked**, with the resolved job count **and a `(suite, name) → will-run` predicate** (the same filter the workers apply). Backward-compatible (default no-op); it lets a harness prepare shared artifacts at the same parallelism the workers run at, for exactly the tests that will run — without re-parsing `--jobs`/`--filter` itself.
- **`compile.sk`** — `skc --batch` now writes each failed unit's diagnostics to a per-unit `<output>.err` sidecar (alongside the existing stderr print), so a driver can attribute failures per-unit without parsing interleaved stderr.
- **`tests.sk`** — only the invalid path changes; valid `@exptest`/fallback handling is untouched.
  - `batchCompileInvalid` runs via the `parent_setup` hook (so, parent-only, before forking), sharding the invalid set — **filtered to just the tests that will run** — into **`njobs` — the harness's *own* job count** — concurrent `skc --batch` processes, recovering the parallelism the per-test path had while each shard types the stdlib only once. (Threading the real `njobs` through the hook also fixes a mismatch: on a 20-core box the harness runs 20 workers, so the batch now shards 20 ways too. And honoring the filter means `skargo test <one-test>` compiles one unit, ~5 s, not all 826.)
  - Outputs go to a deterministic scratch dir under `Environ.temp_dir()`, recreated each run (no stale artifacts) and derived identically by parent and workers (no coordination needed).
  - Each per-test closure (`runInvalidFromBatch`) is now a pure filesystem read: an artifact present ⇒ "Expected compile error"; otherwise compare `<output>.err` to `.exp_err` (same `.trim()` as before).

**Opting out.** Batching can be disabled via env var — each invalid test then compiles in its own `skc` again (the old `genInvalidTest` path):
- `SKC_NO_BATCH=1` — disable *only* the invalid-test batch (keep `@exptest` for valid tests).
- `SKC_SUBPROCESS=1` — now disables the batch too, so it once again means what its comment always claimed: *all* tests run in subprocess mode (no `@exptest`, no batch).

Per-test semantics are unchanged: the `.err` sidecar holds the same rendered errors a one-shot `skc` writes to stderr (verified byte-for-byte modulo the trailing newline `.trim()` already absorbs).

## Verified

Built the full compiler test binary with the new harness and ran the whole suite:

- **Identical PASS/FAIL vs `main`:** both harnesses report **1723 successes / 1724** on the same machine — every one of the 826 invalid tests and 897 valid tests passes through the batch. (The lone failure, `Native CompilerVersionCheck`, reproduces identically on `main`; it's a local multi-stage-build artifact — the test binary bakes the working-tree commit while a locally-built `stage1` `skc` reports its bootstrap commit — and matches in CI.)
- Scratch dir after a full run: **826 `.err` sidecars, 0 binaries** — exactly as designed.
- **Speed (full `skargo test` run, same machine): ~58 s vs ~351 s on `main`** — a **~6× reduction**, from type-checking the stdlib once per job instead of ~800 times.
- **Filter is honored:** `test overridable7` → compiles **1** unit, passes, **~5 s** (not the full 826) — so filtered dev runs stay as cheap as before.
- **Opt-out works:** with `SKC_NO_BATCH=1` and with `SKC_SUBPROCESS=1`, the same test passes with **no batch** (no scratch dir created) — each invalid test compiled in its own `skc`.

## Test plan

- [x] full suite: all 826 invalid + 897 valid pass through the batch (1723/1724, matches `main`)
- [x] filtered run compiles only matching tests
- [x] `SKC_NO_BATCH=1` / `SKC_SUBPROCESS=1` disable the batch, tests still pass
- [x] before/after wall-clock on the same machine
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
