### PR TITLE
sktest: split SKTEST_FILTERS on whitespace so CI actually runs the tests

### DIFF
--- a/skiplang/sktest/extra/src/host.sk
+++ b/skiplang/sktest/extra/src/host.sk
@@ -144,9 +144,16 @@ untracked fun expectStdout(
 // dropped). An empty result means "no suite restriction".
 fun parseSuiteFilters(env: ?String): Array<String> {
   result = mutable Vector<String>[];
+  // Split on any whitespace, not just newlines: `circleci tests run` hands the
+  // selected suites back to `run-sktest.sh` as a single space-separated line
+  // (via `xargs`), so splitting only on `\n` would yield one bogus filter that
+  // matches no suite -- and the whole run would silently execute 0 tests. Suite
+  // names never contain whitespace, so this is safe.
   env.each(s ->
-    for (part in s.split("\n")) {
-      if (part != "") result.push(part)
+    for (line in s.split("\n")) {
+      for (part in line.split(" ")) {
+        if (part != "") result.push(part)
+      }
     }
   );
   result.toArray()


### PR DESCRIPTION
## Summary

The compiler test job (and any sktest-based job using the `circleci tests run` rerun wiring) has been **running 0 tests and passing vacuously**.

`bin/run-sktest.sh` wraps `skargo test` in `circleci tests run` so the "Rerun failed tests" button reruns only the failed suites. `circleci tests run` hands the selected suites back to the inner invocation as a **single space-separated line**, which `xargs -r -d '\n'` passes as **one argument**, so the harness gets them in `SKTEST_FILTERS` as one space-joined blob (e.g. `"Runtime Syntax ... visibility"`).

`parseSuiteFilters` split `SKTEST_FILTERS` on `\n` **only** → that blob became a *single* filter equal to no suite name → `matchesFilters` matched nothing → **0 tests ran**, and the job went green anyway.

## Evidence

- The compiler job's "Run compiler tests" step ends with `Failures: 0, successes: 0 (total: 0)`, and the CircleCI Tests tab reports **0 parsed tests** — on this branch's job and on an unrelated earlier one (#1313, build 17697), i.e. it long predates any single PR.
- Locally: `SKTEST_FILTERS="typechecking"` runs all 439 typechecking tests, but the space-joined blob `"Visibility Typechecking … visibility"` runs **0** — reproducing CI exactly. `xargs -r -d '\n'` on a space-separated line yields one argument (confirmed).

## Fix

Split `SKTEST_FILTERS` on **any whitespace** (space and newline), not just `\n`. Suite names never contain whitespace, so this is safe, and a normal newline-separated value keeps working.

## Verified

Rebuilt the compiler test binary with the fix: a space-joined `SKTEST_FILTERS="Native Visibility"` now runs **exactly** the `Native` (24) and `Visibility` (13) suites — 37 tests — instead of nothing. (The lone failure is the local multi-stage-build `CompilerVersionCheck` artifact, unrelated.)

## Why it matters

This is what makes the compiler CI meaningful again — it unblocks real test validation for e.g. #1320, whose compiler job is currently a vacuous green for the same reason.

## Test plan

- [x] space-joined `SKTEST_FILTERS` runs the named suites (was 0)
- [x] newline-separated value still works (split is a superset)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)