### PR TITLE
Automate CI image publishing from GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 Dockerfile
 docker-bake.hcl
+.git
 **/target/
 node_modules/
 /skiplang/prelude/runtime/*.bc

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install and run actionlint
         shell: bash
         run: |
+          # The version argument is required: the tag in the URL only selects
+          # the downloader script, which otherwise installs its own hardcoded
+          # default version rather than the one requested here.
           bash <(curl --proto '=https' --tlsv1.2 -sSf \
-            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash)
+            https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
           ./actionlint -color

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,235 @@
+name: docker-publish
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.circleci/**'
+      - 'docker-bake.hcl'
+      - 'bin/check_ci_images.sh'
+      - '.github/workflows/docker-publish.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'skiplang/Dockerfile'
+      - 'sql/Dockerfile'
+      - 'bin/apt-install.sh'
+      - 'docker-bake.hcl'
+      - 'requirements-dev.txt'
+      - '.github/workflows/docker-publish.yml'
+  schedule:
+    # Weekly, so base image security updates land without anyone remembering.
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-publish
+  # Publishing is not latency sensitive, and cancelling midway through the merge
+  # would leave some images' :latest updated and others not.
+  cancel-in-progress: false
+
+env:
+  # setup-buildx-action's version input has no default, so without this we get
+  # whatever buildx the runner image happens to ship. `imagetools create`
+  # silently dropped attestations before v0.30.0, which is a failure we would
+  # only notice by auditing the registry.
+  BUILDX_VERSION: v0.35.0
+
+jobs:
+  check-images:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v4
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+      - name: Check every image CircleCI pulls is published
+        shell: bash
+        run: ./bin/check_ci_images.sh
+
+  build:
+    needs: [check-images]
+    # Fork PRs get no secrets, so they would only fail; forks get no schedule.
+    if: github.repository == 'SkipLabs/skip' && github.event_name != 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The compiler is built from source in the image, and its Makefile
+          # needs the pinned bootstrap and libbacktrace submodules.
+          submodules: true
+      - uses: docker/setup-buildx-action@v4
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Resolve images to publish
+        id: images
+        shell: bash
+        run: |
+          # Each runner pushes by digest, which needs a name with no tag, so
+          # replace each target's `skiplabs/foo:latest` with a bare repository.
+          # Derived from the bake "ci" group rather than listed here, so this
+          # workflow cannot disagree with docker-bake.hcl about what we publish.
+          {
+            echo 'set<<SETEOF'
+            docker buildx bake -f docker-bake.hcl --print ci |
+              jq -r '.group.ci.targets[] as $t
+                     | .target[$t].tags[0]
+                     | sub(":.*$"; "")
+                     | "\($t).tags=docker.io/\(.)"'
+            echo 'SETEOF'
+          } >> "$GITHUB_OUTPUT"
+          count=$(docker buildx bake -f docker-bake.hcl --print ci |
+            jq '.group.ci.targets | length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+      - name: Show disk space before build
+        shell: bash
+        run: df -h /
+      - name: Build and push by digest
+        id: bake
+        uses: docker/bake-action@v7
+        with:
+          # v6+ defaults to the git context, which would pick up neither the
+          # submodules checked out above nor .dockerignore.
+          source: .
+          files: ./docker-bake.hcl
+          targets: ci
+          # No cache backend is configured, so every layer is rebuilt; pull
+          # re-resolves the FROM refs, which is what makes a scheduled run
+          # actually pick up base image updates.
+          pull: true
+          # Matches bin/docker_build.sh, so images published either way carry
+          # the same attestations. mode=max records build args: do not pass
+          # secrets as build args.
+          provenance: mode=max
+          sbom: true
+          set: |
+            *.platform=${{ matrix.platform }}
+            *.output=type=image,push-by-digest=true,name-canonical=true,push=true
+            ${{ steps.images.outputs.set }}
+      - name: Collect pushed digests
+        shell: bash
+        env:
+          METADATA: ${{ steps.bake.outputs.metadata }}
+          EXPECTED: ${{ steps.images.outputs.count }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p /tmp/meta
+          # Two things in the metadata are not pushed images and must not be
+          # counted as such: buildx.build.warnings, which is not an object, and
+          # targets reached only as a named context dependency, which carry a
+          # build ref but no digest.
+          jq '[to_entries[]
+               | select(.value | type == "object"
+                        and has("containerimage.digest"))
+               | {image: .value["image.name"],
+                  digest: .value["containerimage.digest"]}]' \
+            <<< "$METADATA" > "/tmp/meta/$ARCH.json"
+          cat "/tmp/meta/$ARCH.json"
+          count=$(jq 'length' "/tmp/meta/$ARCH.json")
+          if [[ "$count" -ne "$EXPECTED" ]]; then
+            echo "::error::pushed $count image(s), expected $EXPECTED"
+            exit 1
+          fi
+      - name: Show disk space after build
+        if: always()
+        shell: bash
+        run: df -h /
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metadata-${{ matrix.arch }}
+          path: /tmp/meta/${{ matrix.arch }}.json
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    # Redundant with needs (build is guarded and a skipped need skips this job),
+    # but explicit so no future edit to build's guard can leak a publish here.
+    if: github.repository == 'SkipLabs/skip'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/meta
+          pattern: metadata-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+        with:
+          # Load bearing here, not just in build: imagetools create runs from
+          # the CLI plugin this installs, and it is what preserves or drops the
+          # per-platform attestations.
+          version: ${{ env.BUILDX_VERSION }}
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create multi-arch tags
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(/tmp/meta/*.json)
+          platforms=${#files[@]}
+          if [[ "$platforms" -eq 0 ]]; then
+            echo "::error::no build metadata found"
+            exit 1
+          fi
+          jq -s 'add | group_by(.image)
+                 | map({image: .[0].image, digests: map(.digest)})' \
+            "${files[@]}" > /tmp/images.json
+          cat /tmp/images.json
+          # Check every image before publishing any of them. Interleaving the
+          # two would let an image that sorts early get its :latest updated
+          # before a later one fails, which is the split-state this is meant to
+          # prevent. Nothing has touched a :latest tag yet.
+          while IFS=$'\t' read -r image digests; do
+            read -r -a refs <<< "$digests"
+            if [[ "${#refs[@]}" -ne "$platforms" ]]; then
+              echo "::error::$image has ${#refs[@]} digest(s), expected $platforms"
+              exit 1
+            fi
+          done < <(jq -r '.[] | "\(.image)\t\(.digests | join(" "))"' /tmp/images.json)
+          while IFS=$'\t' read -r image digests; do
+            read -r -a refs <<< "$digests"
+            args=()
+            for d in "${refs[@]}"; do
+              args+=("$image@$d")
+            done
+            docker buildx imagetools create -t "$image:latest" "${args[@]}"
+          done < <(jq -r '.[] | "\(.image)\t\(.digests | join(" "))"' /tmp/images.json)
+      - name: Check attestations survived the merge
+        shell: bash
+        run: |
+          # Losing attestations in the merge is silent: the image still works,
+          # it just has no provenance. Each platform contributes its image
+          # manifest plus an attestation manifest, so assert both are there.
+          platforms=$(jq -r '.[0].digests | length' /tmp/images.json)
+          expected=$((platforms * 2))
+          while read -r image; do
+            raw=$(docker buildx imagetools inspect "$image:latest" --raw)
+            total=$(jq '.manifests | length' <<< "$raw")
+            attested=$(jq '[.manifests[]
+                            | select(.annotations["vnd.docker.reference.type"]
+                                     == "attestation-manifest")] | length' <<< "$raw")
+            echo "$image: $total manifest(s), $attested attestation(s)"
+            if [[ "$total" -ne "$expected" || "$attested" -ne "$platforms" ]]; then
+              echo "::error::$image: expected $expected manifests and $platforms attestations"
+              exit 1
+            fi
+          done < <(jq -r '.[].image' /tmp/images.json)

--- a/bin/README.md
+++ b/bin/README.md
@@ -21,9 +21,29 @@ Convenience wrappers are provided for common workflows:
 
 - `build_docker_images.sh` — local build of all images
 - `build_prod_skdb_images.sh` — local production build (`--prod`)
-- `release_docker_ci_images.sh` — push CI images to Docker Hub
+- `release_docker_ci_images.sh` — push the published images to Docker Hub by hand
 - `release_docker_skdb.sh` — push skdb image
 - `release_docker_skdb_dev_server.sh` — interactive push of dev server
+- `check_ci_images.sh` — check that every image CircleCI pulls is one we publish
+
+## Publish the CI images
+
+The images in the `ci` group of `docker-bake.hcl` are published to Docker Hub
+automatically by `.github/workflows/docker-publish.yml`, on demand, on merges to
+`main` that touch the files the images are built from, and weekly so base image
+security updates land without anyone remembering.
+
+That group is the single source of truth: the workflow and
+`release_docker_ci_images.sh` both take their image list from it, and
+`check_ci_images.sh` asserts every image CircleCI pulls is in it. It holds
+toolchain images only — their final stages contain compiled binaries and apt
+packages but no repo source, so republishing them is not a release.
+
+`skdb` and `skdb-dev-server` are not in that group and stay manual: they bake in
+source and their tags carry release semantics.
+
+Use `release_docker_ci_images.sh` only when the workflow is unavailable. It
+publishes the same images from your machine, using your own credentials.
 
 ## Release NPM packages
 

--- a/bin/check_ci_images.sh
+++ b/bin/check_ci_images.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Assert that every skiplabs/ image CircleCI pulls is published by the "ci"
+# group in docker-bake.hcl.
+#
+# The relation is a subset, not equality: skiplang-bin-builder is published but
+# never pulled by CI. What must not happen is the other direction -- a CI job
+# pulling an image nothing publishes.
+#
+# Compares image names rather than bake target names, so it stays correct if a
+# target is ever named differently from the image it produces.
+#
+# Usage: check_ci_images.sh
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO="$SCRIPT_DIR/.."
+
+mapfile -t pulled < <(
+    grep -ohP 'image:\s+skiplabs/\K[^:\s]+' "$REPO"/.circleci/*.yml | sort -u
+)
+if [[ ${#pulled[@]} -eq 0 ]]; then
+    echo "Error: no skiplabs/ images found in .circleci/*.yml" >&2
+    exit 1
+fi
+
+mapfile -t published < <(
+    docker buildx bake -f "$REPO/docker-bake.hcl" --print ci |
+        jq -r '.group.ci.targets[] as $t | .target[$t].tags[]' |
+        sed 's|.*/||; s|:.*||' | sort -u
+)
+if [[ ${#published[@]} -eq 0 ]]; then
+    echo 'Error: bake group "ci" publishes no images' >&2
+    exit 1
+fi
+
+missing=$(comm -23 <(printf '%s\n' "${pulled[@]}") <(printf '%s\n' "${published[@]}"))
+if [[ -n "$missing" ]]; then
+    echo "Error: pulled by CircleCI but not published by bake group \"ci\":" >&2
+    echo "$missing" | sed 's/^/  skiplabs\//' >&2
+    echo "Add it to the \"ci\" group in docker-bake.hcl, or CI will pull an" >&2
+    echo "image that nothing keeps up to date." >&2
+    exit 1
+fi
+
+echo "OK: ${#pulled[@]} image(s) pulled by CircleCI, all published by bake group \"ci\""

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -144,13 +144,17 @@ fi
 # them. The tracked file is never touched: nothing to restore, nothing to
 # repair, and a local edit to .dockerignore no longer blocks builds.
 #
+# The tracked .dockerignore is cat'd in first, so its static exclusions
+# (including .git) apply here just as they do for builds that bypass this
+# script and read it directly.
+#
 # '**/*.dockerignore' excludes the generated files from the context, and they
 # are filtered out of the body below (git clean lists them once they exist) so
 # that the body is identical on every run -- which is what keeps --push-only
 # hitting the cache from an earlier --dry-run.
 ignore_body=$(
     cat .dockerignore
-    printf '%s\n' '**/*.dockerignore' '.git'
+    printf '%s\n' '**/*.dockerignore'
     # sed -n '...p' (not grep) so a pristine tree, which prints nothing here,
     # does not fail the pipeline under `set -o pipefail`.
     git clean -xd --dry-run | sed -n 's|^Would remove |/|p' | sed '/\.dockerignore$/d'

--- a/bin/release_docker_ci_images.sh
+++ b/bin/release_docker_ci_images.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-# Build and push Docker images used in CI.
-# Image names are extracted from .circleci/base.yml so the two stay in sync.
+# Build and push the Docker images we publish, taken from the "ci" group in
+# docker-bake.hcl.
+#
+# .github/workflows/docker-publish.yml publishes the same group automatically,
+# and is the normal path. This is the manual escape hatch, for when the workflow
+# is broken or unavailable.
+#
 # Defaults to amd64,arm64 (matching release_docker.sh); use --arch to
 # override (e.g. --arch amd64).
 # Usage: release_docker_ci_images.sh [--dry-run] [--arch PLATFORMS]
@@ -13,13 +18,15 @@ REPO="$SCRIPT_DIR/.."
 
 export DOCKER_DEFAULT_ARCH="${DOCKER_DEFAULT_ARCH:-amd64,arm64}"
 
-# Extract unique skiplabs/ image names from CI config
+"$SCRIPT_DIR"/check_ci_images.sh
+
 mapfile -t images < <(
-    grep -oP 'image:\s+skiplabs/\K[^:\s]+' "$REPO/.circleci/base.yml" | sort -u
+    docker buildx bake -f "$REPO/docker-bake.hcl" --print ci |
+        jq -r '.group.ci.targets[]' | sort -u
 )
 
 if [[ ${#images[@]} -eq 0 ]]; then
-    echo "Error: no skiplabs/ images found in .circleci/base.yml" >&2
+    echo 'Error: bake group "ci" is empty' >&2
     exit 1
 fi
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,6 +20,26 @@ group "default" {
   ]
 }
 
+# The set of images published to Docker Hub, and the single source of truth for
+# what both bin/release_docker_ci_images.sh and .github/workflows/docker-publish.yml
+# publish. bin/check_ci_images.sh asserts that every skiplabs/ image CircleCI
+# pulls appears here.
+#
+# Toolchain images only. Their final stages contain compiled binaries and apt
+# packages but no repo source, so any commit on main can rebuild them and
+# republishing is not a release. skdb and skdb-dev-server are deliberately
+# absent: they bake in source and their tags carry release semantics, so they
+# stay manual.
+#
+# skiplang-bin-builder is published but never pulled by CI, which is why this
+# list cannot be derived from .circleci/ -- and why it went a year without a
+# rebuild (#1338).
+group "ci" {
+  targets = [
+    "skiplang", "skiplang-bin-builder", "skip", "skdb-base",
+  ]
+}
+
 group "local" {
   targets = [
     "skiplang", "skiplang-bin-builder", "skip",


### PR DESCRIPTION
Closes #1348.

## Problem

The `skiplabs/*` images CI runs on were published by a maintainer running `bin/release_docker_ci_images.sh` locally, with their own Docker Hub credentials. Nothing else ever rebuilt them, and it shows:

- `skiplang-bin-builder` sat ~a year stale carrying **3 critical / 68 high** CVEs (#1338), because the only thing that ever published it was a human remembering to.
- `skdb-base` silently stopped building after the Ubuntu 24.04 bump and no one noticed until a manual rebuild happened to surface it (#1290) — CI runs *against* the published images, so it structurally cannot catch this.
- `skiplang:latest` and `skip:latest` on Docker Hub are currently a week apart despite being stages of the *same* Dockerfile, so CI jobs run against inconsistent compiler builds.

## What this does

Builds and pushes the images from GitHub Actions instead, on three triggers:

- **`workflow_dispatch`** — on demand
- **`push` to `main`**, path-filtered to the files the images are built from — this is what fixes the #1338 class of rot (pin bumped, republish forgotten)
- **weekly `schedule`** — picks up base-image security updates, since with no layer cache every run re-resolves `FROM` and re-runs `apt`

### Scope: four toolchain images

Publishes the new **`ci` group** in `docker-bake.hcl`: `skiplang`, `skiplang-bin-builder`, `skip`, `skdb-base`. These are toolchain images — their final stages hold compiled binaries and apt packages but no repo source, so any green `main` commit can rebuild them and republishing is not a release.

`skdb` and `skdb-dev-server` are deliberately excluded: they bake in source and their tags carry release semantics. (`skiplabs/skdb` has in fact never existed on Docker Hub, despite being in bake's `default` group.)

### Source of truth

The `ci` group is authoritative. The workflow derives its per-image tag overrides from `bake --print ci` at runtime rather than listing them, `release_docker_ci_images.sh` now takes its list from the same group (so the manual path and the automated one can't drift, and a manual publish finally includes `skiplang-bin-builder`), and a new `bin/check_ci_images.sh` asserts every image CircleCI pulls is in the group — replacing the old `grep .circleci/base.yml` derivation, which structurally could not express `skiplang-bin-builder`.

### Runner strategy

Native `ubuntu-24.04` + `ubuntu-24.04-arm` in parallel (arm64 hosted runners are free on public repos), each pushing by digest, then a merge job creates the multi-arch tags. QEMU was rejected: ~4× slower and it would emulate a self-hosting compiler bootstrap. **Nothing rewrites a `:latest` tag until every platform of every image has pushed successfully**, and the merge validates all images before publishing any.

Provenance (`mode=max`) + SBOM attestations are emitted via bake-action's `provenance`/`sbom` inputs, matching what `bin/docker_build.sh` already does for the manual path (#1350), so images published either way carry the same attestations.

## Verification

The parts that can't be exercised without pushing were verified locally against a registry on buildx v0.35.0:

- a target that is both published **and** consumed as a named context (`skdb-base` builds `FROM skip`) keeps its own push-by-digest output — settled at solve time, not just `bake --print`;
- each per-platform push is an OCI index carrying its attestation manifest inline;
- `imagetools create` preserves **both** platforms' attestations into the merged tag (verified: merged index = 2 platform manifests + 2 attestation manifests).

`actionlint` (1.7.7) and `shellcheck` are clean on everything here.

## Notes for the reviewer

- **Requires org secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`** (scoped push token) before the first run — the repo has none today. The first run should be a watched `workflow_dispatch`, not the weekly schedule.
- **Stacked on the actionlint fix** (first commit): CI currently installs actionlint **1.7.6** — the `v1.7.7` in the URL only selects the downloader script, which defaults to 1.7.6 — and 1.7.6 rejects `runs-on: ubuntu-24.04-arm`. That commit stands on its own but this workflow needs it to lint.
- **Conscious tradeoff:** the workflow does not run CI against the freshly built images before overwriting `:latest`. That would roughly double the pipeline; the digest/attestation guards catch push-level failures but not "builds fine, breaks CI". `cancel-in-progress: false` and a watched first run are the mitigations.
- Actions are pinned to major tags (`@v4`/`@v7`), matching repo convention (no dependabot). SHA-pinning would harden this first credential-holding workflow but the actions would then never update — happy to switch if preferred.
- Expect `unknown/unknown` rows on Docker Hub for these images — that's how BuildKit stores attestation manifests, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
