### PR TITLE
ci: manual + weekly publishing only, and per-ref publish concurrency

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: docker-publish
+  # Scoped per ref, not one global group. Every publish trigger (workflow_dispatch,
+  # schedule) runs on refs/heads/main, so publishes still serialize against each
+  # other; a pull_request check-images run gets its own lane and is never cancelled
+  # by a contending publish.
+  group: docker-publish-${{ github.ref }}
   # Publishing is not latency sensitive, and cancelling midway through the merge
   # would leave some images' :latest updated and others not.
   cancel-in-progress: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,16 +8,6 @@ on:
       - 'docker-bake.hcl'
       - 'bin/check_ci_images.sh'
       - '.github/workflows/docker-publish.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'Dockerfile'
-      - 'skiplang/Dockerfile'
-      - 'sql/Dockerfile'
-      - 'bin/apt-install.sh'
-      - 'docker-bake.hcl'
-      - 'requirements-dev.txt'
-      - '.github/workflows/docker-publish.yml'
   schedule:
     # Weekly, so base image security updates land without anyone remembering.
     - cron: '17 6 * * 1'

--- a/bin/README.md
+++ b/bin/README.md
@@ -28,10 +28,11 @@ Convenience wrappers are provided for common workflows:
 
 ## Publish the CI images
 
-The images in the `ci` group of `docker-bake.hcl` are published to Docker Hub
-automatically by `.github/workflows/docker-publish.yml`, on demand, on merges to
-`main` that touch the files the images are built from, and weekly so base image
-security updates land without anyone remembering.
+The images in the `ci` group of `docker-bake.hcl` are published to Docker Hub by
+`.github/workflows/docker-publish.yml` — on demand (`workflow_dispatch`) and
+weekly, so base image security updates land without anyone remembering. Publish
+after landing an image-affecting change by triggering it manually; it does not
+publish automatically on merge.
 
 That group is the single source of truth: the workflow and
 `release_docker_ci_images.sh` both take their image list from it, and


### PR DESCRIPTION
Two independent fixes to `docker-publish.yml`, one per commit.

## 1. Scope the concurrency group per ref

The group was a single global `docker-publish` lane shared by every run. With `cancel-in-progress: false`, GitHub keeps one running + one pending per group and cancels any earlier pending run — so a PR's `check-images` run gets cancelled the moment a publish run on `main` contends. That's exactly what happened when #1359 merged: its check-images run was cancelled, not failed.

Fix: `group: docker-publish-${{ github.ref }}`. Every publish trigger runs on `refs/heads/main`, so publishes still serialize against each other, while each PR gets its own lane and its check never gets cancelled by a publish.

## 2. Stop publishing on push to main

Publishing on every merge that touched an image-affecting path meant each such merge immediately overwrote `:latest` for the whole CI fleet, with no gate. Weekly scheduled rebuilds keep the base images patched, and `workflow_dispatch` covers "I just changed a Dockerfile, publish it now" — that's enough.

So the push-to-main trigger is removed. Triggers are now **`workflow_dispatch` + weekly `schedule`**, plus `pull_request` (which only runs `check-images`, never a publish).

**Consequence, on purpose:** an image-affecting change no longer republishes on merge — trigger it by hand when you want it live. Documented in `bin/README.md`. This also removes the "a bad Dockerfile merge instantly breaks every CI job" failure mode, at the cost of images lagging `main` until the next manual or weekly run.

No change to the build/merge/attestation logic, which is now validated in production (the first real publish went green end-to-end and the four `:latest` tags are live, multi-arch, with provenance + SBOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)