### PR TITLE
Bump the examples to @skiplabs/eslint-config 0.0.3

### DIFF
--- a/examples/blogger/reactive_service/package-lock.json
+++ b/examples/blogger/reactive_service/package-lock.json
@@ -16,7 +16,7 @@
         "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^20.0.0",
         "eslint": "10.4.0",
@@ -272,14 +272,14 @@
       }
     },
     "node_modules/@skiplabs/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.3.tgz",
+      "integrity": "sha512-Lb1rg7Rn2OmQj8QcsppSbb9mDU7Zw4Getvtchonaer/0L/8lIYkDEwncJkQz+5+GXNK/KvwYE93cmIqssC52fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.0",
-        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "eslint-plugin-jsdoc": "^62.6.0",
         "typescript-eslint": "^8.56.0"
       }
@@ -341,21 +341,25 @@
         "@skipruntime/core": "0.0.23"
       }
     },
-    "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
-      "integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.0.0"
+        "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@types/esrecurse": {

--- a/examples/blogger/reactive_service/package.json
+++ b/examples/blogger/reactive_service/package.json
@@ -21,7 +21,7 @@
     "@skip-adapter/postgres": "0.0.23"
   },
   "devDependencies": {
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@skiplabs/tsconfig": "^0.0.3",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0",

--- a/examples/blogger/www/package-lock.json
+++ b/examples/blogger/www/package-lock.json
@@ -12,7 +12,7 @@
         "vue-router": "^4.4.0"
       },
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@vitejs/plugin-vue": "^6.0.7",
         "eslint": "^10.0.0",
         "eslint-plugin-vue": "^10.0.0",
@@ -617,14 +617,14 @@
       }
     },
     "node_modules/@skiplabs/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.3.tgz",
+      "integrity": "sha512-Lb1rg7Rn2OmQj8QcsppSbb9mDU7Zw4Getvtchonaer/0L/8lIYkDEwncJkQz+5+GXNK/KvwYE93cmIqssC52fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^10.0.0",
-        "@stylistic/eslint-plugin-js": "^4.4.0",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "eslint-plugin-jsdoc": "^62.6.0",
         "typescript-eslint": "^8.56.0"
       }
@@ -650,21 +650,25 @@
         }
       }
     },
-    "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
-      "integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.0.0"
+        "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/examples/blogger/www/package.json
+++ b/examples/blogger/www/package.json
@@ -20,7 +20,7 @@
     "vue-tsc": "^2.1.0",
     "typescript": "^5.7.2",
     "eslint": "^10.0.0",
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "eslint-plugin-vue": "^10.0.0",
     "typescript-eslint": "^8.59.4",
     "vue-eslint-parser": "^10.0.0",

