### PR TITLE
ci: bump actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install and run actionlint
         shell: bash
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up JDK 21
       if: matrix.language == 'java-kotlin'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
   check-images:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v4
         with:
           version: ${{ env.BUILDX_VERSION }}
@@ -66,7 +66,7 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # The compiler is built from source in the image, and its Makefile
           # needs the pinned bootstrap and libbacktrace submodules.


### PR DESCRIPTION
`actions/checkout@v4` targets Node 20, which GitHub is [deprecating](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runs already force it onto Node 24 and print:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.

## Fix

Bump `actions/checkout@v4 → @v5` at all four call sites — `actionlint.yml`, `codeql.yml`, and both jobs in `docker-publish.yml`. v5 is the same action on Node 24; the `submodules`, `fetch-depth`, and `persist-credentials` behaviour this repo uses is unchanged.

Kept to **v5** on purpose: it's the minimal move off Node 20. v6 redesigns credential storage and v7 changes fork-PR checkout — both fine here, but unrelated to the deprecation, so I left them out. Happy to jump straight to v7 (latest) if you'd rather.

Only `actions/checkout` is touched; the other `@v4` actions (`setup-buildx`, `login`, `setup-java`, `upload-artifact`) already run on Node 24 and were not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)