### PR TITLE
compiler: drop `private` from three module-crossing declarations

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -1136,7 +1136,7 @@ private fun needsQuotes(s: String): Bool {
 
 // This needs to be made reversible and deal correctly with name clashes.
 // See T22100866
-private fun mangle(name: String): String {
+fun mangle(name: String): String {
   i = name.getIter();
   String::tabulate(name.length(), _ -> {
     i.next().fromSome() match {

--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -40,7 +40,7 @@ private fun default_lib_name(output: ?String): String {
   }
 }
 
-private class Config{
+class Config{
   release: Bool,
   verbose: Bool,
   debug: Bool,

--- a/skiplang/compiler/src/OuterIstToIR.sk
+++ b/skiplang/compiler/src/OuterIstToIR.sk
@@ -4881,7 +4881,7 @@ private const kEmptyMethods: UnorderedMap<
   SFunctionID,
 > = UnorderedMap[];
 
-private fun makeOuterIst(context: mutable SKStore.Context): OuterIst.Program {
+fun makeOuterIst(context: mutable SKStore.Context): OuterIst.Program {
   // run the compiler front end from parsing to type checking
   typedAst = SkipMain.type_program(context);
   // OuterIst skeleton is built here, but code is done lazily


### PR DESCRIPTION
Prep for enforcing module-level `private` (#1343). Three declarations are marked `private` inside their modules but referenced from *outside* them — so they were never actually private; module-`private` simply isn't enforced today, which is why this compiles at all. This makes them public to state what is already true, so that turning enforcement on later doesn't break the build here.

Because the feature is unenforced, this is a **no-op at runtime** — the compiler rebuilds itself cleanly (verified: a full `make stage1` from this source succeeds).

| Declaration | Where | Referenced from |
| --- | --- | --- |
| `Config.Config` | `Config.sk:43` | ~56 sites across ~20 backend modules, as a type (`config: Config.Config`) |
| `OuterIstToIR.makeOuterIst` | `OuterIstToIR.sk:4884` | `compile.sk:236` (driver, global scope) |
| `AsmOutput.mangle` | `AsmOutput.sk:1139` | `compile.sk:618` (driver, global scope) |

`Config.Config` is a plain mislabel — it's the compiler's shared config record, threaded as a type through the whole backend. The other two are internal helpers the driver legitimately calls. Note `PrettyIR` has its *own* `private fun mangle` (`PrettyIR.sk:626`); that one is same-module and stays private — only `AsmOutput.mangle` is the cross-module one.

This is the first of the prep PRs from my analysis on #1343 (the harmless un-private migration). The obstack/`gContextSync` cross-package reaches are handled separately, by giving SKJSON/SKDB sanctioned SKStore wrappers rather than un-privating the internals.

— Claude Opus 4.8 (1M context)