### PR TITLE
skipruntime: stop CSE merging popContext and getFork

### DIFF
--- a/skipruntime-ts/skiplang/core/src/Extern.sk
+++ b/skipruntime-ts/skiplang/core/src/Extern.sk
@@ -3,13 +3,23 @@ module SkipRuntime;
 @cpp_extern("SkipRuntime_pushContext")
 native fun pushContext(context: mutable SKStore.Context): void;
 
+// Untracked because it pops the host context stack: it takes no arguments and
+// returns void, so without this two pops in straight-line code merge into one
+// and the stack leaks. (pushContext is safe by accident — its mutable argument
+// already blocks CSE.)
+@allow_tracked_call
 @cpp_extern("SkipRuntime_popContext")
-native fun popContext(): void;
+untracked native fun popContext(): void;
 
 @cpp_extern("SkipRuntime_getContext")
 native fun getContext(): ?mutable SKStore.Context;
 
+// Untracked because it reads host state that the TS side reassigns via
+// setFork(), which the compiler cannot see: two reads straddling a setFork
+// must not collapse onto the stale first value. (getContext is safe by
+// accident — its ?mutable Context return already blocks CSE.)
+@allow_tracked_call
 @cpp_extern("SkipRuntime_getFork")
-native fun getFork(): ?String;
+untracked native fun getFork(): ?String;
 
 module end;


### PR DESCRIPTION
The skipruntime half of #1369, and the same bug class as #1342 / #1365 / #1368. Both declarations are zero-argument natives over mutable host state, so every gate in `canCSECall` passes and two identical calls merge into one.

## `popContext`

```skip
@cpp_extern("SkipRuntime_popContext")
native fun popContext(): void;
```

Backed by `SkipRuntime_popContext(): void { this.stack.pop(); }` (`core/src/index.ts:999` → `Stack.pop`, `index.ts:232`) — a destructive pop of the host context stack.

**The existing call sites are safe today only by luck.** They all follow this shape:

```skip
pushContext(context);
try {
  ...
  popContext();      // success path
} catch {
| ex ->
  popContext();      // catch path
  throw ex
}
```

The two pops are on mutually exclusive paths, so neither dominates the other and GVN leaves them alone. But that is an accident of the current code, not a guarantee: inlining a push/pop function twice into one caller yields straight-line `pop(); pop();`, which **does** merge — one pop for two pushes, and the stack leaks. `pushContext` is unaffected, because its `mutable` argument already blocks CSE.

## `getFork`

```skip
@cpp_extern("SkipRuntime_getFork")
native fun getFork(): ?String;
```

Backed by `SkipRuntime_getFork(): Nullable<string> { return this.forkName; }` (`index.ts:1007`), where `forkName` is reassigned by the sibling setter `setFork` (`index.ts:1015`). The compiler cannot see that write, so two reads straddling a `setFork` collapse onto the stale first value. `getContext` is unaffected — its `?mutable Context` return already blocks CSE.

## On evidence

I have **not** constructed a running repro for these two, and I would rather say so than overclaim. What I do have is the structural proof from the sibling PR #1368: `printPersistentSize` has the identical signature shape — zero arguments, `void` return, stateful implementation — and two identical calls to it **provably printed one line instead of two**. `popContext` differs only in what the side effect is.

## The fix

`untracked` + `@allow_tracked_call`, as established in #1353. Verified both `skipruntime-core` and `skipruntime` (ffi) typecheck unchanged, so `@allow_tracked_call` holds across every existing caller in `BaseTypes.sk`, `Runtime.sk`, `Utils.sk` and `FFI.sk`.

Leaves the exception-slot trio (`getExn`/`saveExn`/`replaceExn`) from #1369 untouched — that one is exception plumbing and wants a deliberate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Opus 4.8 (1M context)