### PR TITLE
Publish skdb-dev-server weekly with the other images

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -36,12 +36,27 @@ publish automatically on merge.
 
 That group is the single source of truth: the workflow and
 `release_docker_ci_images.sh` both take their image list from it, and
-`check_ci_images.sh` asserts every image CircleCI pulls is in it. It holds
-toolchain images only — their final stages contain compiled binaries and apt
-packages but no repo source, so republishing them is not a release.
+`check_ci_images.sh` asserts every image CircleCI pulls is in it. Most of it is
+toolchain images — their final stages contain compiled binaries and apt packages
+but no repo source, so republishing them is not a release.
 
-`skdb` and `skdb-dev-server` are not in that group and stay manual: they bake in
-source and their tags carry release semantics.
+`skdb-dev-server` is the exception, and the one image here users actually run. It
+bakes in source, so publishing it from main **is** a release of main:
+`skdb-dev-server:latest` tracks main as of the last publish, not the last tagged
+release. That trade is deliberate — left manual it went a year without a rebuild
+and rotted to 1 critical / 18 high severity advisories, on the image users run.
+
+`skdb-dev-server:quickstart` still carries release semantics and stays manual, via
+`release_docker_skdb_dev_server.sh`. Do not reach for it as the "safe" alternative
+to `:latest`: nothing refreshes it either, and it has not been rebuilt since
+2024-01-30, so it is further behind on security fixes than the `:latest` this
+group now keeps current. A pinned tag is only safer than a moving one if somebody
+re-cuts it.
+
+`skdb` is not in the group, so `skiplabs/skdb` is still published by hand. It is
+rebuilt on every publish anyway, as a link-only dependency of `skdb-dev-server`:
+bake forces such targets to `output=cacheonly`, so it is built fresh and consumed
+but never pushed.
 
 Use `release_docker_ci_images.sh` only when the workflow is unavailable. It
 publishes the same images from your machine, using your own credentials.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,18 +25,29 @@ group "default" {
 # publish. bin/check_ci_images.sh asserts that every skiplabs/ image CircleCI
 # pulls appears here.
 #
-# Toolchain images only. Their final stages contain compiled binaries and apt
+# Mostly toolchain images: their final stages contain compiled binaries and apt
 # packages but no repo source, so any commit on main can rebuild them and
-# republishing is not a release. skdb and skdb-dev-server are deliberately
-# absent: they bake in source and their tags carry release semantics, so they
-# stay manual.
+# republishing is not a release.
+#
+# skdb-dev-server is the exception. It bakes in source, so publishing it from
+# main IS a release of main, and its :latest tracks main rather than the last
+# tagged release. That is deliberate: left manual it went a year without a
+# rebuild and rotted to 1 critical / 18 high (#1363), and it is the only one of
+# these images that users actually run. A stale :latest is the worse failure.
+# Release-semantic tags (e.g. skdb-dev-server:quickstart) stay manual, via
+# bin/release_docker_skdb_dev_server.sh.
+#
+# skdb is absent but still gets rebuilt here, as a link-only dependency of
+# skdb-dev-server: bake forces such targets to output=cacheonly, so it is built
+# fresh and consumed but never pushed. Publishing skiplabs/skdb itself stays
+# manual.
 #
 # skiplang-bin-builder is published but never pulled by CI, which is why this
 # list cannot be derived from .circleci/ -- and why it went a year without a
 # rebuild (#1338).
 group "ci" {
   targets = [
-    "skiplang", "skiplang-bin-builder", "skip", "skdb-base",
+    "skiplang", "skiplang-bin-builder", "skip", "skdb-base", "skdb-dev-server",
   ]
 }
 


### PR DESCRIPTION
## Summary

`skiplabs/skdb-dev-server` is the only published image users actually **run** — the rest are build toolchain — and it was the only one left out of automated publishing. Left manual, it went ~a year without a rebuild and rotted to **1 critical / 18 high**: the worst-scoring image we publish, and the only one failing Scout's *high-profile vulnerabilities* policy.

#1363 fixed the vulnerable dependencies, but **that fix is inert until something rebuilds the image — and nothing does.** This adds it to the `ci` group, which both `.github/workflows/docker-publish.yml` and `bin/release_docker_ci_images.sh` derive their image list from, so the weekly run picks it up.

## ⚠️ This deliberately changes what the tag means

The group held toolchain images, whose final stages carry no repo source — so republishing them was *not* a release. **`skdb-dev-server` bakes in source**, so publishing it from main **is** a release of main:

> `skdb-dev-server:latest` now tracks **main as of the last publish**, not the last tagged release.

That's the trade: a year-stale `:latest` shipping a known critical is the worse failure, on the one image users run. Both the bake group comment and `bin/README.md` previously documented the **opposite** rationale, so both are updated — otherwise the docs would contradict the code.

**This is the judgement call in this PR.** Everything else is mechanical. If you'd rather preserve strict release semantics, the alternative is publishing a weekly date/sha tag and leaving `:latest` to releases — happy to switch.

Note `:quickstart` is **not** a safe fallback: nothing refreshes it either, and it hasn't been rebuilt since **2024-01-30**, so it is *further* behind on security fixes than the `:latest` this keeps current. The README now says so rather than pointing people at it.

## Bonus: `:latest` becomes multi-arch

The published `skdb-dev-server:latest` is currently a **single amd64 manifest**. Going through this workflow makes it a proper multi-arch index (amd64 + arm64) with provenance/SBOM attestations, like the other four. arm64 users are silently unserved today.

## Why `skdb` is not added

It's reached only as a **link-only dependency** of `skdb-dev-server`, and bake forces such targets to `output=cacheonly` — so it's rebuilt fresh and consumed, but never pushed. `skiplabs/skdb` stays manual. That's also what keeps the workflow's pushed-count assertion balanced.

## Verified (not assumed)

```
$ docker buildx bake -f docker-bake.hcl --print ci | jq '.group.ci.targets'
  skiplang, skiplang-bin-builder, skip, skdb-base, skdb-dev-server   # count: 5

$ ... | jq '.target | to_entries[] | "\(.key): \(.value.output)"'
  skdb: output=[{"type":"cacheonly"}]     # built fresh, never pushed, no digest

$ ./bin/check_ci_images.sh
  OK: 3 image(s) pulled by CircleCI, all published by bake group "ci"   # exit 0
```

- The *Collect pushed digests* step asserts `pushed == .group.ci.targets | length`. Now 5 targets → 5 images with a `containerimage.digest`; `skdb` carries none (cacheonly) and is already dropped by the metadata `jq` filter's `has("containerimage.digest")` guard.
- `check_ci_images.sh` asserts a **subset** relation (`skiplang-bin-builder` is already published but never pulled by CI), so growing the group keeps it valid.

## Expected impact

Once published, `skdb-dev-server` should go from `1C 18H` (2/7 policies, high-profile failing) to roughly `1C 2H` (3/7, high-profile passing) — measured locally in #1363. The residual `1C 2H` is inherited from the `eclipse-temurin:21` base itself.

## Test plan

- [x] `bake --print ci` → 5 targets; `skdb` resolves to `cacheonly`
- [x] `check_ci_images.sh` passes
- [x] Full multi-arch build of `skdb-dev-server` succeeds end-to-end (verified locally; the workflow uses native `ubuntu-24.04-arm`, so no emulation)
- [ ] CI green
- [ ] Dispatch `docker-publish` on **main after merge** to land the #1363 fix rather than waiting for Monday

## Reviewer notes

Two risks I raised on the first draft were **measured and refuted**, recorded here so they aren't re-litigated:

- **OOM / `SKIP_CAPACITY`** — not a risk. The 16 GiB reservation is lazily-faulted virtual address space, and the `skip` target already performs the same toolchain build on these same runners weekly. `sql/Dockerfile` taking no `SKIP_CAPACITY` is pre-existing and fine here (CircleCI needs it only because gen2 builders enforce a VM limit).
- **Disk** — not a risk. Runners report ~88–109 GB free against ~4–5 GB used.

Genuinely open: **`make build/skdb` has no arm64 coverage in any CI system**, and `skdb-dev-server`'s last arm64 build was 2024-01-30. The toolchain self-hosts on the native arm runner weekly, so the risk is narrow — but if arm64 fails, the merge step is skipped and no image republishes that week. Dispatching manually post-merge finds out immediately rather than on a Monday.

— Claude Opus 4.8 (1M context), effort xhigh