### PR TITLE
Retry transient apt mirror failures during image builds

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -31,6 +31,18 @@ else
     steps=("$@")
 fi
 
+# Retry transient mirror fetch failures rather than aborting the whole build.
+# arm64 builds run under QEMU emulation and pull from ports.ubuntu.com, which
+# intermittently drops connections; without this a single dropped fetch fails
+# the entire apt-get and the multi-arch image build with it.
+#
+# Best effort: only written when the apt config dir is writable (i.e. running
+# as root, as in the Docker builds this targets). Retries are an optimisation,
+# so a non-root invocation should skip this rather than fail on it.
+if [ -w /etc/apt/apt.conf.d ]; then
+    echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+fi
+
 for step in "${steps[@]}"; do
     case "$step" in
         skiplang-build-deps)


### PR DESCRIPTION
## Problem

Multi-arch image builds (`release_docker_ci_images.sh` / `docker_build.sh --arch amd64,arm64`) run the arm64 apt steps under QEMU emulation, which fetch from `ports.ubuntu.com`. That mirror intermittently refuses connections, and apt does **not** retry by default, so one dropped fetch aborts the whole `apt-get` — and the build with it — even though the mirror is fine moments later.

Observed in a real republish: the `skip` arm64 build died with
```
E: Failed to fetch http://ports.ubuntu.com/.../tzdata_..._all.deb  Unable to connect to ports.ubuntu.com:80
E: Failed to fetch .../libsqlite3-0 ... python3.12 ... jq ...
E: Unable to fetch some archives ...   exit code: 100
```
A plain re-run then succeeded — i.e. purely transient.

## Fix

Set `Acquire::Retries "3"` at the top of `bin/apt-install.sh`, so apt retries transient fetch failures across every `apt-get update`/`install`, all steps, both arches.

The config is written **only when `/etc/apt/apt.conf.d` is writable**. The Docker builds this targets run as root, so it applies there; a non-root local invocation (`bin/apt-install.sh` is a documented Debian/Ubuntu install path) skips it rather than aborting on a permission error under `set -e` — retries are an optimisation, not a requirement.

## Test plan

- [x] **root** — writes the config; `apt-config dump Acquire::Retries` prints `3`; script continues under `set -e`
- [x] **non-root** (`-u 1000:1000`) — skips the write and reaches the end under `set -e`; the unguarded version dies with `Permission denied`
- [x] `shellcheck --exclude SC2181 --exclude SC2002` clean (matches `Makefile:104`)
- [ ] CI green

— Claude Opus 4.8 (1M context), effort xhigh
