### PR TITLE
ci: stop building libskipruntime in jobs that never load it

### DIFF
--- a/skipruntime-ts/Makefile
+++ b/skipruntime-ts/Makefile
@@ -36,8 +36,20 @@ install: libskipruntime
 install-all: libskipruntime
 	../bin/cd_sh .. "npm install"
 
+# Like install-all but without the native libskipruntime build, for consumers
+# that only need the TypeScript sources installed (typecheck/lint/wasm), never
+# the native addon. --ignore-scripts skips the addon's node-gyp rebuild, which
+# would otherwise fail to link the (unbuilt) libskipruntime.so.
+.PHONY: install-all-no-native
+install-all-no-native:
+	../bin/cd_sh .. "npm install --ignore-scripts"
+
+# check-ts only runs tsc/eslint; neither loads the native addon (it is pulled in
+# at runtime via an untyped createRequire that the type-checker never resolves),
+# so building libskipruntime here is redundant with the skipruntime/-bun jobs
+# that do load it.
 .PHONY: check-ts
-check-ts: install-all
+check-ts: install-all-no-native
 	../bin/check-ts.sh
 
 .PHONY: build

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -17,7 +17,10 @@ check-all: check-src check-tests
 
 .PHONY: build
 build:
-	${MAKE} -C ../skipruntime-ts install-all
+#	install-all-no-native only for its side effect of installing skdb/skdb-tests'
+#	npm deps (NPM_WORKSPACES excludes sql, so this is the target that covers them);
+#	nothing under sql/ links libskipruntime, so skip building it.
+	${MAKE} -C ../skipruntime-ts install-all-no-native
 	../bin/cd_sh .. "npm run build -w skdb -w skdb-tests"
 
 .PHONY: clean


### PR DESCRIPTION
## What

Stop building the native `libskipruntime.so` (and the addon's node-gyp rebuild) in the two jobs that never load it: **check-ts** (~79s, ~28% of the job) and **skdb-wasm** (~78s). Adds one `install-all-no-native` target (`npm install --ignore-scripts`, no `libskipruntime` prerequisite) and points both jobs at it.

Closes out the redundant-`libskipruntime`-build part of #980.

> **Depends on #1357 (already merged).** #1357 is what makes this coverage-neutral: it routes the shared build-infra paths (root `Makefile`/`package.json`/`package-lock.json`, `bin/`, `skipruntime-ts/Makefile`) to the `skipruntime`/`skipruntime-bun` jobs, so those jobs — which build **and load** the addon — now fire on every diff that can affect the native compile.

## Why it's safe (no coverage lost)

Compiling the addon is a real check, so the test is whether every diff that could break it still runs a job that compiles it:

- **`skipruntime` / `skipruntime-bun`** build *and load* the addon, and (with #1357) fire on every input to that compile: the `.sk` sources via the reverse-dependency graph, and `binding.gyp` / `package-lock.json` / `skipruntime-ts/Makefile` via the shared-build-infra routing. They remain unchanged here.
- **check-ts** runs only `tsc`/`eslint`. Neither loads the addon — it's required at runtime through an untyped `createRequire` the type-checker never resolves — and no workspace `build`/`typecheck`/`lint` script references the `.so` or the `.node` (verified by grep across all 24 workspaces; `prebuild.mjs` only symlinks in-repo TS source). `--ignore-scripts` skips only lifecycle scripts (node-gyp, better-sqlite3, …), never `tsc`, so the type-check is unaffected **by construction**.
- **skdb-wasm** never imports `@skipruntime/*` (nothing under `sql/` does) and never runs `better-sqlite3` at runtime (only `skipruntime-ts/examples` does, which skdb-wasm doesn't build or run). `install-all-no-native` still installs every workspace, so `skdb`/`skdb-tests` keep their deps and the root devDeps (`typescript`, `@skiplabs/tsconfig`).

## Unchanged on purpose

Verified by `make -n`:

- `make -C skipruntime-ts install-all` (the `skipruntime`/`skipruntime-bun` `test-all` path) still builds `libskipruntime` and does a full-scripts `npm install` → the addon is built and loaded where it's actually used.
- `make -C skipruntime-ts build` / `install` (docs, local dev) still build the native lib.

## Trade-off

Native-compile breakage is now first surfaced by `skipruntime`/`skipruntime-bun` rather than by check-ts. check-ts stays fast feedback for its actual job (types), and gets ~28% faster; the native jobs run in parallel, so this costs no wall-clock on the critical path.

One local-dev note: `install-all-no-native` uses `--ignore-scripts`, so after running a typecheck-only flow, a later `npm install` may report "up to date" without building native deps. `make install-all` / `make install` (unchanged) build them; run `npm rebuild` if switching a dev tree from a no-native install to a native one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
