### PR TITLE
Mark side-effecting stdlib native funs @debug so they aren't CSE'd

### DIFF
--- a/skiplang/prelude/src/stdlib/filesystem/FileSystem.sk
+++ b/skiplang/prelude/src/stdlib/filesystem/FileSystem.sk
@@ -8,6 +8,7 @@
 // Module for manipulating the Files and Directories.
 
 // TODO: What module should this go in?
+@debug
 @cpp_extern("SKIP_getcwd")
 @may_alloc
 native fun getcwd(): String;
@@ -66,14 +67,17 @@ fun writeTextFile(filename: String, contents: String): void {
   string_to_file(contents, filename);
 }
 
+@debug
 @cpp_extern("SKIP_get_mtime")
 native fun getLastModificationTime(fileName: String): Int;
 
+@debug
 @synonym("appendFile")
 @synonym("appendFileSync")
 @cpp_extern
 native fun appendTextFile(filename: String, contents: String): void;
 
+@debug
 @cpp_extern("SKIP_check_if_file_exists")
 native fun exists(filename: String): Bool;
 
@@ -148,11 +152,13 @@ fun stat(path: String): ?FileStat {
   if (rc < 0) None() else Some(unsafe_chill_trust_me(result))
 }
 
+@debug
 @cpp_extern("SKIP_file_stat")
 private native fun fillStat(result: mutable FileStat, path: String): Int;
 
 // TODO: Rename the C++ entrypoints and merge these into the
 // public API above.
+@debug
 @cpp_extern
 private native fun .open_file(String): String;
 
@@ -160,6 +166,7 @@ private native fun .open_file(String): String;
 @cpp_extern
 private native fun .string_to_file(s: String, file: String): void;
 
+@debug
 @cpp_extern("SKIP_is_directory")
 private native fun is_directory(filename: String): Bool;
 

--- a/skiplang/prelude/src/stdlib/other/Posix.sk
+++ b/skiplang/prelude/src/stdlib/other/Posix.sk
@@ -449,6 +449,7 @@ mutable native class SpawnFileActions {
   mutable native fun close(fd: Int): void;
 }
 
+@debug
 @cpp_extern("SKIP_posix_spawnp")
 native fun internalSpawnp(
   argv: Array<String>,

--- a/skiplang/prelude/src/stdlib/other/System.sk
+++ b/skiplang/prelude/src/stdlib/other/System.sk
@@ -173,17 +173,21 @@ native fun getMemoryFrameUsage(): Int;
 
 module end;
 
+@debug
 @cpp_extern
 @may_alloc
 native fun read_line(): ?String;
 
+@debug
 @cpp_extern
 @may_alloc
 native fun read_to_end(): String;
 
+@debug
 @cpp_extern("SKIP_flush_stdout")
 native fun flushStdout(): void;
 
+@debug
 @cpp_extern("SKIP_system")
 @may_alloc
 native fun system(cmd: String): Int;


### PR DESCRIPTION
## Problem

A number of OS-facing `native fun`s in the stdlib carry no tracking annotation, which lets the optimizer merge two identical calls into one. `funCanCSE` ([peephole.sk](https://github.com/SkipLabs/skip/blob/main/skiplang/compiler/src/peephole.sk#L361-L364)) allows CSE for any tracked function without `@debug`, and `canCSECall` only additionally requires that the arguments and return type be deep-frozen — which is exactly the case for `system(cmd)`, `read_line()`, `exists(path)`, `open_file(path)` and friends.

This is a miscompilation, not merely a missed side effect. Reduced case, built `--release`:

```skip
fun main(): void {
  a = read_line();
  b = read_line();
  print_string("a=" + a.default("<none>"));
  print_string("b=" + b.default("<none>"));
}
```

```
$ printf '1\n2\n' | ./csetest
a=1
b=1      # <-- the two reads were merged; the second input line is silently dropped
```

With `@debug` restored it prints `a=1` / `b=2`. `system(cmd)` invoked twice with the same command collapses the same way, and two `appendTextFile(f, s)` calls append once.

Dead-code elimination is *not* involved: `alwaysLive` ([deadcode.sk](https://github.com/SkipLabs/skip/blob/main/skiplang/compiler/src/deadcode.sk#L191-L193)) keeps every `CallBase` because any call might throw. CSE is the only hazard here.

## Why `@debug` and not `untracked`

Both block CSE, but they are not interchangeable:

- `untracked` is a **type-level, transitive** property for "important" side effects. A tracked caller of an untracked fun is a hard error (`check_tracking`).
- `@debug` is a **non-transitive** no-CSE marker, intended — per the comment in `peephole.sk` — for side effects that should not be optimized away "without the heavyweight transitive implications".

`untracked` is not applicable to these leaves: they are called from *tracked* wrappers, so marking them untracked does not typecheck. Flipping `Posix.read` to `untracked` immediately fails on `IO.File.read` (`IO.sk:147`) and cascades through the whole I/O stack up to user `main()`. Making stdlib I/O properly untracked is a stdlib redesign and is out of scope here; `@debug` is the correct marker for these declarations today.

## Changes

Three per-module commits adding `@debug` to 12 declarations:

| Module | Functions |
|---|---|
| `System` | `system`, `read_line`, `read_to_end`, `flushStdout` |
| `FileSystem` | `getcwd`, `getLastModificationTime`, `appendTextFile`, `exists`, `open_file`, `is_directory`, `fillStat` |
| `Posix` | `internalSpawnp` |

The annotation was already applied haphazardly — `realpath` and `opendir` had it while `exists` and `open_file` did not — so this also makes the convention uniform.

`fillStat` and `internalSpawnp` cannot be CSE'd today (a `mutable` / `readonly` argument keeps them out), so for those two the annotation documents intent and guards against later signature changes rather than fixing a live bug. Happy to drop them if reviewers would rather keep the diff strictly to the reachable cases.

## Deliberately left unannotated

Functions that are genuinely pure, where CSE is valid and desirable: `Math.*`; `Posix.open_flags` and the `wif*` / `wexitstatus` / `wtermsig` / `wstopsig` decoders (pure functions of `stat_loc`); `Time.strftime` (deterministic given its arguments); and `Environ.internalGetArgc` / `internalGetArgN` — argv is fixed at startup, unlike the environment, which is why `varOpt` *is* `@debug`.

## Test plan

- `skargo check` on the prelude is clean.
- The reduced case above was built `--release` and run with and without the annotation, confirming both the miscompilation and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Opus 4.8 (1M context)