### PR TITLE
stdlib: give OS-facing native decls an untracked type instead of @debug

### DIFF
--- a/skiplang/prelude/src/stdlib/filesystem/FileSystem.sk
+++ b/skiplang/prelude/src/stdlib/filesystem/FileSystem.sk
@@ -8,10 +8,10 @@
 // Module for manipulating the Files and Directories.
 
 // TODO: What module should this go in?
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_getcwd")
 @may_alloc
-native fun getcwd(): String;
+untracked native fun getcwd(): String;
 
 base class FileKind uses Orderable {
   children =
@@ -67,19 +67,19 @@ fun writeTextFile(filename: String, contents: String): void {
   string_to_file(contents, filename);
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_get_mtime")
-native fun getLastModificationTime(fileName: String): Int;
+untracked native fun getLastModificationTime(fileName: String): Int;
 
-@debug
+@allow_tracked_call
 @synonym("appendFile")
 @synonym("appendFileSync")
 @cpp_extern
-native fun appendTextFile(filename: String, contents: String): void;
+untracked native fun appendTextFile(filename: String, contents: String): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_check_if_file_exists")
-native fun exists(filename: String): Bool;
+untracked native fun exists(filename: String): Bool;
 
 fun isDirectory(filename: String): Bool {
   is_directory(filename);
@@ -152,38 +152,41 @@ fun stat(path: String): ?FileStat {
   if (rc < 0) None() else Some(unsafe_chill_trust_me(result))
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_file_stat")
-private native fun fillStat(result: mutable FileStat, path: String): Int;
+private untracked native fun fillStat(
+  result: mutable FileStat,
+  path: String,
+): Int;
 
 // TODO: Rename the C++ entrypoints and merge these into the
 // public API above.
-@debug
+@allow_tracked_call
 @cpp_extern
-private native fun .open_file(String): String;
+private untracked native fun .open_file(String): String;
 
-@debug
+@allow_tracked_call
 @cpp_extern
-private native fun .string_to_file(s: String, file: String): void;
+private untracked native fun .string_to_file(s: String, file: String): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_is_directory")
-private native fun is_directory(filename: String): Bool;
+private untracked native fun is_directory(filename: String): Bool;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_opendir")
-private native fun opendir(dirname: String): Int;
+private untracked native fun opendir(dirname: String): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_readdir")
-private native fun readdir(dirhandle: Int): String;
+private untracked native fun readdir(dirhandle: Int): String;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_closedir")
-private native fun closedir(dirhandle: Int): void;
+private untracked native fun closedir(dirhandle: Int): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_realpath")
-native fun realpath(path: String): String;
+untracked native fun realpath(path: String): String;
 
 module end;

--- a/skiplang/prelude/src/stdlib/other/Environ.sk
+++ b/skiplang/prelude/src/stdlib/other/Environ.sk
@@ -40,17 +40,17 @@ fun current_exe(): String {
   invariant_violation("Could not determine main executable.")
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_getcwd")
-native fun current_dir(): String;
+untracked native fun current_dir(): String;
 
 fun temp_dir(): String {
   varOpt("TMPDIR").default("/tmp")
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_chdir")
-native fun set_current_dir(path: String): void;
+untracked native fun set_current_dir(path: String): void;
 
 @cpp_extern("SKIP_getArgc")
 native fun internalGetArgc(): Int;
@@ -65,13 +65,13 @@ fun args(): mutable Iterator<String> {
   }
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_get_envc")
-native fun internalGetEnvc(): Int;
+untracked native fun internalGetEnvc(): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_get_envN")
-native fun internalGetEnvN(n: Int): String;
+untracked native fun internalGetEnvN(n: Int): String;
 
 fun vars(): mutable Iterator<(String, String)> {
   envc = internalGetEnvc();
@@ -90,9 +90,9 @@ fun internalCreateNoneStringOption(): ?String {
   None()
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_getenv")
-native fun varOpt(name: String): ?String;
+untracked native fun varOpt(name: String): ?String;
 
 class VarError(name: String) extends Exception {
   fun getMessage(): String {
@@ -107,12 +107,12 @@ fun var(name: String): String {
   }
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_setenv")
-native fun set_var(name: String, value: String): void;
+untracked native fun set_var(name: String, value: String): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_unsetenv")
-native fun remove_var(name: String): void;
+untracked native fun remove_var(name: String): void;
 
 module end;

--- a/skiplang/prelude/src/stdlib/other/Posix.sk
+++ b/skiplang/prelude/src/stdlib/other/Posix.sk
@@ -1,44 +1,52 @@
 module Posix;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_open")
-native fun internalOpen(path: String, oflag: Int, mode: Int): Int;
+untracked native fun internalOpen(path: String, oflag: Int, mode: Int): Int;
 
 fun open(path: String, oflag: Int, mode: Int = 0): Int {
   internalOpen(path, oflag, mode)
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_close")
-native fun close(fd: Int): void;
+untracked native fun close(fd: Int): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_write")
-native fun write(fd: Int, buf: readonly Unsafe.Ptr<UInt8>, len: Int): Int;
+untracked native fun write(
+  fd: Int,
+  buf: readonly Unsafe.Ptr<UInt8>,
+  len: Int,
+): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_read")
-native fun read(fd: Int, buf: mutable Unsafe.Ptr<UInt8>, len: Int): Int;
+untracked native fun read(
+  fd: Int,
+  buf: mutable Unsafe.Ptr<UInt8>,
+  len: Int,
+): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_lseek")
-native fun internalLseek(fd: Int, offset: Int, whence: Int): Int;
+untracked native fun internalLseek(fd: Int, offset: Int, whence: Int): Int;
 
 fun lseek(fd: Int, offset: Int, whence: SeekWhence): Int {
   internalLseek(fd, offset, whence.toInt())
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_pipe")
-native fun pipe(): Pipe;
+untracked native fun pipe(): Pipe;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_dup")
-native fun dup(fd: Int): Int;
+untracked native fun dup(fd: Int): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_dup2")
-native fun dup2(oldfd: Int, newfd: Int): void;
+untracked native fun dup2(oldfd: Int, newfd: Int): void;
 
 @cpp_extern("SKIP_posix_open_flags")
 native fun open_flags(
@@ -63,37 +71,37 @@ native fun wtermsig(stat_loc: Int): Int;
 @cpp_extern("SKIP_posix_wstopsig")
 native fun wstopsig(stat_loc: Int): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_kill")
-native fun kill(pid: Int, sig: Int): void;
+untracked native fun kill(pid: Int, sig: Int): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_waitpid")
-native fun waitpid(pid: Int, nohang: Bool = false): Int;
+untracked native fun waitpid(pid: Int, nohang: Bool = false): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_execvp")
-native fun internalExecvp(args: Array<String>): void;
+untracked native fun internalExecvp(args: Array<String>): void;
 
 fun execvp<T>(args: Array<String>): T {
   internalExecvp(args);
   invariant_violation("unreachable")
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_poll")
-native fun poll(pollfds: mutable Array<mutable Pollfd>): Int;
+untracked native fun poll(pollfds: mutable Array<mutable Pollfd>): Int;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_isatty")
-native fun internalIsatty(fd: Int): Int;
+untracked native fun internalIsatty(fd: Int): Int;
 fun isatty(fd: Int): Bool {
   internalIsatty(fd) != 0
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_mkstemp")
-native fun internalMkstemp(template: String): Int;
+untracked native fun internalMkstemp(template: String): Int;
 
 fun mkstemp(template: String): mutable IO.File {
   // TODO: Properly set filename.
@@ -449,9 +457,9 @@ mutable native class SpawnFileActions {
   mutable native fun close(fd: Int): void;
 }
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_posix_spawnp")
-native fun internalSpawnp(
+untracked native fun internalSpawnp(
   argv: Array<String>,
   env: Array<String>,
   file_actions: readonly SpawnFileActions,

--- a/skiplang/prelude/src/stdlib/other/Random.sk
+++ b/skiplang/prelude/src/stdlib/other/Random.sk
@@ -13,8 +13,8 @@ private native fun init(): void;
 const _unit: void = init();
 
 @cpp_extern("SKIP_random_next")
-@debug
-native fun next(): Int;
+@allow_tracked_call
+untracked native fun next(): Int;
 
 // Default RNG using the Xoroshiro128plus algorithm. This is a robust RNG with
 // 128 bits of state. Note that low bits have less entropy than higher bits:

--- a/skiplang/prelude/src/stdlib/other/System.sk
+++ b/skiplang/prelude/src/stdlib/other/System.sk
@@ -173,24 +173,24 @@ native fun getMemoryFrameUsage(): Int;
 
 module end;
 
-@debug
+@allow_tracked_call
 @cpp_extern
 @may_alloc
-native fun read_line(): ?String;
+untracked native fun read_line(): ?String;
 
-@debug
+@allow_tracked_call
 @cpp_extern
 @may_alloc
-native fun read_to_end(): String;
+untracked native fun read_to_end(): String;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_flush_stdout")
-native fun flushStdout(): void;
+untracked native fun flushStdout(): void;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_system")
 @may_alloc
-native fun system(cmd: String): Int;
+untracked native fun system(cmd: String): Int;
 
 module System;
 

--- a/skiplang/prelude/src/stdlib/other/Time.sk
+++ b/skiplang/prelude/src/stdlib/other/Time.sk
@@ -1,25 +1,25 @@
 module Time;
 
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_time")
-native fun time(): Int;
+untracked native fun time(): Int;
 
 // Current time expressed as the number of milliseconds since
 // 1970-01-01T00:00:00.000Z, the beginning of the Unix epoch.
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_time_ms")
-native fun time_ms(): Int;
+untracked native fun time_ms(): Int;
 
 // Current time in nanoseconds from a monotonic clock (steady_clock).
 // Suitable for measuring elapsed time, not wall-clock time.
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_time_ns")
-native fun time_ns(): Int;
+untracked native fun time_ns(): Int;
 
 // Sleep for the given number of milliseconds.
-@debug
+@allow_tracked_call
 @cpp_extern("SKIP_sleep_ms")
-native fun sleep_ms(ms: Int): void;
+untracked native fun sleep_ms(ms: Int): void;
 
 @cpp_extern("SKIP_strftime")
 native fun strftime(format: String, timestamp: Int): String;


### PR DESCRIPTION
**Stacked on #1352** (the bootstrap bump) — that base is required, since the bootstrap had to learn `@allow_tracked_call` before the prelude could use it. Retarget to `main` once #1352 lands.

Converts 43 OS-facing native declarations from `@debug` to `untracked` + `@allow_tracked_call`.

## Why

#1337 used `@debug` to stop the optimizer merging two identical calls to a side-effecting function. That fixed a real miscompilation, but `@debug` is the wrong marker for these, by the compiler's own account. From `peephole.sk`:

> ... to allow users to help "debug-by-print" to see what their code is doing **without the heavyweight transitive implications of "important" side effects like writing to an external database**.

Filesystem, posix, process, env, clock and RNG access *are* the important side effects that comment contrasts itself against. `@debug` was doing the job only because it happens to block CSE.

`untracked` states the truth in the declaration's **type**, and `@allow_tracked_call` keeps the existing tracked callers compiling. Codegen is unchanged: the back end reads the raw `untracked` keyword and deliberately ignores the annotation (`OuterIstToIR.sk:2392` — "the optimizer must keep treating it as untracked (e.g. no CSE), like `@debug`"), so `funCanCSE` stays false exactly as before.

## What this buys

- The declaration says what it means. `@debug` on `system()` reads as a lie.
- Every knowing escape is greppable: `@allow_tracked_call`.
- A far better migration path. Doing this properly later means deleting the annotation and making callers `untracked` one at a time — instead of a `@debug`→`untracked` rewrite from scratch.

**What it does not buy: transitivity.** A tracked wrapper around one of these is still CSE-able — the same hole `@debug` has. Only bare `untracked` closes that, and it cascades through the whole I/O stack up to user `main()`. That remains future work.

## Deliberately not converted

The print helpers keep `@debug`: `print_raw`, `print_error`, `print_debug`, `print_stack_trace`, plus `exit`, `localGC`, `getMemoryFrameUsage`. Debug-by-print is precisely what the annotation was designed for; converting them would apply the mechanical change against the reasoning behind it.

Pure natives stay unannotated, so CSE keeps working where it is valid: `Posix.open_flags` and the `wif*`/`wexitstatus` decoders, `Time.strftime`, and `Environ.internalGetArgc`/`internalGetArgN` (argv is fixed at startup — unlike the environment, which is why `varOpt` *is* converted).

## Verification

Built and run against the new bootstrap's stage0:

- a plain **tracked** function calling `FileSystem.exists` compiles and runs — **no cascade**, so `@allow_tracked_call` holds through the conversion;
- `Time.time_ns()` twice → distinct, `Random.next()` twice → distinct — **no CSE**, the property `@debug` was providing is preserved.

Six per-module commits, each independently reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Opus 4.8 (1M context)