### PR TITLE
Exception: stop CSE merging the thread-local exception slot

### DIFF
--- a/skiplang/prelude/src/core/language/Exception.sk
+++ b/skiplang/prelude/src/core/language/Exception.sk
@@ -75,19 +75,26 @@ class RuntimeError(msg: String) extends Exception {
   }
 }
 
+// The three below read and write a single thread-local slot, so they are
+// untracked: they take no arguments (or a frozen one) and return frozen
+// types, which is everything CSE needs to merge two identical calls. Merging
+// two getExn() reads that straddle a write silently yields the stale value.
+@allow_tracked_call
 @cpp_extern("SKIP_getExn")
-native fun getExn(): Exception;
+untracked native fun getExn(): Exception;
 
 @export("SKIP_call0")
 fun call0(f: () -> void): void {
   f()
 }
 
+@allow_tracked_call
 @cpp_runtime
-native fun saveExn(exn: Exception): void;
+untracked native fun saveExn(exn: Exception): void;
 
+@allow_tracked_call
 @cpp_extern
-native fun replaceExn(exn: Exception): void;
+untracked native fun replaceExn(exn: Exception): void;
 
 class ExternalException(
   private eptr: SKStore.ExternalPointer,


### PR DESCRIPTION
Closes #1369 — the last of the bug class from #1342, and the one I said there I could not construct a repro for. I can:

```skip
class MyExn(tag: String) extends Exception {
  fun getMessage(): String { this.tag }
}

untracked fun main(): void {
  saveExn(MyExn("first"));
  a = getExn().getMessage();
  saveExn(MyExn("second"));
  b = getExn().getMessage();
  print_string("a=" + a);
  print_string("b=" + b);
}
```

| | before | after |
| --- | --- | --- |
| `a` | `first` | `first` |
| `b` | **`first`** | `second` |

The second `getExn()` is replaced by the first, so it returns the value from *before* the intervening write. That is a silent wrong read, not a missed side effect.

## Why

`getExn`, `saveExn` and `replaceExn` are one thread-local slot (`runtime64_specific.cpp:207-219`):

```c
thread_local void* exn;
void* SKIP_getExn() { return exn; }
void SKIP_saveExn(void* e) { exn = e; }
void SKIP_replaceExn(void* e) { exn = e; }
```

`getExn` takes no arguments and returns `Exception` (deep-frozen); the setters take a deep-frozen `Exception` and return `void`. All were tracked with no `@debug`, so `funCanCSE` and `canCSECall` both pass.

## Honest scoping

Only `getExn` silently returns wrong data. `saveExn` and `replaceExn` are annotated for correctness rather than because a merge is observable today — writing the same exception twice is idempotent on the 64-bit runtime, so merging two identical setter calls is benign there. The 32-bit path is not so lucky: `replaceExn` reads the *current* slot as a key and re-keys a map (`runtime32_specific.c:20-25` → `sk_types.ts:564-570`), so a dropped call drops a re-key. Leaving the setters tracked while fixing the getter would also be an odd split of one mechanism.

I also checked that the compiler does **not** resolve any of these by name — `saveExn` is `@cpp_runtime` and therefore registered in `runtimeFunctions`, but nothing consumes it, so the annotation has no effect on lowering.

## Verification

- The repro above flips from `first`/`first` to `first`/`second`.
- `vtry` — the only `getExn` caller in the tree, and tracked — still compiles and catches: `vtry: caught-ok`.
- Ordinary `try`/`catch` still works end to end.
- The eleven `replaceExn` callers in `Context.sk`'s `withRegion*` are tracked and compile unchanged; `std` typechecks.

`untracked` + `@allow_tracked_call`, consistent with #1353, #1365, #1368 and #1370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Opus 4.8 (1M context)