### PR TITLE
Attach provenance and SBOM attestations to published images

### DIFF
--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -180,12 +180,26 @@ if [[ -n "$ARCH" ]]; then
     BAKE_ARGS+=(--set "*.platform=$ARCH")
 fi
 
+# Provenance + SBOM attestations, for published images only.
+#
+# These are restricted to push flows on purpose: they require the
+# docker-container driver, which is what the named builder below uses. Local
+# builds go to the docker driver via --load, which rejects them outright
+# ("Attestation is not supported for the docker driver"), so enabling these
+# everywhere would break every local build.
+#
+# mode=max records the build's sources and materials, which is what lets
+# consumers (and Docker Scout) identify the base image rather than guess it.
+# It also records build args, so do not pass secrets as build args -- the ones
+# used here (STAGE, SKIP_CAPACITY) are not sensitive.
+ATTEST_ARGS=(--provenance=mode=max --sbom=true)
+
 # Output mode
 if $PUSH_ONLY; then
     # Push existing layers — no --no-cache so BuildKit finds them in the builder
-    BAKE_ARGS+=(--push)
+    BAKE_ARGS+=(--push "${ATTEST_ARGS[@]}")
 elif $PUSH; then
-    BAKE_ARGS+=(--no-cache)
+    BAKE_ARGS+=(--no-cache "${ATTEST_ARGS[@]}")
     if ! $DRY_RUN; then
         BAKE_ARGS+=(--push)
     fi


### PR DESCRIPTION
## Summary

Docker Scout reports **"Required supply chain attestations missing"** on every `skiplabs/*` image. Worse, without provenance Scout has to *guess* an image's origin — it prints `Base image was auto-detected` and attributes findings to an inferred base rather than the real one. (That guessing is not theoretical: it produces confidently wrong base-image attributions.)

This emits **provenance (`mode=max`)** and **SBOM** attestations, using bake's native `--provenance` / `--sbom` shorthands.

## Scoped to push flows on purpose

Attestations require the **docker-container** driver — which is exactly what the named builder used for `--push`/`--push-only` provides. Local builds export via `--load` on the default **docker** driver, which rejects them outright:

```
ERROR: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store
```

So enabling them unconditionally — e.g. by putting `attest` in `docker-bake.hcl` — **would break every local build**. Gating on push avoids that while still attesting everything we publish.

Verified both directions with `bake --print`:

| path | resolved `attest` |
|---|---|
| push (`--provenance`/`--sbom`) | `[{type: sbom}, {mode: max, type: provenance}]` ✅ |
| local (`--load`) | absent ✅ |

## Other drawbacks considered

- **`mode=max` records build args**, so a secret passed as a build arg would be embedded. The only ones passed here are `STAGE` and `SKIP_CAPACITY`, neither sensitive. A comment records this so it stays true.
- **Attestations add `unknown/unknown` entries to the image index.** Normal `docker pull` ignores them, and nothing in this repo parses manifest lists or iterates platforms, so no tooling is affected.
- **The `skipruntime` target** exports with `--output type=local` (to extract `libskipruntime.so`) and is never pushed, so it's unaffected.
- **Registry support**: Docker Hub supports OCI image indexes with attestation manifests.

## Test plan

- [x] `bake --print` confirms `attest` present on the push path, absent on the local path
- [x] Confirmed the `docker` driver rejects attestations (reproduced the error) — the reason for the gating
- [x] Confirmed the `docker-container` driver produces them: exported an OCI index containing `platform=unknown/unknown  type=attestation-manifest` alongside the image manifest
- [x] `shellcheck --exclude SC2181 --exclude SC2002` clean (matches `Makefile:104`)
- [x] CI green
- [ ] After merge + a republish, confirm Scout's *"Required supply chain attestations missing"* policy passes and `Base image was auto-detected` no longer appears

Relates to #1348 (automating publishing — a GitHub Actions workflow would emit these natively).