### PR TITLE
Refresh skiplang-bin-builder base to a current bookworm snapshot (-66 high CVEs)

### DIFF
--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -3,7 +3,13 @@
 
 # aim to start from an image with a version of glibc that is as widely
 # compatible as possible while still receiving security updates
-FROM debian:bookworm-20250113-slim AS base
+#
+# Keep the codename at bookworm: it sets the glibc floor (2.36) for the
+# libskipruntime.so binary releases built from this image, and bumping it
+# would drop support for Debian 12 / Ubuntu 22.04 / RHEL 9 users. Only the
+# date pin should be refreshed, which picks up security updates while
+# leaving glibc at 2.36.
+FROM debian:bookworm-20260713-slim AS base
 
 ARG LLVM_VERSION=20
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

`skiplang/Dockerfile` pins `debian:bookworm-20250113-slim` — an **18-month-old** snapshot. That contradicts the file's own stated intent ("a version of glibc that is as widely compatible as possible **while still receiving security updates**"): the date pin means rebuilds keep pulling the same frozen, unpatched base layer.

This refreshes only the **date**: `bookworm-20250113-slim` → `bookworm-20260713-slim`.

**The codename deliberately stays `bookworm`.** It sets the glibc floor (2.36) for the `libskipruntime.so` binary releases built from this image; bumping to trixie would raise it to 2.41 and drop Debian 12 / Ubuntu 22.04 / RHEL 9 users — the compatibility promise discussed in #1261. A comment now records this so a future "modernize the base" change doesn't silently regress it.

## Measured impact (Docker Scout)

Rebuilt image vs the currently-published `skiplabs/skiplang-bin-builder:latest`:

| | published | refreshed |
|---|---|---|
| critical | 3 | **1** |
| high | **68** | **2** |
| medium | 60 | **3** |
| low | 202 | 107 |
| **fixable C/H** | **2C 61H** | **0C 0H** |

Flips the **"No fixable critical or high vulnerabilities"** policy from fail → pass (3/7 → 4/7 policies met). The residual 1C/2H have no upstream fix available.

## Test plan

- [x] Image rebuilds cleanly from the new pin
- [x] **glibc floor preserved** — rebuilt image is Debian 12 (bookworm), glibc **2.36**
- [x] Toolchain works — `skc 0.3.3 (56bb92cfc)` builds and runs
- [x] Scout delta measured (above)
- [x] CI green
- [ ] Republish `skiplabs/skiplang-bin-builder` after merge (`./bin/docker_build.sh --push --arch amd64,arm64 skiplang-bin-builder`) — the published image is from 2025-07-24 and won't pick this up until rebuilt

## Follow-ups (not in this PR)

Scout's remaining policy failures on this image are separate levers: **runs as root**, **supply-chain attestations missing** (no provenance/SBOM in `docker-bake.hcl`), and copyleft licenses.