### PR TITLE
Fix pre-existing ESLint findings in the example projects

### DIFF
--- a/examples/blogger/www/eslint.config.js
+++ b/examples/blogger/www/eslint.config.js
@@ -15,8 +15,7 @@ export default [
     },
   },
   // vue-eslint-parser parses .vue templates; delegate <script lang="ts"> to
-  // @typescript-eslint/parser. Disable type-checked rules for .vue files since
-  // vue-eslint-parser doesn't forward type info to typescript-eslint.
+  // @typescript-eslint/parser.
   {
     files: ["**/*.vue"],
     languageOptions: {
@@ -26,6 +25,19 @@ export default [
         extraFileExtensions: [".vue"],
       },
     },
+  },
+  // Type-checked rules can't run on .vue: vue-eslint-parser doesn't forward
+  // type information to typescript-eslint. Kept as its own config object so its
+  // languageOptions merge with (rather than overwrite) the parser block above.
+  {
+    files: ["**/*.vue"],
     ...tseslint.configs.disableTypeChecked,
+  },
+  // Single-word names are intentional for these page/route components.
+  {
+    files: ["**/*.vue"],
+    rules: {
+      "vue/multi-word-component-names": "off",
+    },
   },
 ];

--- a/examples/blogger/www/src/composables/useAuth.ts
+++ b/examples/blogger/www/src/composables/useAuth.ts
@@ -3,12 +3,12 @@ import { ref, readonly } from "vue";
 // Session type can be expanded as needed
 type Session = any;
 
-const session = ref<Session | null>(null);
+const session = ref<Session>(null);
 
 // On load, check for existing token and fetch session
 const token = localStorage.getItem("jwt");
 if (token) {
-  fetchSession(token);
+  void fetchSession(token);
 }
 
 async function fetchSession(token: string) {
@@ -40,9 +40,12 @@ async function login(username: string, password: string) {
       body: JSON.stringify({ username, password }),
     });
     if (!response.ok) {
-      throw new Error("Login failed: " + response.status);
+      throw new Error(`Login failed: ${response.status}`);
     }
-    const { token: jwt, user } = await response.json();
+    const { token: jwt, user } = (await response.json()) as {
+      token: string;
+      user: Session;
+    };
     localStorage.setItem("jwt", jwt);
     session.value = user;
   } catch (error) {

--- a/examples/blogger/www/src/main.ts
+++ b/examples/blogger/www/src/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue";
+import { createApp, type Component } from "vue";
 import { createRouter, createWebHistory } from "vue-router";
 import App from "./App.vue";
 
@@ -22,6 +22,8 @@ const router = createRouter({
 });
 
 // Create and mount the app
-const app = createApp(App);
+// App is imported from a .vue SFC, which typescript-eslint's project service
+// resolves as an untyped module, so assert the component type explicitly.
+const app = createApp(App as Component);
 app.use(router);
 app.mount("#app");

--- a/examples/cache_invalidation/www/eslint.config.js
+++ b/examples/cache_invalidation/www/eslint.config.js
@@ -15,8 +15,7 @@ export default [
     },
   },
   // vue-eslint-parser parses .vue templates; delegate <script lang="ts"> to
-  // @typescript-eslint/parser. Disable type-checked rules for .vue files since
-  // vue-eslint-parser doesn't forward type info to typescript-eslint.
+  // @typescript-eslint/parser.
   {
     files: ["**/*.vue"],
     languageOptions: {
@@ -26,6 +25,19 @@ export default [
         extraFileExtensions: [".vue"],
       },
     },
+  },
+  // Type-checked rules can't run on .vue: vue-eslint-parser doesn't forward
+  // type information to typescript-eslint. Kept as its own config object so its
+  // languageOptions merge with (rather than overwrite) the parser block above.
+  {
+    files: ["**/*.vue"],
     ...tseslint.configs.disableTypeChecked,
+  },
+  // Single-word names are intentional for these page/route components.
+  {
+    files: ["**/*.vue"],
+    rules: {
+      "vue/multi-word-component-names": "off",
+    },
   },
 ];

