### PR TITLE
SKStore: stop genSym handing out duplicate ids

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -87,8 +87,12 @@ class DirSub(
 /* Unique number generator. */
 /*****************************************************************************/
 
+// Untracked because it draws from a global counter: two identical calls must
+// not be merged, or the "unique" ids collide. @allow_tracked_call keeps the
+// tracked callers (Path::iid, skjson, the back end's type ids) compiling.
+@allow_tracked_call
 @cpp_extern("SKIP_genSym")
-native fun genSym(Int): Int;
+untracked native fun genSym(Int): Int;
 
 @intrinsic
 native fun const_typed_symbol<T>(): Int;


### PR DESCRIPTION
Fixes #1342.

`SKStore.genSym` is the unique-number generator, but two identical calls get merged by CSE, so it hands out **the same id twice**.

## The bug

```skip
fun trackedFresh(): Int { SKStore.genSym(0) }

untracked fun main(): void {
  // A loop body is ONE instruction run N times: CSE cannot merge across
  // iterations, so this shows genSym's real behaviour.
  v = mutable Vector[];
  for (_ in Range(0, 4)) { v.push(trackedFresh()) };
  print_string("loop:     " + v.join(","));

  a = SKStore.genSym(0);
  b = SKStore.genSym(0);
  print_string("straight: " + a + "," + b)
}
```

| | `loop:` | `straight:` |
| --- | --- | --- |
| before | `1,2,3,4` | **`5,5`** ← same id twice |
| after | `1,2,3,4` | `5,6` |

Reproduces at `-O0` as well as `--release`.

## Why

The declaration was tracked, with an `Int` argument and `Int` return — both deep-frozen — so `funCanCSE` (`peephole.sk:361-364`) and `canCSECall` (`peephole.sk:383-402`) both pass and GVN merges the calls. But the implementation is a global counter:

- `skiplang/prelude/runtime/palloc.c:41` — `return __atomic_fetch_add(gid, n, __ATOMIC_RELAXED);`
- `skiplang/prelude/runtime/runtime32_specific.c:107` — `static SkipInt x = 1; x++; return x;`

The trap is that **every call site passes a constant** — `genSym(0)` — which is precisely what makes two calls identical and therefore mergeable. And in a loop the ids come out fine, which is why this hid for so long.

Exposed callers: `Path::iid` (`Path.sk:78`), skjson's fresh variable names (`Parser.sk:348`, `Pattern.sk:283`), and the back end's type ids (`AsmOutput.sk:2287`).

## The fix

`untracked` + `@allow_tracked_call`, matching what #1353 just established for the stdlib's OS-facing natives — rather than the `@debug` I originally proposed in #1342, which predated the bootstrap bump (#1352) that made the annotation usable in the prelude.

`untracked` states what is true of a global counter; `@allow_tracked_call` keeps the tracked callers compiling (verified above — `trackedFresh` is a plain tracked function); and the back end still reads the raw `untracked` keyword and ignores the annotation, so the calls no longer CSE.

## Scope

The other natives in `Context.sk` were checked and are **fine**: `mutexInit`, `condInit`, `freezeLock`, `unfreezeLock` and friends all take a `mutable` argument or return a mutable value, so `canCSECall`'s deep-frozen requirement already excludes them. `genSym` was the one exposed.

A repo-wide sweep for other instances of this bug class is running separately; anything it turns up will be filed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Opus 4.8 (1M context)