--- a/examples/cache_invalidation/edge_service/package.json
+++ b/examples/cache_invalidation/edge_service/package.json
@@ -21,7 +21,7 @@
     "@skip-adapter/postgres": "0.0.23"
   },
   "devDependencies": {
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@skiplabs/tsconfig": "^0.0.3",
     "@types/node": "^20.19.6",
     "typescript": "^5.8.3",

--- a/examples/cache_invalidation/edge_service/pnpm-lock.yaml
+++ b/examples/cache_invalidation/edge_service/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  path-to-regexp: ^0.1.13
+
 importers:
 
   .:
@@ -25,8 +28,8 @@ importers:
         version: 0.0.23
     devDependencies:
       '@skiplabs/eslint-config':
-        specifier: ^0.0.2
-        version: 0.0.2(eslint@10.4.0)(typescript@5.9.3)
+        specifier: ^0.0.3
+        version: 0.0.3(eslint@10.4.0)(typescript@5.9.3)
       '@skiplabs/tsconfig':
         specifier: ^0.0.3
         version: 0.0.3
@@ -117,8 +120,8 @@ packages:
     resolution: {integrity: sha512-NeuvZ/eN7pGuPkasLe+2SCusOdGSwNyVOOcHbQspN/GVvyBUjs+H9d/yYNqpQUjPMIf+XlVeu41tkdvhyIInHA==}
     engines: {node: '>=22.6.0 <23.0.0'}
 
-  '@skiplabs/eslint-config@0.0.2':
-    resolution: {integrity: sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==}
+  '@skiplabs/eslint-config@0.0.3':
+    resolution: {integrity: sha512-Lb1rg7Rn2OmQj8QcsppSbb9mDU7Zw4Getvtchonaer/0L/8lIYkDEwncJkQz+5+GXNK/KvwYE93cmIqssC52fg==}
 
   '@skiplabs/tsconfig@0.0.3':
     resolution: {integrity: sha512-PALwao9q5j6Y6WtNbAjG/nroQEtOI3nn+uEjFqNbyg+UJQ7HzZ2Z/2AIq3DFEam2419p6xfLAePSI7PnUhcrIQ==}
@@ -139,11 +142,11 @@ packages:
   '@skipruntime/wasm@0.0.23':
     resolution: {integrity: sha512-pGWMOsKLOyMPX3vY32kt6wXMmtZWSQ/PJi2GydlP8JFgdqSRco3IbFrkVgwT9jRW0vt9VTxr3HpIuxlSSGrRUw==}
 
-  '@stylistic/eslint-plugin-js@4.4.1':
-    resolution: {integrity: sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==}
+  '@stylistic/eslint-plugin@5.10.0':
+    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=9.0.0'
+      eslint: ^9.0.0 || ^10.0.0
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -933,10 +936,10 @@ snapshots:
     transitivePeerDependencies:
       - pg-native
 
-  '@skiplabs/eslint-config@0.0.2(eslint@10.4.0)(typescript@5.9.3)':
+  '@skiplabs/eslint-config@0.0.3(eslint@10.4.0)(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.4.0)
-      '@stylistic/eslint-plugin-js': 4.4.1(eslint@10.4.0)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.4.0)
       eslint-plugin-jsdoc: 62.9.0(eslint@10.4.0)
       typescript-eslint: 8.60.0(eslint@10.4.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -975,11 +978,15 @@ snapshots:
     dependencies:
       '@skipruntime/core': 0.0.23
 
-  '@stylistic/eslint-plugin-js@4.4.1(eslint@10.4.0)':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.4.0)':
     dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@typescript-eslint/types': 8.60.0
       eslint: 10.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.4
 
   '@types/esrecurse@4.3.1': {}
 

