### PR TITLE
fix: make docker_build.sh's dockerfile-discovery portable to macOS

### DIFF
--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -163,9 +163,19 @@ ignore_body=$(
 # Ask bake which dockerfiles exist rather than hardcoding them. --print does
 # not need a working daemon. stderr is left attached so an HCL error is
 # visible instead of being swallowed.
-mapfile -t DOCKERFILES < <(
+#
+# Portable on purpose: avoid `mapfile` (bash 4+, absent from macOS's stock
+# /bin/bash 3.2) and `grep -P`/`\K` (GNU-only, absent from BSD grep) so this
+# runs the same under either toolchain, not just whatever happens to be
+# first on the invoking shell's PATH.
+DOCKERFILES=()
+while IFS= read -r df; do
+    DOCKERFILES+=("$df")
+done < <(
     docker buildx bake -f docker-bake.hcl --print "${KNOWN_IMAGES[@]}" \
-        | grep -oP '"dockerfile":\s*"\K[^"]+' | sort -u
+        | grep -o '"dockerfile":[[:space:]]*"[^"]*"' \
+        | sed -E 's/^"dockerfile":[[:space:]]*"([^"]*)"$/\1/' \
+        | sort -u
 )
 if [[ ${#DOCKERFILES[@]} -eq 0 ]]; then
     echo "Error: could not enumerate dockerfiles from 'docker buildx bake --print'" >&2


### PR DESCRIPTION
## Summary

`bin/build_docker_images.sh` (via `bin/docker_build.sh`) fails on macOS with:

```
bin/docker_build.sh: line 166: mapfile: command not found
grep: invalid option -- P
```

Both trace to one spot: dockerfile discovery uses `mapfile` (a bash 4+
builtin) and `grep -oP '...\K...'` (GNU-only PCRE support). The
script's `#!/bin/bash` shebang always resolves to macOS's stock
`/bin/bash` (3.2, kept old by Apple for licensing reasons) and BSD
`grep`, regardless of whatever newer bash/grep the invoking shell's
own `PATH` has — so this breaks for anyone running the script
directly on macOS, even with modern tools installed via Homebrew,
since a shebang bypasses interactive `PATH` customization.

## Fix

Replace the `mapfile` + `grep -oP` step with a portable read-loop and
a `grep -o` + `sed -E` extraction. Both GNU and BSD `grep`/`sed`
support `-o` and POSIX extended regex (`-E`); neither `mapfile` nor
PCRE features (`\K`) are used anymore.

## Testing

Verified the replacement three ways before trusting it:
- against a synthetic sample of `docker buildx bake --print`-shaped JSON;
- against the real `docker buildx bake -f docker-bake.hcl --print` output in this repo;
- the full pipeline explicitly invoked through `/bin/bash` +
  `/usr/bin/grep` + `/usr/bin/sed` (the actual constrained macOS
  system tools, not whatever's first on an interactive shell's PATH).

Then ran the fixed `bin/docker_build.sh --dry-run` end-to-end and
confirmed it gets past the previously-failing line and into real
`docker buildx bake` progress (loading Dockerfiles, pulling base
image metadata).