### PR TITLE
ci: derive the reverse-dependency graph so shared-lib changes retest dependents

### DIFF
--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -15,13 +15,42 @@ for skargo_toml in **/Skargo.toml; do
     && SK_CHANGED["$dir"]=false || SK_CHANGED["$dir"]=true
 done
 
-if ${SK_CHANGED[skiplang/prelude]}; then
-  SK_CHANGED[skiplang/compiler]=true
-  SK_CHANGED[sql]=true
-fi
-if ${SK_CHANGED[skiplang/sqlparser]}; then
-  SK_CHANGED[sql]=true
-fi
+# Retest every package that (transitively) depends on a changed one, so a change
+# to a shared library reaches its dependents' jobs. The reverse dependency graph
+# is derived from the `path = "..."` entries in each Skargo.toml (all dependency
+# sections), rather than hand-maintained, so it stays correct as packages change.
+declare -A SK_DEPS
+for skargo_toml in **/Skargo.toml; do
+  dir=$(dirname "$skargo_toml")
+  deps=""
+  while IFS= read -r dep_path; do
+    [ -n "$dep_path" ] || continue
+    resolved=$(realpath -m --relative-to=. "$dir/$dep_path" 2>/dev/null)
+    [ -f "$resolved/Skargo.toml" ] && deps="$deps $resolved"
+  done < <(awk '/^\[(dev-|build-)?dependencies\]/{d=1;next} /^\[/{d=0} d && /path *=/{print}' "$skargo_toml" \
+           | grep -oE 'path *= *"[^"]+"' | sed 's/.*"\(.*\)"/\1/')
+  SK_DEPS["$dir"]="$deps"
+done
+
+declare -A SK_RDEPS
+for pkg in "${!SK_DEPS[@]}"; do
+  for dep in ${SK_DEPS[$pkg]}; do
+    SK_RDEPS["$dep"]="${SK_RDEPS[$dep]:-} $pkg"
+  done
+done
+
+# Cycle-safe BFS over the reverse graph, seeded with the directly-changed packages.
+queue=()
+for pkg in "${!SK_CHANGED[@]}"; do ${SK_CHANGED["$pkg"]} && queue+=("$pkg"); done
+while [ "${#queue[@]}" -gt 0 ]; do
+  cur="${queue[0]}"; queue=("${queue[@]:1}")
+  for dependent in ${SK_RDEPS["$cur"]:-}; do
+    if [ "${SK_CHANGED[$dependent]:-false}" != true ]; then
+      SK_CHANGED["$dependent"]=true
+      queue+=("$dependent")
+    fi
+  done
+done
 
 check_ts=false
 declare -A TS_CHANGED


### PR DESCRIPTION
Closes #1327.

## Problem

`.circleci/generate_config.sh` picks per-package CI jobs from directory-level diffs, but it propagated **reverse dependencies with a hand-maintained list**:

```sh
if ${SK_CHANGED[skiplang/prelude]}; then SK_CHANGED[skiplang/compiler]=true; SK_CHANGED[sql]=true; fi
if ${SK_CHANGED[skiplang/sqlparser]}; then SK_CHANGED[sql]=true; fi
```

Anything not in that list didn't trigger its dependents' jobs. In particular **`sktest`** — a dependency of most packages' test binaries — triggered only the `sktest` job, so a `sktest` change never ran the `compiler` suite (which is exactly why #1326's fix couldn't be validated on the compiler suite in its own CI).

## Fix

Derive the reverse graph from the `path = "..."` entries in each `Skargo.toml` (all dependency sections) and mark every **transitive** dependent of a changed package, via a cycle-safe BFS (`prelude`/`sktest`/`cli` form a dev-dependency cycle). This subsumes the old hardcoded rules and stays correct as packages/deps change.

## Verified

Ran the generated `workflows:` for simulated changes:

| change | jobs generated |
|---|---|
| **sktest** | `compiler`, `prelude-tests`, `cli-tests`, `arparser-tests`, `semver-tests`, `skdate-tests`, `skjson-tests`, `toml-tests`, `sktest-tests`, `skargo-build`, `skdb`, `skdb-wasm`, `skipruntime`, `skipruntime-bun` |
| **skdate** (leaf) | `skdate-tests`, `skdb`, `skdb-wasm` — **no `compiler`** |
| **compiler** only | `compiler` |

Foundational libs (`prelude`/`sktest`/`cli`) fan out to everything — which is correct, since they're in every package's build/test. Over-triggering is safe; the previous under-triggering silently skipped affected suites.

Note: a dev-dependency-only change (e.g. `sktest`) still cascades into the TS `skdb-wasm` job via `sql` (same path `prelude` already takes today). That's a safe over-trigger; distinguishing dev- vs build-deps in the SK→TS bridge could tighten it later if desired.

## Test plan

- [x] generated workflows for sktest / leaf / compiler-only changes match expectations
- [x] subsumes the previous `prelude`/`sqlparser` rules
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)