--- a/examples/cache_invalidation/www/package.json
+++ b/examples/cache_invalidation/www/package.json
@@ -15,7 +15,7 @@
     "vue-router": "^4.4.0"
   },
   "devDependencies": {
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@vitejs/plugin-vue": "^5.2.0",
     "eslint": "^10.0.0",
     "eslint-plugin-vue": "^10.0.0",

--- a/examples/cache_invalidation/www/pnpm-lock.yaml
+++ b/examples/cache_invalidation/www/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 4.6.4(vue@3.5.34(typescript@5.9.3))
     devDependencies:
       '@skiplabs/eslint-config':
-        specifier: ^0.0.2
-        version: 0.0.2(eslint@10.7.0)(typescript@5.9.3)
+        specifier: ^0.0.3
+        version: 0.0.3(eslint@10.7.0)(typescript@5.9.3)
       '@vitejs/plugin-vue':
         specifier: ^5.2.0
         version: 5.2.4(vite@6.4.3)(vue@3.5.34(typescript@5.9.3))
@@ -29,7 +29,7 @@ importers:
         version: 10.7.0
       eslint-plugin-vue:
         specifier: ^10.0.0
-        version: 10.9.1(@typescript-eslint/parser@8.60.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(vue-eslint-parser@10.4.0(eslint@10.7.0))
+        version: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.7.0))(@typescript-eslint/parser@8.60.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(vue-eslint-parser@10.4.0(eslint@10.7.0))
       globals:
         specifier: ^15.12.0
         version: 15.15.0
@@ -420,14 +420,14 @@ packages:
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
 
-  '@skiplabs/eslint-config@0.0.2':
-    resolution: {integrity: sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==}
+  '@skiplabs/eslint-config@0.0.3':
+    resolution: {integrity: sha512-Lb1rg7Rn2OmQj8QcsppSbb9mDU7Zw4Getvtchonaer/0L/8lIYkDEwncJkQz+5+GXNK/KvwYE93cmIqssC52fg==}
 
-  '@stylistic/eslint-plugin-js@4.4.1':
-    resolution: {integrity: sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==}
+  '@stylistic/eslint-plugin@5.10.0':
+    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=9.0.0'
+      eslint: ^9.0.0 || ^10.0.0
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1286,10 +1286,10 @@ snapshots:
 
   '@sindresorhus/base62@1.0.0': {}
 
-  '@skiplabs/eslint-config@0.0.2(eslint@10.7.0)(typescript@5.9.3)':
+  '@skiplabs/eslint-config@0.0.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.7.0)
-      '@stylistic/eslint-plugin-js': 4.4.1(eslint@10.7.0)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.7.0)
       eslint-plugin-jsdoc: 62.9.0(eslint@10.7.0)
       typescript-eslint: 8.60.0(eslint@10.7.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -1297,11 +1297,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@stylistic/eslint-plugin-js@4.4.1(eslint@10.7.0)':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.7.0)':
     dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@typescript-eslint/types': 8.60.0
       eslint: 10.7.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.5
 
   '@types/esrecurse@4.3.1': {}
 
@@ -1589,13 +1593,13 @@ snapshots:
       html-entities: 2.6.0
       object-deep-merge: 2.0.1
       parse-imports-exports: 0.2.4
-      semver: 7.8.1
+      semver: 7.8.5
       spdx-expression-parse: 4.0.0
       to-valid-identifier: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.60.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(vue-eslint-parser@10.4.0(eslint@10.7.0)):
+  eslint-plugin-vue@10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.7.0))(@typescript-eslint/parser@8.60.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(vue-eslint-parser@10.4.0(eslint@10.7.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       eslint: 10.7.0
@@ -1606,6 +1610,7 @@ snapshots:
       vue-eslint-parser: 10.4.0(eslint@10.7.0)
       xml-name-validator: 4.0.0
     optionalDependencies:
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.7.0)
       '@typescript-eslint/parser': 8.60.0(eslint@10.7.0)(typescript@5.9.3)
 
   eslint-scope@9.1.2:

--- a/examples/chatroom/reactive_service/package.json
+++ b/examples/chatroom/reactive_service/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@skiplabs/tsconfig": "^0.0.3"
   }
 }

--- a/examples/chatroom/web_service/package.json
+++ b/examples/chatroom/web_service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.0",
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@skiplabs/tsconfig": "^0.0.3"
   }
 }

--- a/examples/chatroom/www/package.json
+++ b/examples/chatroom/www/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.7.2",
     "vite": "^6.0.1 >= 6.0.9",
     "eslint": "^10.0.0",
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3"
   }

--- a/examples/hackernews/reactive_service/package.json
+++ b/examples/hackernews/reactive_service/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@skiplabs/tsconfig": "^0.0.3"
   }
 }

