### PR TITLE
ci: make the all-checks gate a no-op job

### DIFF
--- a/.circleci/base.yml
+++ b/.circleci/base.yml
@@ -304,14 +304,15 @@ jobs:
           command: docker compose down --volumes
 
   # Aggregating gate: `generate_config.sh` makes this job depend on every other
-  # job it schedules, so `ci/circleci: all-checks` is a single, always-present
-  # status context that only passes once all triggered jobs pass. Make it a
-  # required check so auto-merge waits for the whole dynamically-generated set.
+  # job it schedules, so it is a single, always-present status context that only
+  # passes once all triggered jobs pass. It is the required check that auto-merge
+  # waits on, covering the whole dynamically-generated set.
+  #
+  # A `no-op` job needs no executor and consumes no credits. Note that under the
+  # GitHub OAuth integration, no-op jobs (unlike build jobs) report a context
+  # prefixed with the workflow name, so the required check is
+  # `ci/circleci: ci/all-checks`, not `ci/circleci: all-checks`. Changing this
+  # job's type, or the workflow name, renames that context and needs a matching
+  # branch protection update.
   all-checks:
-    docker:
-      - image: cimg/base:2025.01
-    resource_class: small
-    steps:
-      - run:
-          name: All triggered jobs passed
-          command: echo "All triggered CI jobs passed."
+    type: no-op

--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -166,9 +166,10 @@ fi
 
 # Schedule every triggered job in a single `ci` workflow, gated by `all-checks`.
 # The gate depends on all of them, so its status context (`ci/circleci:
-# all-checks`) only turns green once every triggered job has passed. It is
-# always emitted -- even when no jobs are triggered -- so it is a stable required
-# check that branch protection / auto-merge can wait on regardless of the diff.
+# ci/all-checks` -- see the note on the job in base.yml) only turns green once
+# every triggered job has passed. It is always emitted -- even when no jobs are
+# triggered -- so it is a stable required check that branch protection /
+# auto-merge can wait on regardless of the diff.
 echo "workflows:"
 echo "  ci:"
 echo "    jobs:"


### PR DESCRIPTION
Follow-up to #1335. The `all-checks` gate exists only to depend on the other
jobs — it never needed a container. This makes it a `type: no-op` job (no
executor, no credits), dropping the `small` container and `cimg/base` image pull
it was doing purely to `echo`. CircleCI documents this exact aggregating-gate
pattern for GitHub required status checks.

## Status-context rename — branch protection already updated

Under the **GitHub OAuth** integration this project uses, no-op jobs (unlike
build jobs) report a context prefixed with the *workflow* name. Confirmed on
this PR's own run:

```
ci/circleci: ci/all-checks = success     # was ci/circleci: all-checks
```

`main`'s required checks have already been repointed to
`ci/circleci: ci/all-checks` (alongside `ci/circleci: setup` and
`ci/circleci: fast-checks`). This PR reports that context **green**, so it
satisfies the requirement and is ready to merge. Merging it makes `main`'s
generated config emit `ci/circleci: ci/all-checks` on every pipeline, matching
the requirement.

Until this merges there is a transient mismatch: branch protection now expects
`ci/circleci: ci/all-checks`, but `main` still emits the old
`ci/circleci: all-checks`. So other open PRs won't report the required context
until they take this commit — **Update branch** (which `strict: true` forces
before merge anyway) re-runs their setup against the new config. Merging this PR
promptly is what un-wedges them.

## Cost/benefit

Saves a container spin-up + image pull per pipeline (a few seconds, ~2–3 credits
on `small`) and removes a failure mode the gate had no reason to carry: a
required check that could fail on an image pull.

— Claude Opus 4.8 (1M context)
