### PR TITLE
Bump undertow and jackson-databind off known vulnerabilities (-1 critical, -14 high)

### DIFF
--- a/sql/server/core/build.gradle.kts
+++ b/sql/server/core/build.gradle.kts
@@ -19,11 +19,11 @@ repositories {
 }
 
 dependencies {
-  implementation("io.undertow:undertow-core:2.3.2.Final") // http/ws
+  implementation("io.undertow:undertow-core:2.3.26.Final") // http/ws
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
   implementation("org.java-websocket:Java-WebSocket:1.5.3")
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1") // json
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.21.5") // json
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/sql/server/dev/build.gradle.kts
+++ b/sql/server/dev/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 
   // http/ws server
-  implementation("io.undertow:undertow-core:2.3.9.Final")
+  implementation("io.undertow:undertow-core:2.3.26.Final")
 
   // coroutines
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")


### PR DESCRIPTION
## Summary

`skiplabs/skdb-dev-server` is the worst-scoring published image (**2/7 policies**, `1C 18H`) and the only one failing **"High-profile vulnerabilities"**. Most of that comes from two pinned Java dependencies whose jars ship in the image — a rebuild alone does **not** fix them.

- **`undertow-core`** `2.3.2.Final` (core) / `2.3.9.Final` (dev) → **`2.3.26.Final`**
  Clears `CVE-2025-12543` (**critical**, fixed 2.3.21.Final) plus 8 highs (`CVE-2024-7885`, `-6162`, `-5971`, `-1635`, `CVE-2025-9784`, …, all fixed ≤2.3.20.Final). Staying on the 2.3.x line keeps the API stable. Also pulls **`xnio-api` 3.8.8 → 3.8.16.Final** transitively, clearing another high.
- **`jackson-databind`** `2.16.1` → **`2.21.5`** — clears `CVE-2026-54512` / `-54513`.

> ⚠️ Worth knowing for future bumps: those jackson advisories have **two** affected ranges — `>=2.10.0,<2.18.8` **and** `>=2.19.0,<2.21.4`. Anything in 2.19.0–2.21.3 (including the then-latest **2.20.2**) is *still affected*; the backport landed in 2.18.8 but the mainline fix only in 2.21.4. "Take the latest" lands you back in the vulnerable range.

## Measured impact (Docker Scout, `skdb-dev-server`)

| | published | rebuilt with these bumps |
|---|---|---|
| total | 1C **18H** 175M 82L | 1C **2H** 10M 1L |
| **fixable C/H** | **1C 16H** | **1C 2H** |
| High-profile vulns | ❌ 3H 1M | ✅ **none** |
| policies | 2/7 | **3/7** |

Every application-level CVE is eliminated. The residual `1C 2H` (`golang.org/x/net`, `stdlib`) comes from the **`eclipse-temurin:21` base itself** — it reports the identical `1C 2H` — so it isn't fixable here.

The published image is also badly stale (its debs are Ubuntu 22.04-era: `glibc 2.35`, `curl 7.81.0-1ubuntu1.13`), predating both the Noble migration and the Temurin-21 bump. It sits outside the `ci` bake group, so routine republishes skip it. A republish after this merge picks up those base fixes too.

## Test plan

- [x] `server-core` builds — `BUILD SUCCESSFUL`, compile + `check` pass
- [x] `dev`/`skgw` stage builds — `dev.jar` produced
- [x] Resolved runtime classpath verified: `undertow-core:2.3.26.Final`, `xnio-api:3.8.16.Final`, `jackson-databind:2.21.5`
- [x] Full `dev` image rebuilt and Scout-measured (table above)
- [x] Confirmed the residual `1C 2H` is inherited from `eclipse-temurin:21`, not our code
- [ ] CI green

## Follow-ups (not here)

- **Republish `skdb-dev-server`** — it's manual/outside the `ci` group, which is why it rotted (see #1348).
- **Non-root is not a drive-by fix.** `start_dev.sh` runs `mkdir -p /var/db || exit 1` and `/var/db` is a mounted volume holding the database, so a `USER` switch would fail the mkdir and/or be unable to write a root-owned bind mount — breaking existing deployments. It needs a deliberate migration.
- `eclipse-temurin:21-jre` would suit this runtime stage (it only runs `java -jar`) but only drops 1 high (`1C 1H` vs `1C 2H`); the base critical remains either way.

— Claude Opus 4.8 (1M context), effort xhigh
