### PR TITLE
ci: gate auto-merge on all triggered jobs via an all-checks job

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -302,3 +302,16 @@ jobs:
           name: Tear down cache invalidation example
           working_directory: ~/project/examples/cache_invalidation
           command: docker compose down --volumes
+
+  # Aggregating gate: `generate_config.sh` makes this job depend on every other
+  # job it schedules, so `ci/circleci: all-checks` is a single, always-present
+  # status context that only passes once all triggered jobs pass. Make it a
+  # required check so auto-merge waits for the whole dynamically-generated set.
+  all-checks:
+    docker:
+      - image: cimg/base:2025.01
+    resource_class: small
+    steps:
+      - run:
+          name: All triggered jobs passed
+          command: echo "All triggered CI jobs passed."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ jobs:
           name: Generate config
           command: |
             .circleci/generate_config.sh > generated_config.yml
-            if ! grep -q '^workflows:' generated_config.yml; then
-              echo "No dynamic workflows to run"
-              circleci-agent step halt
-            fi
       - continuation/continue:
           configuration_path: generated_config.yml
 

--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -85,17 +85,19 @@ fi
 
 cat .circleci/base.yml
 
-WORKFLOWS=$(mktemp)
-trap 'rm -f "$WORKFLOWS"' EXIT
+JOBS=$(mktemp)
+trap 'rm -f "$JOBS"' EXIT
 
+# Names of every job scheduled below, so the `all-checks` gate can require them.
+NAMES=()
+
+# The brace group runs in the current shell (redirection does not fork it), so
+# NAMES accumulates across the blocks below.
 {
 if $check_ts
 then
-    cat <<EOF
-  check-ts:
-    jobs:
-      - check-ts
-EOF
+    echo "      - check-ts"
+    NAMES+=(check-ts)
 fi
 
 for dir in "${!SK_CHANGED[@]}"; do
@@ -105,69 +107,63 @@ for dir in "${!SK_CHANGED[@]}"; do
         TS_CHANGED[skipruntime-ts]=true
         ;;
       sql)
-        cat <<EOF
-  skdb:
-    jobs:
-      - skdb
-EOF
+        echo "      - skdb"
+        NAMES+=(skdb)
         ;;
       skiplang/compiler)
-   cat <<EOF
-  compiler:
-    jobs:
-      - compiler
-EOF
+        echo "      - compiler"
+        NAMES+=(compiler)
         ;;
       skiplang/sqlparser) ;;
       *)
         name=$(basename "$dir")
         if [ -d "$dir/tests" ]; then
-          echo "  $name-tests:"
-          echo "    jobs:"
           echo "      - skip-package-tests:"
         else
-          echo "  $name-build:"
-          echo "    jobs:"
           echo "      - skip-package-build:"
         fi
         echo "          dir: $dir"
         echo "          name: $name"
+        NAMES+=("$name")
     esac
   fi
 done
 
 if ${TS_CHANGED[sql]}
 then
-    cat <<EOF
-  skdb-wasm:
-    jobs:
-      - skdb-wasm
-EOF
+    echo "      - skdb-wasm"
+    NAMES+=(skdb-wasm)
 fi
 
 if ${TS_CHANGED[skipruntime-ts]}
 then
-    cat <<EOF
-  skipruntime:
-    jobs:
-      - skipruntime
-  skipruntime-bun:
-    jobs:
-      - skipruntime-bun
-EOF
+    echo "      - skipruntime"
+    echo "      - skipruntime-bun"
+    NAMES+=(skipruntime skipruntime-bun)
 fi
 
 if (( examples != 0 ))
 then
-    cat <<EOF
-  examples:
-    jobs:
-      - check-examples
-EOF
+    echo "      - check-examples"
+    NAMES+=(check-examples)
 fi
-} > "$WORKFLOWS"
+} > "$JOBS"
 
-if [ -s "$WORKFLOWS" ]; then
-  echo "workflows:"
-  cat "$WORKFLOWS"
+# Schedule every triggered job in a single `ci` workflow, gated by `all-checks`.
+# The gate depends on all of them, so its status context (`ci/circleci:
+# all-checks`) only turns green once every triggered job has passed. It is
+# always emitted -- even when no jobs are triggered -- so it is a stable required
+# check that branch protection / auto-merge can wait on regardless of the diff.
+echo "workflows:"
+echo "  ci:"
+echo "    jobs:"
+cat "$JOBS"
+if [ "${#NAMES[@]}" -gt 0 ]; then
+  echo "      - all-checks:"
+  echo "          requires:"
+  for name in "${NAMES[@]}"; do
+    echo "            - $name"
+  done
+else
+  echo "      - all-checks"
 fi


### PR DESCRIPTION
## Problem

CI is a CircleCI setup + continuation pipeline: `generate_config.sh` emits a
different set of jobs depending on which directories a PR touches. GitHub sees a
status context per job (`ci/circleci: <job>`), but the only *required* check on
`main` is `ci/circleci: fast-checks`. So auto-merge (and branch protection)
ignores every dynamically-triggered job — a PR can merge while `skdb-wasm`,
`compiler`, `skipruntime`, package tests, etc. are still running or red.

We can't just mark them all required: a required context that a given diff
*doesn't* trigger stays "Expected — waiting for status to be reported" forever
and wedges the PR. The set of jobs is dynamic, so the required check has to be
too.

## Fix

Add a single aggregating gate. `generate_config.sh` now:

- schedules every triggered job in **one** `ci` workflow (instead of one
  workflow per job), and
- appends an **`all-checks`** job that `requires` every job it scheduled.

`all-checks` is **always** emitted — even when a diff triggers no jobs (it then
just has no `requires` and passes immediately). So `ci/circleci: all-checks` is a
stable status context present on every pipeline that only turns green once all
triggered jobs pass. That makes it the single check auto-merge can wait on,
regardless of which jobs the diff triggered.

Because a `workflows:` block is now always produced, the "halt when there are no
dynamic workflows" branch in `config.yml` is dead and is removed.

Consolidating the per-job workflows into one `ci` workflow does **not** change
the per-job status context names GitHub sees (`ci/circleci: <job>` is keyed on
the job, not the workflow).

## Follow-up required from a maintainer (branch protection)

This PR only makes the gate *exist*. To make auto-merge actually wait on it, a
repo admin must add it to the required status checks on `main` **after this
merges** (Settings → Branches → `main`, or via API):

- keep `ci/circleci: fast-checks` (runs in the setup workflow, not gated),
- add `ci/circleci: all-checks`,
- optionally add `ci/circleci: setup` (so a broken config generation is visible).

Order matters: merge this first so the `all-checks` context exists, then flip the
setting. With `strict: true` already set, open PRs pick up the new gate when they
rebase onto `main`.

When a triggered job fails, `all-checks` is skipped rather than run, so its
context stays *pending* (the failure itself shows red on the failing job).
A pending `all-checks` therefore means "an upstream job is still running or
failed" — which correctly keeps the PR unmergeable.