--- a/examples/hackernews/www/package.json
+++ b/examples/hackernews/www/package.json
@@ -16,7 +16,7 @@
     "react-router-dom": "^7.0.1"
   },
   "devDependencies": {
-    "@skiplabs/eslint-config": "^0.0.2",
+    "@skiplabs/eslint-config": "^0.0.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-router-dom": "^5.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,24 +332,11 @@
         "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^20.0.0",
         "eslint": "10.4.0",
         "typescript": "^5.0.0"
-      }
-    },
-    "examples/blogger/reactive_service/node_modules/@skiplabs/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/js": "^10.0.0",
-        "@stylistic/eslint-plugin-js": "^4.4.0",
-        "eslint-plugin-jsdoc": "^62.6.0",
-        "typescript-eslint": "^8.56.0"
       }
     },
     "examples/blogger/reactive_service/node_modules/@types/node": {
@@ -381,24 +368,11 @@
         "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^20.19.6",
         "eslint": "10.4.0",
         "typescript": "^5.8.3"
-      }
-    },
-    "examples/cache_invalidation/edge_service/node_modules/@skiplabs/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/js": "^10.0.0",
-        "@stylistic/eslint-plugin-js": "^4.4.0",
-        "eslint-plugin-jsdoc": "^62.6.0",
-        "typescript-eslint": "^8.56.0"
       }
     },
     "examples/cache_invalidation/edge_service/node_modules/@types/node": {
@@ -445,22 +419,9 @@
         "kafkajs": "^2.2.4"
       },
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^22.10.0"
-      }
-    },
-    "examples/chatroom/reactive_service/node_modules/@skiplabs/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/js": "^10.0.0",
-        "@stylistic/eslint-plugin-js": "^4.4.0",
-        "eslint-plugin-jsdoc": "^62.6.0",
-        "typescript-eslint": "^8.56.0"
       }
     },
     "examples/hackernews/reactive_service": {
@@ -475,53 +436,9 @@
         "@skipruntime/wasm": "0.0.23"
       },
       "devDependencies": {
-        "@skiplabs/eslint-config": "^0.0.2",
+        "@skiplabs/eslint-config": "^0.0.3",
         "@skiplabs/tsconfig": "^0.0.3",
         "@types/node": "^22.10.0"
-      }
-    },
-    "examples/hackernews/reactive_service/node_modules/@skiplabs/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@skiplabs/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-jM3KaGosMEZyZlbulmuwGvK3XIpZFU0CfJuTe4x+Vx4Z7mjPeI9foWdyvtl4LDGnUpHEH4At5sfe11pQdTMF1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/js": "^10.0.0",
-        "@stylistic/eslint-plugin-js": "^4.4.0",
-        "eslint-plugin-jsdoc": "^62.6.0",
-        "typescript-eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
-      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.58.0",
-        "comment-parser": "1.4.6",
-        "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -1344,23 +1261,6 @@
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
-      "integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
@@ -2384,16 +2284,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/comment-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
-      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2777,66 +2667,6 @@
         "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
-      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.86.0",
-        "@es-joy/resolve.exports": "1.2.0",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.6",
-        "debug": "^4.4.3",
-        "escape-string-regexp": "^4.0.0",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
-        "html-entities": "^2.6.0",
-        "object-deep-merge": "^2.0.0",
-        "parse-imports-exports": "^0.2.4",
-        "semver": "^7.7.4",
-        "spdx-expression-parse": "^4.0.0",
-        "to-valid-identifier": "^1.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-scope": {
@@ -3654,16 +3484,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {


### PR DESCRIPTION
Now that `@skiplabs/eslint-config@0.0.3` is published, point the example projects at it. They were held on `^0.0.2` in #1325 because their standalone Docker builds (`check-examples`) install from the public registry, where 0.0.3 didn't exist yet — bumping them then failed with `npm ETARGET`.

- 9 example `package.json` files: `@skiplabs/eslint-config` `^0.0.2` → `^0.0.3` (4 backends, 4 `www` frontends, `chatroom/web_service`).
- Regenerated the lockfiles that are committed (root, `blogger/www`, `cache_invalidation/www`, `blogger/reactive_service`, `edge_service`); the diffs are limited to the eslint-config subtree (the unified `@stylistic/eslint-plugin@5` replaces the deprecated `-js`).
- The workspace **root lockfile** also drops the transitional duplicate — the backends now resolve the local 0.0.3 workspace copy instead of pulling a second, published 0.0.2 alongside it.

## Verification

`npm run lint` is green in the examples under 0.0.3. Example Dockerfiles `COPY package.json` then `npm install` (not `npm ci`), so `check-examples` resolves 0.0.3 from the registry directly.