### PR TITLE
Adopt ESLint v10 config features in @skiplabs/eslint-config

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiplabs/eslint-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Shared ESLint configuration for SkipLabs packages.",
   "main": "src/eslint.config.js",
   "type": "module",

--- a/eslint-config/src/eslint.config.js
+++ b/eslint-config/src/eslint.config.js
@@ -1,12 +1,11 @@
+import { globalIgnores } from "eslint/config";
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import stylisticJs from "@stylistic/eslint-plugin";
 import jsdoc from "eslint-plugin-jsdoc";
 
 export default tseslint.config(
-  {
-    ignores: ["**/dist/*"],
-  },
+  globalIgnores(["**/dist/*"]),
   eslint.configs.recommended,
   jsdoc.configs["flat/recommended-typescript-error"],
   ...tseslint.configs.strictTypeChecked,
@@ -14,6 +13,7 @@ export default tseslint.config(
   {
     linterOptions: {
       reportUnusedDisableDirectives: "error",
+      reportUnusedInlineConfigs: "error",
     },
     languageOptions: {
       parserOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "examples/blogger/reactive_service"
       ],
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^22.10.0",
         "eslint": "10.4.0",
@@ -41,7 +41,7 @@
     },
     "eslint-config": {
       "name": "@skiplabs/eslint-config",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.0",
@@ -339,89 +339,17 @@
         "typescript": "^5.0.0"
       }
     },
-    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config/node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "extraneous": true,
+    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
+      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config/node_modules/eslint-plugin-jsdoc": {
-      "version": "50.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
-      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
-      "extraneous": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.50.2",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.4.1",
-        "escape-string-regexp": "^4.0.0",
-        "espree": "^10.3.0",
-        "esquery": "^1.6.0",
-        "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.2",
-        "spdx-expression-parse": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "@eslint/js": "^10.0.0",
+        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "eslint-plugin-jsdoc": "^62.6.0",
+        "typescript-eslint": "^8.56.0"
       }
     },
     "examples/blogger/reactive_service/node_modules/@types/node": {
@@ -460,89 +388,17 @@
         "typescript": "^5.8.3"
       }
     },
-    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config/node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "extraneous": true,
+    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
+      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config/node_modules/eslint-plugin-jsdoc": {
-      "version": "50.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
-      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
-      "extraneous": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.50.2",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.4.1",
-        "escape-string-regexp": "^4.0.0",
-        "espree": "^10.3.0",
-        "esquery": "^1.6.0",
-        "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.2",
-        "spdx-expression-parse": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "@eslint/js": "^10.0.0",
+        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "eslint-plugin-jsdoc": "^62.6.0",
+        "typescript-eslint": "^8.56.0"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/@types/node": {
@@ -594,6 +450,19 @@
         "@types/node": "^22.10.0"
       }
     },
+    "examples/chatroom/reactive_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
+      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^10.0.0",
+        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "eslint-plugin-jsdoc": "^62.6.0",
+        "typescript-eslint": "^8.56.0"
+      }
+    },
     "examples/hackernews/reactive_service": {
       "name": "reactive-hackernews-leader",
       "version": "1.0.0",
@@ -609,6 +478,50 @@
         "@skiplabs/eslint-config": "^0.0.2",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^22.10.0"
+      }
+    },
+    "examples/hackernews/reactive_service/node_modules/@skiplabs/eslint-config": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
+      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^10.0.0",
+        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "eslint-plugin-jsdoc": "^62.6.0",
+        "typescript-eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.58.0",
+        "comment-parser": "1.4.6",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -1431,6 +1344,23 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
+      "integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
@@ -2454,6 +2384,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2837,6 +2777,66 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "62.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.86.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.6",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.4",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-scope": {
@@ -3654,6 +3654,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -5750,7 +5760,14 @@
     "skipruntime-ts/addon": {
       "name": "@skipruntime/native",
       "version": "0.0.23",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
       "hasInstallScript": true,
+      "os": [
+        "linux"
+      ],
       "dependencies": {
         "@skipruntime/core": "0.0.23",
         "node-addon-api": "^8.7.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@skiplabs/tsconfig": "^0.0.3",
     "eslint": "10.4.0",
     "prettier": "3.4.1",


### PR DESCRIPTION
Stacked on #1324.

Adopts two flat-config features in the shared `@skiplabs/eslint-config` and cuts a new version.

- **`globalIgnores(["**/dist/*"])`** (ESLint 9.22+, from `eslint/config`) replaces the bare `{ ignores: [...] }` object — the ESLint-recommended, self-documenting way to express a global ignore.
- **`linterOptions.reportUnusedInlineConfigs: "error"`** (ESLint 9.19+) — the counterpart to the `reportUnusedDisableDirectives: "error"` already enforced; it flags inline `/* eslint rule: ... */` comments whose severity/options are redundant with the resolved config.
- Bump `@skiplabs/eslint-config` **0.0.2 → 0.0.3** and point the workspace-internal dependents at `^0.0.3` (a `^0.0.x` range is patch-locked, so `^0.0.2` would resolve the published 0.0.2 rather than the local workspace copy).

## Publishing (maintainer step)

The standalone example projects still reference `^0.0.2` and keep installing the published 0.0.2 until this is released. After merge:

```
make publish-eslint-config OTP=<npm-2FA-code>
```

Then bump the standalone examples (`examples/*/www`, `examples/chatroom/web_service`) to `^0.0.3` and reinstall. Republishing also clears a pre-existing issue: the published 0.0.2 predates the `@stylistic/eslint-plugin-js` → `@stylistic/eslint-plugin` change and emits a deprecation banner in those examples.

## Verification

The resolved config loads cleanly (`globalIgnores` import + both `linterOptions`, severity `error`). The workspace already has zero inline rule-config comments, so `reportUnusedInlineConfigs` reports nothing new. `globalIgnores([...])` is behaviorally identical to the previous global `ignores` object.