### PR TITLE
Hint at the likely cause when skc crashes internally

### DIFF
--- a/skiplang/skargo/src/utils.sk
+++ b/skiplang/skargo/src/utils.sk
@@ -10,7 +10,8 @@ fun withTimer<T>(f: () -> T, g: Float -> void): T {
 }
 
 fun subprocess_error_message(p: System.CompletedProcess): String {
-  "command exited with non-zero status\n\n" +
+  message =
+    "command exited with non-zero status\n\n" +
     "Caused by:\n" +
     "  process did not exit successfully: \`" +
     p.args[0] +
@@ -20,7 +21,20 @@ fun subprocess_error_message(p: System.CompletedProcess): String {
     "\n" +
     "  --- stderr\n" +
     p.stderr.split("\n").map(l -> "  " + l).join("\n") +
-    "\n"
+    "\n";
+  // An "Invariant violation" from skc is the compiler crashing internally, not a
+  // diagnostic about the code being compiled. It almost always means skc is out
+  // of sync with those sources (stale build artifacts or an out-of-date
+  // compiler) rather than a problem the user can fix in their code.
+  if (p.args[0].endsWith("skc") && p.stderr.contains("Invariant violation")) {
+    message +
+      "\nnote: skc terminated with an internal error rather than reporting a normal\n" +
+      "diagnostic. This usually means the compiler is out of sync with the sources being\n" +
+      "compiled (stale build artifacts or an out-of-date compiler), not a bug in the code.\n" +
+      "Try `skargo clean` and rebuild; if it persists, rebuild or update skc.\n"
+  } else {
+    message
+  }
 }
 
 module end;


### PR DESCRIPTION
An `Invariant violation` from `skc` is the compiler crashing internally, not a diagnostic about the code being compiled — so the failure looks like the user's fault when it usually isn't. It almost always means `skc` is out of sync with the sources it's compiling (stale build artifacts or an out-of-date compiler).

This detects that case in skargo's subprocess-error formatter (command ends in `skc` and stderr contains `Invariant violation`) and appends a short note pointing at `skargo clean` / rebuilding `skc`.

Note: I couldn't compile-test locally (the environment hit exactly this `skc` crash), but `skfmt` accepted the change (syntax parses) and the String API used (`endsWith`, `contains`) and `&&` / if-expression forms match existing skargo code. Relying on CI to build-validate.