--- a/examples/cache_invalidation/www/src/composables/useAuth.ts
+++ b/examples/cache_invalidation/www/src/composables/useAuth.ts
@@ -3,12 +3,12 @@ import { ref, readonly } from "vue";
 // Session type can be expanded as needed
 type Session = any;
 
-const session = ref<Session | null>(null);
+const session = ref<Session>(null);
 
 // On load, check for existing token and fetch session
 const token = localStorage.getItem("jwt");
 if (token) {
-  fetchSession(token);
+  void fetchSession(token);
 }
 
 async function fetchSession(token: string) {
@@ -40,9 +40,12 @@ async function login(username: string, password: string) {
       body: JSON.stringify({ username, password }),
     });
     if (!response.ok) {
-      throw new Error("Login failed: " + response.status);
+      throw new Error(`Login failed: ${response.status}`);
     }
-    const { token: jwt, user } = await response.json();
+    const { token: jwt, user } = (await response.json()) as {
+      token: string;
+      user: Session;
+    };
     localStorage.setItem("jwt", jwt);
     session.value = user;
   } catch (error) {

--- a/examples/cache_invalidation/www/src/main.ts
+++ b/examples/cache_invalidation/www/src/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue";
+import { createApp, type Component } from "vue";
 import { createRouter, createWebHistory } from "vue-router";
 import App from "./App.vue";
 
@@ -22,6 +22,8 @@ const router = createRouter({
 });
 
 // Create and mount the app
-const app = createApp(App);
+// App is imported from a .vue SFC, which typescript-eslint's project service
+// resolves as an untyped module, so assert the component type explicitly.
+const app = createApp(App as Component);
 app.use(router);
 app.mount("#app");

--- a/examples/chatroom/www/src/App.tsx
+++ b/examples/chatroom/www/src/App.tsx
@@ -32,8 +32,8 @@ function Feed() {
       const data = JSON.parse(e.data) as [number, Message[]][];
       setMessages((messages) => {
         const newMessages = new Map(messages);
-        for (const [key, [msg]] of data) {
-          if (msg) newMessages.set(key, msg);
+        for (const [key, msgs] of data) {
+          if (msgs.length > 0) newMessages.set(key, msgs[0]);
           else newMessages.delete(key);
         }
         return newMessages;
@@ -125,7 +125,7 @@ function Feed() {
         className="new-message"
         onSubmit={(e) => {
           e.preventDefault();
-          sendMessage();
+          void sendMessage();
         }}
       >
         <input

--- a/examples/hackernews/www/src/App.tsx
+++ b/examples/hackernews/www/src/App.tsx
@@ -14,7 +14,7 @@ export default function App() {
   function updateSession(data: [number, Session[]][]) {
     let session;
     if (data.length > 0 && data[0][1].length > 0) {
-      session = data[0][1][0] as Session;
+      session = data[0][1][0];
     } else {
       session = null;
     }
@@ -44,20 +44,20 @@ export default function App() {
       return -1;
     };
     evSource.addEventListener("init", (e: MessageEvent<string>) => {
-      const data = JSON.parse(e.data) as [number, any[]][];
+      const data = JSON.parse(e.data) as [number, Post[]][];
       const initialPosts = data.map(([post_id, values]) => {
         values[0].date = new Date(values[0].date);
         return { ...values[0], id: post_id };
-      }) as Post[];
+      });
       initialPosts.sort(sortByUpvotes);
       setPosts(initialPosts);
       previousPostsValue.current = initialPosts;
     });
     evSource.addEventListener("update", (e: MessageEvent<string>) => {
-      const data = JSON.parse(e.data);
-      let modifiedPosts: number[] = [];
+      const data = JSON.parse(e.data) as [number, Post[]][];
+      const modifiedPosts: number[] = [];
       let updatedPosts: Post[] = [];
-      for (let [post_id, values] of data) {
+      for (const [post_id, values] of data) {
         modifiedPosts.push(post_id);
         if (values.length > 0) {
           values[0].date = new Date(values[0].date);

--- a/examples/hackernews/www/src/components/Feed.tsx
+++ b/examples/hackernews/www/src/components/Feed.tsx
@@ -39,7 +39,7 @@ function Feed(props: { posts: Post[]; session: Session | null }) {
   const navigate = useNavigate();
 
   function toggleUpvote(post: Post) {
-    let method = post.upvoted ? "DELETE" : "PUT";
+    const method = post.upvoted ? "DELETE" : "PUT";
     void fetch(`/api/posts/${post.id}/upvotes`, { method }).catch(
       (err: unknown) => {
         console.error(err);
@@ -66,9 +66,10 @@ function Feed(props: { posts: Post[]; session: Session | null }) {
                 <div
                   className={post.upvoted ? "votearrow-active" : "votearrow"}
                   title="upvote"
-                  onClick={() =>
-                    session !== null ? toggleUpvote(post) : navigate("/login")
-                  }
+                  onClick={() => {
+                    if (session !== null) toggleUpvote(post);
+                    else void navigate("/login");
+                  }}
                 ></div>
                 <span className="posttitle">
                   <a href={post.url}>{post.title}</a>

--- a/examples/hackernews/www/src/components/Header.tsx
+++ b/examples/hackernews/www/src/components/Header.tsx
@@ -23,7 +23,8 @@ function Header(props: { session: Session | null }) {
           href="#"
           onClick={(e) => {
             e.preventDefault();
-            props.session !== null ? navigate("/submit") : navigate("/login");
+            if (props.session !== null) void navigate("/submit");
+            else void navigate("/login");
           }}
         >
           submit

--- a/examples/hackernews/www/src/components/Login.tsx
+++ b/examples/hackernews/www/src/components/Login.tsx
@@ -18,7 +18,7 @@ function Login() {
     })
       .then((resp) => {
         if (!resp.ok) setLoginError("Invalid credentials");
-        else navigate("/");
+        else void navigate("/");
       })
       .catch((err: unknown) => {
         console.log(err);

--- a/examples/hackernews/www/src/components/Submit.tsx
+++ b/examples/hackernews/www/src/components/Submit.tsx
@@ -29,7 +29,7 @@ function Submit() {
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            createPost().then((_) => navigate("/"));
+            void createPost().then(() => navigate("/"));
           }}
         >
           <input


### PR DESCRIPTION
Stacked on #1322.

The standalone example projects aren't part of the workspace lint job, so findings from the shared `strictTypeChecked` config had accumulated unnoticed (they are identical under ESLint 9 and 10 — the v10 bump in #1322 does not introduce them). This makes `npm run lint` green in each.

**Vue examples** (`blogger/www`, `cache_invalidation/www`)
- Fix a config bug: `...tseslint.configs.disableTypeChecked` was spread into the `.vue` block, overwriting `parser: vue-eslint-parser` / `parserOptions.parser`, so `<script lang="ts">` blocks were parsed as plain JS (`interface`/type-annotation parse errors). Split into a separate config object so ESLint merges `languageOptions` instead.
- Disable `vue/multi-word-component-names` for the single-word page components (`App`/`Feed`/`Login`/`Submit`).
- Type the login response, assert the `.vue` app-root component type, mark the load-time session fetch `void`, and apply autofixable template formatting.

**chatroom** — length-check the message-map update instead of an always-true truthiness test; `void` the fire-and-forget `sendMessage()`.

**hackernews** — type the EventSource payloads as `[number, Post[]][]` (removing now-redundant `as` assertions and dropping `any`), and `void` the `navigate()` / `createPost()` promises used in event handlers.

## Verification

`npm run lint` (via the local `eslint@10.7.0`) exits 0 in all four projects. Template changes are ESLint `--fix` output only.