### PR TITLE
Stop mutating the tracked .dockerignore during builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ skipwasm-worker
 !skipwasm-worker/*
 .vscode/
 !.vscode/extensions.json
+
+# Generated per-dockerfile build-context exclusions (bin/docker_build.sh).
+# The root .dockerignore is tracked and must stay so.
+*.dockerignore
+!/.dockerignore

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -118,14 +118,6 @@ for img in ${IMAGES[@]+"${IMAGES[@]}"}; do
     fi
 done
 
-# The script appends to .dockerignore and restores it with `git restore`
-# on exit, which would silently discard uncommitted changes to that file.
-if ! git diff --quiet -- .dockerignore || ! git diff --cached --quiet -- .dockerignore; then
-    echo "Error: .dockerignore has uncommitted changes" >&2
-    echo "       (this script modifies it and restores it with git restore)" >&2
-    exit 1
-fi
-
 # --push-only reuses an existing builder and doesn't build, so skip
 # submodule validation.
 if ! $PUSH_ONLY; then
@@ -135,13 +127,63 @@ if ! $PUSH_ONLY; then
          (echo "Submodule $name needs update" && exit 1)'
 fi
 
-# Prepare .dockerignore — always needed for consistent build context
-# (--push-only must send the same context as the dry-run for cache hits)
-git clean -xd --dry-run | sed 's|Would remove |/|g' >> .dockerignore
-echo ".git" >> .dockerignore
+# Prepare the build context exclusions.
+#
+# The context must exclude everything git would clean (node_modules, target/,
+# build/, ...), or every build ships hundreds of MB of local artifacts. This
+# used to be done by appending to the tracked .dockerignore and restoring it
+# with `git restore` on exit, which meant a killed build (SIGKILL, OOM, a
+# stopped container -- none of which run the trap) left the file dirty and
+# every later run refusing to start.
+#
+# Instead, generate untracked sibling files. BuildKit reads
+# "<dockerfile>.dockerignore" *instead of* the root .dockerignore -- it is a
+# precedence, not a merge -- and resolves it per bake target, so each target
+# gets its own copy. Patterns are relative to the context root even when the
+# file lives in a subdirectory, so one root-relative body works for all of
+# them. The tracked file is never touched: nothing to restore, nothing to
+# repair, and a local edit to .dockerignore no longer blocks builds.
+#
+# '**/*.dockerignore' excludes the generated files from the context, and they
+# are filtered out of the body below (git clean lists them once they exist) so
+# that the body is identical on every run -- which is what keeps --push-only
+# hitting the cache from an earlier --dry-run.
+ignore_body=$(
+    cat .dockerignore
+    printf '%s\n' '**/*.dockerignore' '.git'
+    # sed -n '...p' (not grep) so a pristine tree, which prints nothing here,
+    # does not fail the pipeline under `set -o pipefail`.
+    git clean -xd --dry-run | sed -n 's|^Would remove |/|p' | sed '/\.dockerignore$/d'
+)
 
