### PR TITLE
Let values out of the runtime be spread, without giving up the static guarantee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - `DepSafeOf<T>`, the dependency-safe form of `T` (#829)
+
+### Changed
+ - Use `DepSafeOf<T>` rather than `T & DepSafe` throughout the API, so that the
+   values returned by `Values`, `EagerCollection`, `LazyCollection` and `Reducer`
+   can be spread and destructured without a cast (#829)
+ - `Managed` is now a class rather than a type alias, and its mark is nominal, so
+   that spreading a dependency-safe object gives back a value that is statically
+   not dependency-safe. This matches the runtime, where the mark is
+   non-enumerable and does not survive the spread either (#829)
+
 ## [0.0.19] - 2025-11-16
 
 ### Added

--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -89,6 +89,21 @@ export type DepSafe =
   | symbol
   | Managed;
 
+/**
+ * The dependency-safe form of `T`.
+ *
+ * Object types are marked `Managed`, while primitives are already dependency-safe and pass through unchanged.
+ *
+ * This exists because `DepSafe` is a union, so it cannot usefully be intersected with an object type: for an object type `T`, `T & DepSafe` keeps arms such as `T & string`, which TypeScript does not consider object types, and so it rejects spreading or destructuring the result.
+ * `DepSafeOf<T>` narrows to `T & Managed` instead, which spreads.
+ *
+ * Spreading a dependency-safe object gives back a plain object, not a dependency-safe one: the `Managed` mark is nominal, and TypeScript drops it from the spread result just as the runtime does.
+ * That is intended -- `{...deps, k: v}` is a fresh, unfrozen object -- so pass it to `deepFreeze` before using it as a `Mapper` or `Reducer` parameter.
+ *
+ * @typeParam T - Type of the value.
+ */
+export type DepSafeOf<T> = T extends object ? T & Managed : T;
+
 export function checkOrCloneParam<T>(value: T): T {
   if (
     typeof value == "boolean" ||

--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -15,19 +15,27 @@ export const sk_managed: unique symbol = Symbol.for("Skip.managed");
  *
  * `Managed` values are important because they can be used in code that will be executed by the reactive computation system without introducing the possibility of stale or unreproducible results.
  */
-export type Managed = {
+export abstract class Managed {
   /**
+   * The mark is `private`, which makes `Managed` nominal rather than structural.
+   * That is deliberate: it is installed non-enumerably, so it does not survive an
+   * object spread at runtime, and a structural mark would survive that spread in
+   * the *type* -- letting `{...managed, k: v}` claim to be dependency-safe when it
+   * is not. TypeScript drops private members from spread results, so a nominal
+   * mark models the runtime faithfully.
+   *
+   * `declare` because the mark is installed by `Object.defineProperty` rather
+   * than by field initialization.
+   *
    * @ignore
    * @hidden
    */
-  [sk_managed]: true;
-};
+  declare private readonly [sk_managed]: true;
+}
 
-export abstract class Frozen implements Managed {
-  // tsc misses that Object.defineProperty in the constructor inits this
-  [sk_managed]!: true;
-
+export abstract class Frozen extends Managed {
   constructor() {
+    super();
     this.freeze();
   }
 
@@ -40,6 +48,13 @@ function tagSkManaged<T extends object>(x: T): T & Managed {
     writable: false,
     value: true,
   }) as T & Managed;
+}
+
+// `Object.freeze` returns `Readonly<T>`, a mapped type, and mapped types drop the
+// private mark that makes `Managed` nominal. Freezing does not remove the mark at
+// runtime -- `tagSkManaged` has already installed it -- so restore it in the type.
+function freezeSkManaged<T extends object>(x: T & Managed): T & Managed {
+  return Object.freeze(x) as T & Managed;
 }
 
 export function isSkManaged(x: any): x is Managed {
@@ -126,12 +141,12 @@ export function deepFreeze<T>(value: T): T & DepSafe {
       for (const elt of value) {
         deepFreeze(elt);
       }
-      return Object.freeze(tagSkManaged(value));
+      return freezeSkManaged(tagSkManaged(value));
     } else {
       for (const val of Object.values(value)) {
         deepFreeze(val);
       }
-      return Object.freeze(tagSkManaged(value));
+      return freezeSkManaged(tagSkManaged(value));
     }
   } else {
     // typeof value == "function" || typeof value == "undefined"
@@ -176,14 +191,17 @@ export type Exportable =
   | ObjectProxy<{ [k: string]: Exportable }>
   | (readonly Exportable[] & Managed);
 
+// `Managed` rather than an `[sk_managed]: true` field: the mark is nominal, so
+// declaring the field structurally would no longer make a proxy `Managed`. The
+// proxy does answer to the mark at runtime -- see `reactiveObject.get`.
 export type ObjectProxy<Base extends { [k: string]: Exportable }> = {
   [sk_isObjectProxy]: true;
-  [sk_managed]: true;
   __pointer: Pointer<Internal.CJSON>;
   clone: () => ObjectProxy<Base>;
   toJSON: () => Base;
   keys: IterableIterator<keyof Base>;
-} & Base;
+} & Base &
+  Managed;
 
 export function isObjectProxy(
   x: any,

--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -136,6 +136,9 @@ export function checkOrCloneParam<T>(value: T): T {
  * @param value - The object to deep-freeze.
  * @returns The same object that was passed in.
  */
+export function deepFreeze<T>(value: T): DepSafeOf<T>;
+// The implementation signature keeps the intersection form: TypeScript cannot
+// check a function body against a deferred conditional return type.
 export function deepFreeze<T>(value: T): T & DepSafe {
   if (
     typeof value == "boolean" ||

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -10,10 +10,11 @@ import type {
   Json,
   JsonObject,
   DepSafe,
+  DepSafeOf,
 } from "../skiplang-json/index.js";
 
 export * from "./errors.js";
-export type { Managed, Json, JsonObject, Opaque, DepSafe };
+export type { Managed, Json, JsonObject, Opaque, DepSafe, DepSafeOf };
 export { deepFreeze } from "../skiplang-json/index.js";
 export type { Nullable };
 
@@ -67,7 +68,7 @@ export interface Reducer<V extends Json, A extends Json> {
    * @param value - The added value.
    * @returns The updated accumulated value.
    */
-  add(accum: Nullable<A>, value: V & DepSafe): A;
+  add(accum: Nullable<A>, value: DepSafeOf<V>): A;
 
   /**
    * Exclude a previously added value from the accumulated value.
@@ -81,25 +82,25 @@ export interface Reducer<V extends Json, A extends Json> {
    * @param value - The removed value.
    * @returns The updated accumulated value, or `null` indicating that the accumulated value should be recomputed using `add` and `initial`.
    */
-  remove(accum: A, value: V & DepSafe): Nullable<A>;
+  remove(accum: A, value: DepSafeOf<V>): Nullable<A>;
 }
 
 /**
  * A non-empty iterable sequence of dependency-safe values.
  */
-export interface Values<T> extends Iterable<T & DepSafe> {
+export interface Values<T> extends Iterable<DepSafeOf<T>> {
   /**
    * Return the first value, if there is exactly one.
    * @param _default
    * @param _default.ifMany - Default value to use instead of throwing if there are multiple values.
    * @throws {SkipNonUniqueValueError} if this iterable contains multiple values.
    */
-  getUnique(_default?: { ifMany?: T }): T & DepSafe;
+  getUnique(_default?: { ifMany?: T }): DepSafeOf<T>;
 
   /**
    * Return all the values.
    */
-  toArray(): (T & DepSafe)[];
+  toArray(): DepSafeOf<T>[];
 }
 
 /**
@@ -118,7 +119,7 @@ export interface LazyCollection<K extends Json, V extends Json>
    * @param key - The key to query.
    * @returns The values associated to `key`.
    */
-  getArray(key: K): (V & DepSafe)[];
+  getArray(key: K): DepSafeOf<V>[];
 
   /**
    * Get (and potentially compute) the single value associated to `key`.
@@ -132,7 +133,7 @@ export interface LazyCollection<K extends Json, V extends Json>
    * @returns The value associated to `key`.
    * @throws {SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
    */
-  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe;
+  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): DepSafeOf<V>;
 }
 
 /**
@@ -151,7 +152,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    * @param key - The key to query.
    * @returns The values associated to `key`.
    */
-  getArray(key: K): (V & DepSafe)[];
+  getArray(key: K): DepSafeOf<V>[];
 
   /**
    * Get the single value associated to a key.
@@ -165,7 +166,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    * @returns The value associated to `key`.
    * @throws {SkipNonUniqueValueError} if `key` is associated to either zero or multiple values and no suitable default is provided.
    */
-  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe;
+  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): DepSafeOf<V>;
 
   /**
    * Create a new eager collection by mapping a function over the values in this one.
@@ -262,7 +263,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    * @param end - The greatest key whose entry will be kept in the result.
    * @returns The restricted eager collection.
    */
-  slice(start: K & DepSafe, end: K & DepSafe): EagerCollection<K, V>;
+  slice(start: DepSafeOf<K>, end: DepSafeOf<K>): EagerCollection<K, V>;
 
   /**
    * Create a new eager collection by keeping only the elements whose keys are in at least one of the given ranges.
@@ -272,7 +273,7 @@ export interface EagerCollection<K extends Json, V extends Json>
    * @param ranges - The pairs of lower and upper bounds on keys to keep in the result.
    * @returns The restricted eager collection.
    */
-  slices(...ranges: [K & DepSafe, K & DepSafe][]): EagerCollection<K, V>;
+  slices(...ranges: [DepSafeOf<K>, DepSafeOf<K>][]): EagerCollection<K, V>;
 
   /**
    * Create a new eager collection by keeping the first entries.

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -32,6 +32,7 @@ import {
   type NamedCollections,
   type Values,
   type DepSafe,
+  type DepSafeOf,
   type Reducer,
   type Resource,
   type SkipService,
@@ -246,7 +247,7 @@ class LazyCollectionImpl<K extends Json, V extends Json>
     Object.freeze(this);
   }
 
-  getArray(key: K): (V & DepSafe)[] {
+  getArray(key: K): DepSafeOf<V>[] {
     return this.refs
       .json()
       .importJSON(
@@ -254,10 +255,10 @@ class LazyCollectionImpl<K extends Json, V extends Json>
           this.lazyCollection,
           this.refs.json().exportJSON(key),
         ),
-      ) as (V & DepSafe)[];
+      ) as DepSafeOf<V>[];
   }
 
-  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe {
+  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): DepSafeOf<V> {
     const values = this.getArray(key);
     switch (values.length) {
       case 1:
@@ -284,7 +285,7 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     Object.freeze(this);
   }
 
-  getArray(key: K): (V & DepSafe)[] {
+  getArray(key: K): DepSafeOf<V>[] {
     return this.refs
       .json()
       .importJSON(
@@ -292,10 +293,10 @@ class EagerCollectionImpl<K extends Json, V extends Json>
           this.collection,
           this.refs.json().exportJSON(key),
         ),
-      ) as (V & DepSafe)[];
+      ) as DepSafeOf<V>[];
   }
 
-  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): V & DepSafe {
+  getUnique(key: K, _default?: { ifNone?: V; ifMany?: V }): DepSafeOf<V> {
     const values = this.getArray(key);
     switch (values.length) {
       case 1:
@@ -887,11 +888,11 @@ export class ServiceInstance {
   }
 }
 
-class ValuesImpl<T> implements Values<T> {
+class ValuesImpl<T extends Json> implements Values<T> {
   /* Lazy Iterable/Sequence: values are generated from
     the Iterator pointer and stored in materialized.
     Once finished the pointer is nullified. */
-  private readonly materialized: (T & DepSafe)[] = [];
+  private readonly materialized: DepSafeOf<T>[] = [];
 
   constructor(
     private readonly skjson: JsonConverter,
@@ -901,14 +902,14 @@ class ValuesImpl<T> implements Values<T> {
     this.pointer = pointer;
   }
 
-  private next(): Nullable<T & DepSafe> {
+  private next(): Nullable<DepSafeOf<T>> {
     if (this.pointer === null) {
       return null;
     }
 
     const v = this.skjson.importOptJSON(
       this.binding.SkipRuntime_NonEmptyIterator__next(this.pointer),
-    ) as Nullable<T & DepSafe>;
+    ) as Nullable<DepSafeOf<T>>;
 
     if (v === null) {
       this.pointer = null;
@@ -918,7 +919,7 @@ class ValuesImpl<T> implements Values<T> {
     return v;
   }
 
-  getUnique(_default?: { ifMany?: T }): T & DepSafe {
+  getUnique(_default?: { ifMany?: T }): DepSafeOf<T> {
     if (this.materialized.length < 1) {
       this.next();
     }
@@ -934,14 +935,14 @@ class ValuesImpl<T> implements Values<T> {
     return first;
   }
 
-  toArray(): (T & DepSafe)[] {
+  toArray(): DepSafeOf<T>[] {
     while (this.next() !== null);
     return this.materialized;
   }
 
-  [Symbol.iterator](): Iterator<T & DepSafe> {
+  [Symbol.iterator](): Iterator<DepSafeOf<T>> {
     let i = 0;
-    const next = (): IteratorResult<T & DepSafe> => {
+    const next = (): IteratorResult<DepSafeOf<T>> => {
       // Invariant: this.materialized.length >= i
       let value = this.materialized[i];
       if (value === undefined /* i.e. this.materialized.length == i */) {
@@ -1306,7 +1307,7 @@ export class ToBinding {
     return skjson.exportJSON(
       reducer.object.add(
         skacc ? (skjson.importJSON(skacc) as Json) : null,
-        skjson.importJSON(skvalue) as Json & DepSafe,
+        skjson.importJSON(skvalue) as DepSafeOf<Json>,
       ),
     );
   }
@@ -1320,7 +1321,7 @@ export class ToBinding {
     const reducer = this.handles.get(skreducer);
     const result = reducer.object.remove(
       skjson.importJSON(skacc) as Json,
-      skjson.importJSON(skvalue) as Json & DepSafe,
+      skjson.importJSON(skvalue) as DepSafeOf<Json>,
     );
     if (result === null) return null;
     return skjson.exportJSON(result);


### PR DESCRIPTION
Fixes #829. Lets values coming out of the runtime be spread and destructured without a cast, with no loss of static safety.

**Superseded approach:** an earlier revision of this PR fixed the ergonomics alone and accepted that `coll.map(M, {...vals.getUnique(), k: v})` would compile and then throw at runtime. @jberdine was right to reject that — trading a compile-time error for a runtime failure is a regression, not a trade. This revision closes that hole first, so it never opens.

## Why `T & DepSafe` cannot be spread

`DepSafe` is a union, and intersecting a union with an object type is what breaks. For an object `T`, `T & DepSafe` expands to a 7-arm union, and only one arm collapses:

| arm | reduces to |
|---|---|
| `T & null` | `never` |
| `T & string`, `& number`, `& boolean`, `& bigint`, `& symbol` | **survive** |
| `T & Managed` | `T & Managed` |

The primitive arms survive on purpose — `T & string` is the branded-primitive pattern (`type UserId = string & { __brand }`) that TypeScript deliberately supports. Spread requires *every* arm of a union to be an object type, so the surviving `T & string` arm makes `{...x}` a **TS2698**.

So this isn't a tsc weakness, as #829's title suggests, and there's nothing to report upstream — tsc rejects spreading a bare `string` for exactly the same rule. We did it to ourselves by intersecting a union.

## The two halves

**1. Make the `Managed` mark nominal** (first commit, and it stands alone).

The mark is installed with `Object.defineProperty(…, { enumerable: false })`, so it does not survive a spread *at runtime*. As a structural type it *did* survive one in the type, because tsc models spread as copying the symbol-keyed property. So the type system already disagreed with the runtime — `{...managed, k: v}` claimed to be dependency-safe while being a fresh, unfrozen object that `checkOrCloneParam` throws on.

That is latent today only because TS2698 rejects the spread outright, for unrelated reasons. It stops being latent the moment the spread is allowed. A private member makes `Managed` nominal, and tsc drops private members from a spread result exactly as the runtime drops the non-enumerable mark.

**2. Then `DepSafeOf<T>`** for the 12 sites that intersect `DepSafe` with another type:

```ts
export type DepSafeOf<T> = T extends object ? T & Managed : T;
```

Objects narrow to `T & Managed`, which spreads. Primitives pass through. `null extends object` is false, so `DepSafeOf<null>` is `null`. It resolves through deferred generics, since an `extends object` constraint is enough for tsc to pick a branch.

**The distinction that matters is bare-vs-intersected, not input-vs-output.** Using `DepSafe` bare is fine, so the `Params extends DepSafe[]` constraints are deliberately untouched — there the union is load-bearing, since a param may legitimately be a number *or* a frozen object.

## The result: ergonomics with the guarantee intact

Verified against the built package:

```ts
const spread = { ...vals.getUnique(), extra: 1 };   // compiles      <- #829
const { id, ...rest } = vals.getUnique();           // compiles      <- was TS2700
coll.map(P, vals.getUnique());                      // compiles      <- round-trip
coll.map(P, { ...vals.getUnique(), name: "x" });    // TS2345        <- statically rejected
coll.map(P, deepFreeze({ ...vals.getUnique() }));   // compiles      <- the fix, in the diagnostic
```

The rejection is exact and names the problem:

```
TS2345: Argument of type '{ name: string; id: number; }' is not assignable to
        parameter of type 'Row & Managed'.
  Property '[sk_managed]' is missing in type '{ name: string; id: number; }'
        but required in type 'Managed'.
```

Type and runtime now agree, which is the point — measured on the built package: `deepFreeze({...})` → `isSkManaged: true`; `{ ...frozen, d: 3 }` → `isSkManaged: false`, and `checkOrCloneParam` throws on it. The type checker rejects exactly what the runtime rejects, so that throw is no longer reachable from type-checked code.

## Breaking changes

Both are the price of the static guarantee, and neither is silent — each surfaces as a compile error with a one-line fix.

- **`Managed` becomes an emitted class**, not a type-only export, and `Frozen` extends rather than implements it. External code implementing these interfaces structurally (mocks, fakes: `class FakeCollection implements EagerCollection<K, V>`) gets TS2720 and must `extends SkManaged`. Unforgeability is the intended consequence: only `deepFreeze` and the runtime should mint `Managed`.
- **Generic wrappers funnelling `deepFreeze` into `DepSafe`** stop compiling, since for unconstrained `T` the false branch leaves a bare `T` arm that isn't provably dependency-safe:
  ```ts
  function f<T>(x: T): DepSafe { return deepFreeze(x); }
  // TS2322: Type 'DepSafeOf<T>' is not assignable to type 'DepSafe'.
  ```
  Annotating `DepSafeOf<T>`, or constraining `T` to `Json`/`object`, compiles. There's no overload that fixes it — `deepFreeze<T extends DepSafe>(value: T): T` does *not* work (an unconstrained caller `T` never matches and falls through), so I'm declaring it rather than papering over it.

Plain callers are unaffected and gain the spread. `DepSafe` stays exported, so merely *naming* it still compiles. Package is pre-1.0 (0.0.23).

## Notes

- **Commits are ordered so the hole never opens**, and each builds independently (verified per-commit). The nominal mark lands first; `DepSafeOf` follows.
- `deepFreeze`'s overload ships with its callers rather than with the type, because `DepSafeOf<V>` and `V & DepSafe` are mutually unassignable for deferred `V` — splitting them gives a commit that doesn't build. The overload is load-bearing, not cosmetic: without it core fails with 5 TS2322s from the internal `_default.ifNone/ifMany` calls.
- `Object.freeze` returns `Readonly<T>`, a mapped type, which drops the private mark; `freezeSkManaged` restores it, freezing not having removed it at runtime.
- `ObjectProxy` now intersects `Managed` rather than declaring the mark structurally, which no longer confers it — the proxy does answer to the mark at runtime.
- `Values<T>` is deliberately left unconstrained, as on `main`. Constraining it to `Json` would break plain-`interface` consumers (TS2344, the index-signature gotcha) for no benefit; only `ValuesImpl` needs the bound, for null-narrowing.
- Also quietly fixes a docs bug: typedoc renders `(T & DepSafe)[]` as `T & DepSafe []`, dropping the parens so it reads as `T & (DepSafe[])`. `DepSafeOf<T>[]` is unambiguous.
- Naming: `DepSafeOf<T>` over `Dep<T>` because `Dep<Row>` misreads as "a dependency of Row", and this is the most-hovered type in the API.

## Not included

**The examples still carry their workarounds.** `examples/chatroom` and `examples/hackernews` each bind `getUnique()` to an annotated local purely to launder the type for a spread — the annotation looks ordinary and nothing says it's load-bearing. Deleting both is the payoff of this change and is verified locally, but the examples `npm install @skipruntime/core@0.0.23` from the registry inside Docker, so they compile against the released package rather than this workspace. That cleanup follows a release containing `DepSafeOf<T>`, in the same shape as #1334. The commit is ready and waiting.

## Testing

Repo tsc 5.7.3, all after `rm -rf dist` (a stale `dist/` gives false greens). `core`, `helpers`, `server`, `tests`, `examples` build clean; `sql/ts` type-checks clean. Each of the four commits builds independently. `DepSafeOf<T>` survives declaration emit nameable rather than expanding into an unreadable union.

The five behaviours above were checked against the built package through a real example's tsconfig, and the runtime half (`deepFreeze`/`isSkManaged`/`checkOrCloneParam`, including the spread) was exercised against the emitted JS. Runtime suites are covered by CI, not locally — the skiplang toolchain doesn't build in my environment.

---
*— Claude Opus 4.8 (1M context), via Claude Code. Every type-level claim above was compiled against the repo's tsc 5.7.3 rather than asserted, and the runtime claims were measured against the emitted JS.*