### PR TITLE
SKStore: two more natives CSE was silently merging

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1656,6 +1656,7 @@ native fun gUnsafeIncrRefCount(Contexts): void;
 @cpp_extern("SKIP_should_GC")
 native fun shouldGC(Obstack): UInt32;
 
+@debug
 @cpp_extern("SKIP_print_persistent_size")
 native fun printPersistentSize(): void;
 

--- a/skiplang/prelude/src/skstore/EagerDir.sk
+++ b/skiplang/prelude/src/skstore/EagerDir.sk
@@ -378,8 +378,11 @@ base class MInfo {
 /* The class used for subscriptions. */
 /*****************************************************************************/
 
+// Untracked because it writes the notification file: the write IS the
+// notification, so two identical calls must not be merged into one.
+@allow_tracked_call
 @cpp_extern("SKIP_notify")
-native fun unixNotify(String, Int32): Int32;
+untracked native fun unixNotify(String, Int32): Int32;
 
 /*****************************************************************************/
 /* The map containing the new data. */


### PR DESCRIPTION
Two more instances of the #1342 / #1365 bug class, found by sweeping the repo for stateful natives that satisfy every CSE gate. Both are in SKStore. Same shape as the stdlib natives fixed in #1337 / #1353.

## `printPersistentSize` — demonstrated

```skip
untracked fun main(): void {
  print_string("--- two identical calls follow; expect TWO numbers ---");
  SKStore.printPersistentSize();
  SKStore.printPersistentSize();
  print_string("--- end ---")
}
```

| before | after |
| --- | --- |
| `8` | `8` |
| | `8` |

One line for two calls. It takes no arguments and returns `void` — both vacuously deep-frozen — so every gate in `canCSECall` passes. It also reads `ginfo->total_palloc_size` (`palloc.c:744`), live allocator state mutated by every `sk_palloc`, so the merged call prints a **stale** value if anything allocated between the two.

Fixed with `@debug`, not `untracked`: this is a debug printf, which is exactly what the annotation is for — and **every other declaration in the same runtime-primitives block already has it** (`gUnsafeIncrRefCount`, `shouldGC`, `gGlobalLock`, …). This one was simply missed.

## `unixNotify` — analysis + build-verified

`unixNotify(String, Int32): Int32` (`EagerDir.sk:382`) opens, writes and closes the notification file (`runtime64_specific.cpp:388`). The write *is* the notification — a watcher observes the file changing. `String` and `Int32` are deep-frozen, the decl was tracked with no `@debug`, so two identical calls merge: one notification instead of two, and the second call's OS error status is never observed because the first call's `Int32` is reused.

That is the "important side effect" `peephole.sk:376-380` contrasts `@debug` against, so it gets `untracked` + `@allow_tracked_call`, matching #1353. Verified the tracked caller (`Context.sk:891`) still compiles — the prelude builds.

## Not in scope

The sweep confirmed five more of these, which I have **not** touched here because they need a judgement call rather than a mechanical fix:

- `getExn` / `saveExn` / `replaceExn` (`core/language/Exception.sk`) — the thread-local exception slot behind `vtry`. Real, but it is exception plumbing and deserves its own discussion.
- `SkipRuntime.popContext` / `getFork` (`skipruntime-ts/skiplang/core/src/Extern.sk`) — TS-backed externs over a mutable host stack.

Filed separately so they can be argued on their merits.

Also checked and **not** bugs, for the record: the `Context.sk` mutex/cond primitives (a `mutable` argument already blocks CSE), and `createExternalPointer` (stateful, but the refcount and list-node effects cancel, so merging is benign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Opus 4.8 (1M context)