### PR TITLE
Install the Docker client from Docker's repo instead of Ubuntu's docker.io (-20 critical CVEs)

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -59,7 +59,17 @@ for step in "${steps[@]}"; do
             ;;
         other-CI-tools)
             # Assumes other steps have been run before
-            apt-get install -q -y --no-install-recommends clang-format-$LLVM_VERSION docker.io docker-buildx parallel pip shellcheck
+            _ensure_base_deps
+            # Use Docker's own packages rather than Ubuntu's docker.io: they are
+            # built against a current Go toolchain (Ubuntu's lag, carrying Go
+            # stdlib/x-crypto CVEs), and they install only the client. CI talks to
+            # a remote daemon via setup_remote_docker, so dockerd/containerd/runc
+            # -- which docker.io pulls in -- are never used.
+            wget -qO /etc/apt/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg
+            # shellcheck disable=SC1091  # /etc/os-release is provided by the base image, not this repo
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" >> /etc/apt/sources.list.d/docker.list
+            apt-get update
+            apt-get install -q -y --no-install-recommends clang-format-$LLVM_VERSION docker-ce-cli docker-buildx-plugin parallel pip shellcheck
             # Version from requirements-dev.txt (check repo root, then /tmp for docker builds)
             BLACK_VERSION=$(grep '^black==' requirements-dev.txt /tmp/requirements-dev.txt 2>/dev/null | head -1 | cut -d'=' -f3)
             # --break-system-packages: Ubuntu 24.04+ enforces PEP 668; safe in a throwaway container image


### PR DESCRIPTION
## Summary

`bin/apt-install.sh` installs `docker.io` + `docker-buildx` from Ubuntu. Those packages are built against an older Go toolchain and carry its CVEs — Scout attributes essentially the whole fixable surface of `skiplabs/skip` to them (Go `stdlib` 1C/16H, `golang.org/x/crypto` 7C, plus `x/net`, `grpc`, `containerd`, `buildkit`). `/usr/bin/docker` in the published image is built with `go1.24.4`.

They also drag in **`dockerd`, `containerd` and `runc`** — a daemon stack CI never runs. Jobs reach a *remote* daemon via CircleCI's `setup_remote_docker`, so only the client is ever needed.

This switches to **`docker-ce-cli` + `docker-buildx-plugin`** from `download.docker.com`, using the same `signed-by` apt-repo pattern already used for LLVM, NodeSource and Adoptium.

## Measured impact (Docker Scout, `skiplabs/skip`)

| | published | this change |
|---|---|---|
| critical | 22 | **2** |
| high | 112 | **64** |
| **fixable C/H** | **20C 56H** | **0C 9H** |

**Every fixable critical is eliminated**, and the image loses an unused daemon stack.

Being precise: the *"No fixable critical or high vulnerabilities"* policy does **not** flip to pass — 9 fixable highs remain, none actionable here:
- `containerd` (3H) + `docker/docker` (1H) — Go modules vendored **inside** upstream's own `docker-ce-cli`/`docker-buildx-plugin`
- `setuptools` (2H) + `wheel` (1H) — apt-owned, hard dependencies of `python3-pip`, which `make fmt-py` needs
- `picomatch` (1H) + `sigstore` (1H) — bundled inside npm

## Requirements check

Everything CI does with docker is covered by client + buildx:
- `skipruntime` job (the only `skiplabs/skip` job using docker) → `native_addon_unreleased/run.sh` → `bin/build_runtime.sh` → `docker_build.sh` → **`docker buildx bake`**
- `native_addon/run.sh` → plain `docker build` / `docker run`
- `check-examples` (uses `docker compose`) runs on `cimg/base`, not this image

## Test plan

- [x] Full `skip` image builds cleanly with the new repo
- [x] Installs client only — `docker-ce-cli 29.6.1`, `docker-buildx-plugin 0.35.0`; no `dockerd`/`containerd`/`runc` binaries
- [x] `docker buildx version` works (v0.35.0) — `docker buildx bake` path intact
- [x] Scout delta measured (above)
- [x] `shellcheck --exclude SC2181 --exclude SC2002` clean (matches `Makefile:104`)
- [x] CI green
- [ ] Republish CI images after merge to realize the improvement