-# Clean up on exit: restore .dockerignore and tear down the buildx builder
-# when appropriate.
+# Ask bake which dockerfiles exist rather than hardcoding them. --print does
+# not need a working daemon. stderr is left attached so an HCL error is
+# visible instead of being swallowed.
+mapfile -t DOCKERFILES < <(
+    docker buildx bake -f docker-bake.hcl --print "${KNOWN_IMAGES[@]}" \
+        | grep -oP '"dockerfile":\s*"\K[^"]+' | sort -u
+)
+if [[ ${#DOCKERFILES[@]} -eq 0 ]]; then
+    echo "Error: could not enumerate dockerfiles from 'docker buildx bake --print'" >&2
+    exit 1
+fi
+# The optional per-user image below is built directly, not through bake.
+if [[ -f "${USER:-}/Dockerfile" ]]; then
+    DOCKERFILES+=("${USER:-}/Dockerfile")
+fi
+
+for df in "${DOCKERFILES[@]}"; do
+    printf '%s\n' "$ignore_body" > "$df.dockerignore.$$.tmp"
+    mv -f "$df.dockerignore.$$.tmp" "$df.dockerignore"
+done
+
+# Clean up on exit: tear down the buildx builder when appropriate.
+#
+# The generated *.dockerignore files are deliberately left in place. Removing
+# them would race a concurrent build that has generated but not yet read them,
+# and several targets `COPY . /skdb`, so a missing exclusion file bakes local
+# artifacts into the image rather than merely slowing the build. They are
+# gitignored and rewritten on every run.
 NAMED_BUILDER="skip-builder"
 BUILDX_BUILDER=""
 cleanup() {
@@ -149,7 +191,8 @@ cleanup() {
         docker buildx stop "$BUILDX_BUILDER"
         docker buildx rm "$BUILDX_BUILDER"
     fi
-    git restore .dockerignore
+    # Only this process's temp files; concurrent builds own theirs.
+    find . -name "*.dockerignore.$$.tmp" -delete 2>/dev/null || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Problem

`docker_build.sh` keeps the build context small by appending everything `git clean -xd` would remove to the **tracked** `.dockerignore`, then restoring it with `git restore` from an `EXIT` trap.

`SIGKILL`, an OOM kill, and a stopped container never run that trap. An interrupted build therefore leaves the tracked file dirty with ~1900 generated lines, and **every later run refuses to start**:

```
Error: .dockerignore has uncommitted changes
```

The same design also makes two concurrent builds unsafe (both clobber one file), and blocks any developer holding a legitimate local edit to `.dockerignore`.

## Approach

Stop touching the tracked file. Generate **untracked sibling** files instead.

BuildKit reads `<dockerfile>.dockerignore` *instead of* the root `.dockerignore` — a **precedence, not a merge** — resolved per bake target. Patterns in it are relative to the **context root** even when the file lives in a subdirectory, so one root-relative body serves every target.

Since the tracked file is never written, a killed build leaves nothing to repair and the guard disappears entirely — the failure modes stop existing rather than being made survivable.

Details worth flagging for review:
- The dockerfile list comes from `bake --print` rather than being hardcoded, and additionally covers the per-user image built outside bake.
- The body filters out `*.dockerignore` so the generated files never feed back into their own inputs (`git clean` lists them once they exist). That is what keeps the body **byte-identical across runs**, which is what lets `--push-only` still hit the cache from an earlier `--dry-run`.
- The body is built with `sed -n '…p'`, not `grep`: `grep` exits 1 when a pristine tree has nothing to list, which would kill the script under `set -o pipefail`.
- Generated files are **deliberately left in place** on exit. Deleting them would race a concurrent build that has generated but not yet read them — and several targets `COPY . /skdb`, so a missing exclusion file bakes local artifacts *into the image* rather than merely slowing the build. They are gitignored and rewritten every run.
- No `--ignore-file` / `--dockerignore` flag or `BUILDKIT_*` variable exists for this; the sibling-file precedence is the supported mechanism.

## Test plan

Verified in a throwaway clone (never against a live checkout):

- [x] **SIGKILL mid-build → tracked `.dockerignore` stays clean.** `timeout -s KILL` gives exit 137 (trap never runs); file clean, nothing to repair. The old code leaves it dirty.
- [x] **Recovery** — a subsequent run starts normally; previously it refused with `has uncommitted changes`.
- [x] **`--push-only` cache parity** — `sql/Dockerfile.dockerignore` byte-identical across two runs (`cmp`), including when the generated files already exist on disk.
- [x] **Exclusions actually apply** — busybox probe through the real `COPY . /skdb`: **7288** files in context with the sibling file vs **13081** with only the root `.dockerignore`.
- [x] All 6 bake dockerfiles get a sibling; `git status` stays clean (gitignored via `*.dockerignore` + `!/.dockerignore`, so the tracked root file remains tracked).
- [x] `shellcheck --exclude SC2181 --exclude SC2002` clean (matches `Makefile:104`).
- [x] CI green

## Known limitations

- Parity still breaks if the tree changes between `--dry-run` and `--push-only` — true of the current code too.
- Precedence-not-merge is a footgun: an empty generated file would silently balloon the context rather than fail loudly.
- First run after merge cache-misses the `COPY .` layers, since `**/*.dockerignore` newly excludes `.dockerignore` itself from the context.