### PR TITLE
sktest: fix stale parseSuiteFilters doc comment (newline -> whitespace)

### DIFF
--- a/skiplang/sktest/extra/src/host.sk
+++ b/skiplang/sktest/extra/src/host.sk
@@ -140,7 +140,7 @@ untracked fun expectStdout(
   expectEq(actual, expected)
 }
 
-// Parse the newline-separated suite names in SKTEST_FILTERS (blank entries
+// Parse the whitespace-separated suite names in SKTEST_FILTERS (blank entries
 // dropped). An empty result means "no suite restriction".
 fun parseSuiteFilters(env: ?String): Array<String> {
   result = mutable Vector<String>[];


### PR DESCRIPTION
Tiny doc fix. The header comment on `parseSuiteFilters` still said `SKTEST_FILTERS` is "newline-separated", but #1326 changed the parse to split on **any whitespace** (space *and* newline). This just updates the comment to match the code (the inline comment inside the function already explains why). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)