### PR TITLE
Finish the untracked test-harness migration (fixes the red toml job)

### DIFF
--- a/skiplang/sktest/extra/src/wasm32.sk
+++ b/skiplang/sktest/extra/src/wasm32.sk
@@ -1,6 +1,6 @@
 module SKTest;
 
-fun test_harness(
+untracked fun test_harness(
   tests: readonly Map<String, readonly Sequence<Test>>,
   // Kept signature-compatible with the host harness; wasm runs tests serially,
   // so this is invoked once with a job count of 1 (and a run-everything

--- a/skiplang/toml/tests/tests.sk
+++ b/skiplang/toml/tests/tests.sk
@@ -87,7 +87,7 @@ fun runInvalidTest(tomlFile: String): void {
   }
 }
 
-fun main(): void {
+untracked fun main(): void {
   tests = mutable Map[];
 
   validTests = FileSystem.readFilesRecursive("./tests/valid", fn ->


### PR DESCRIPTION
## Problem

The `toml` test suite has not compiled since March:

```
File "tests/tests.sk", line 134, characters 3-23:
Cannot call an untracked function from a tracked context
134 |   T.test_harness(tests)
```

`828757ab9` ("Allow untracked functions to be tested") made `SKTest.test_harness` untracked and updated sktest's own `main()` to match. `84ae386d5` later applied the same one-line fix to the compiler's custom harness. `toml` declares a custom harness too — `test-harness = "TOMLTests.main"` ([Skargo.toml:4](https://github.com/SkipLabs/skip/blob/main/skiplang/toml/Skargo.toml#L4)) — and was missed by both, so its tracked `main()` still cannot call the now-untracked `test_harness`.

Only two packages override `test-harness`: `toml` and `compiler`. Everything else gets `SKTest.main`, which is already `untracked` — so `untracked` is the contract for a harness entrypoint, not a deviation here.

## Why it surfaced now

Nothing broke it recently; the toml job simply hadn't run. CI is a setup job plus a dynamic continuation, and `.circleci/generate_config.sh` picks jobs from the diff against `git merge-base main HEAD`. Before `047dd8c20` the reverse-dependency graph was hardcoded, and a prelude change fanned out to `compiler` + `sql` only. That commit derived the graph from the `path = "..."` deps in each `Skargo.toml`, and `skiplang/toml/Skargo.toml` declares `std = { path = "../prelude" }` — so prelude → toml is now a live edge, and the next prelude-touching PR (#1337) scheduled the job and surfaced the failure.

Note the gating is structurally PR-only: on a main push `HEAD == main`, so every diff is empty and only the bare gate runs. The toml job could never have run on main, which is the blind spot `047dd8c20` closed.

## Changes

Two independent one-line commits:

1. **toml** — `fun main` → `untracked fun main` in `tests/tests.sk`. Fixes the live CI failure.
2. **sktest** — `fun test_harness` → `untracked fun test_harness` in `extra/src/wasm32.sk`. The same commit missed the wasm32 harness variant, which calls untracked `run_test` (`:61`) and the untracked `parent_setup` callback (`:50`). `build.sk` selects that file only for `--target wasm32-unknown-unknown` and nothing builds sktest for that target today, so it is latent rather than a live failure — but the wasm harness does not currently compile. Happy to drop this commit if reviewers would rather keep the PR strictly to the red job.

Marking `main()` untracked costs nothing: nothing calls it (skargo exports it as `skip_main`), and the no-CSE implication is callee-side only, so `TOML.decode` / `runValidTest` optimization is unaffected.

## Test plan

- `skargo test` in `skiplang/toml`, on a pristine `origin/main` worktree: reproduces the error above verbatim; with commit 1 applied the suite compiles and passes **331/331, 0 failures**.
- `skargo check --target wasm32-unknown-unknown` in `skiplang/sktest`, on pristine `origin/main`: fails at `wasm32.sk:50`; with commit 2 the lib type-checks clean.

## Relation to #1337

#1337 (`@debug` on stdlib native funs) is red only because of this pre-existing failure — `@debug` is a backend-only annotation, read in `peephole.sk` / `const.sk` well after typing, and it cannot influence the frontend tracking check. That PR needs this one to land first (or to be rebased onto it) to go green. The other jobs `047dd8c20` newly woke for prelude changes — `skdate`, `cli`, `skargo`, `semver`, `arparser`, `skjson` — all passed on #1337, so `toml` is the only stale-broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
