### PR TITLE
ci: fire the TS jobs on shared build-infra changes

### DIFF
--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -83,6 +83,21 @@ if ${TS_CHANGED[skiplang/prelude]}; then
   TS_CHANGED[skipruntime-ts]=true
 fi
 
+# Shared build and dependency infrastructure that no single workspace or Skargo
+# package owns, so the allowlists above attribute it to no job. These paths feed
+# the npm install + libskipruntime build shared by the TS jobs (check-ts,
+# skipruntime, skipruntime-bun, skdb-wasm): the root lockfile pins compile inputs
+# such as node-addon-api (linked by skipruntime-ts/addon/binding.gyp), and the
+# Makefiles/bin scripts drive those builds. Without this a change to e.g. the
+# lockfile or skipruntime-ts/Makefile runs no CI at all, even though it can break
+# those builds -- so route it to the TS job set.
+if ! git diff --quiet HEAD "$BASE" -- \
+     Makefile package.json package-lock.json bin/ skipruntime-ts/Makefile; then
+  check_ts=true
+  TS_CHANGED[skipruntime-ts]=true
+  TS_CHANGED[sql]=true
+fi
+
 cat .circleci/base.yml
 
 JOBS=$(mktemp)


### PR DESCRIPTION
## What

`generate_config.sh` decides which jobs to run by attributing each changed path to a job through two allowlists: npm workspaces (→ `check-ts`) and `Skargo.toml` directories (→ the sk/native jobs). Paths that belong to **neither** allowlist are attributed to no job and run no CI at all — even when they can break a build. This routes the shared build/dependency infrastructure that no single package owns to the TS job set (`check-ts`, `skipruntime`, `skipruntime-bun`, `skdb-wasm`).

Progresses #980. This is the prerequisite correctness fix from that investigation: it closes a coverage gap so that the later, separate step of deduplicating the repeated `libskipruntime` build can drop a build from a job without silently dropping the coverage that build provides.

## Why

`libskipruntime.so` and the node-gyp native addon are compiled by four jobs. `skipruntime`/`skipruntime-bun` both compile *and load* it; `check-ts`/`skdb-wasm` compile it as a build check. Compiling it is genuine coverage — but only if a change that could break the compile actually fires a job that compiles it. Several inputs to that compile fall outside both allowlists:

- **`package.json` / `package-lock.json`** — the root lockfile pins `node-addon-api`, a compile input linked by `skipruntime-ts/addon/binding.gyp`. A float within its `^8.7.0` range can break the native addon link **without touching any `.sk` file or workspace**, and today merges with green CI.
- **`skipruntime-ts/Makefile`** — the `libskipruntime` build recipe and the `SKIPRUNTIME_VERSION` wiring that determines the linked `.so` name.
- **Root `Makefile` / `bin/`** — the drivers of `make check-ts` / `make test-skipruntime-ts` / `make test-wasm` (`bin/check-ts.sh`, `bin/cd_sh`, `bin/build_runtime.sh`, …).

## Verification

Ran `generate_config.sh` against synthetic single-file diffs, before and after. Every triggered set is additionally gated by `all-checks`.

**Now fires the TS jobs (previously ran nothing but the gate):**

| Change | Jobs |
|---|---|
| `skipruntime-ts/Makefile` alone | check-ts, skdb-wasm, skipruntime, skipruntime-bun |
| `package-lock.json` alone | check-ts, skdb-wasm, skipruntime, skipruntime-bun |
| `package.json` alone | check-ts, skdb-wasm, skipruntime, skipruntime-bun |
| root `Makefile` alone | check-ts, skdb-wasm, skipruntime, skipruntime-bun |
| `bin/check-ts.sh` alone | check-ts, skdb-wasm, skipruntime, skipruntime-bun |

**Unchanged (no regression, no over-triggering):**

| Change | Jobs |
|---|---|
| `skipruntime-ts/skiplang/ffi/src` alone | skipruntime, skipruntime-bun |
| `eslint-config` alone | check-ts |
| `skiplang/compiler/src` alone | compiler |
| `sql/src` alone | skdb, skdb-wasm |
| `www/` (docs) alone | — (gate only) |
| `rfc/` alone | — (gate only) |

`shellcheck --exclude SC2181 --exclude SC2002` (the `make check-sh` flags) passes, and the generated config parses as valid YAML.

## Scope / deliberately out

- Routes to the **TS** job set only. A root `Makefile`/`bin/` change can also affect native-only jobs (`skdb` via `make test-native`, `compiler` via `bin/run-sktest.sh`); those jobs are already covered by their `Skargo.toml` inputs, and I didn't want to over-trigger `skdb`/`compiler` on every root-infra edit. Wider native-side attribution can be a follow-up.
- **`.circleci/`** is intentionally excluded — a config change would otherwise run the full TS suite on every CI tweak, and CircleCI already validates config at parse time.

Follow-ups (separate): dedupe the repeated `libskipruntime` build via a shared cache; the two under-triggers noted on #980 (`sql/Skargo.toml`'s `skdate`/`cli` deps not fanning out to `skdb`; root package/lockfile bumps not typechecked) as their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
