### PR TITLE
Check push access before building, not after

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,8 +44,26 @@ jobs:
         shell: bash
         run: ./bin/check_ci_images.sh
 
-  build:
+  check-push-access:
     needs: [check-images]
+    # Needs the secrets, so it carries the same guard as build: fork PRs get
+    # none, and a skipped job skips build below it.
+    if: github.repository == 'SkipLabs/skip' && github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+      - name: Check the credentials can push every published image
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: ./bin/check_push_access.sh
+
+  build:
+    needs: [check-images, check-push-access]
     # Fork PRs get no secrets, so they would only fail; forks get no schedule.
     if: github.repository == 'SkipLabs/skip' && github.event_name != 'pull_request'
     strategy:

--- a/bin/README.md
+++ b/bin/README.md
@@ -25,6 +25,7 @@ Convenience wrappers are provided for common workflows:
 - `release_docker_skdb.sh` — push skdb image
 - `release_docker_skdb_dev_server.sh` — interactive push of dev server
 - `check_ci_images.sh` — check that every image CircleCI pulls is one we publish
+- `check_push_access.sh` — check the Docker Hub credentials can push every published image
 
 ## Publish the CI images
 
@@ -57,6 +58,13 @@ re-cuts it.
 rebuilt on every publish anyway, as a link-only dependency of `skdb-dev-server`:
 bake forces such targets to `output=cacheonly`, so it is built fresh and consumed
 but never pushed.
+
+Adding an image to that group also needs the Docker Hub credentials to be able
+to push it — an existing repository is not enough if the token is scoped to a
+list. The workflow checks this up front (`check_push_access.sh`) and fails in
+seconds rather than after building everything, because Docker Hub grants a token
+with the scopes you have instead of refusing the ones you don't, so a missing
+push right otherwise only surfaces at the final push.
 
 Use `release_docker_ci_images.sh` only when the workflow is unavailable. It
 publishes the same images from your machine, using your own credentials.

--- a/bin/check_push_access.sh
+++ b/bin/check_push_access.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Assert the configured Docker Hub credentials can push every image in the bake
+# "ci" group, before anything spends ten minutes building them.
+#
+# Docker Hub's token endpoint does not reject a scope you lack. It returns 200
+# with a token carrying only the scopes you DO have, and the push then fails
+# with "401 ... insufficient scopes" at the very end of the build, after every
+# image is already built. Asking for `pull,push` up front and checking what came
+# back turns that into a one-second failure.
+#
+# This is not hypothetical: adding skdb-dev-server to the "ci" group (#1371)
+# failed exactly this way, ten minutes in, on both architectures at once, and
+# because the push failed the merge job never ran -- so no image's :latest was
+# updated that run, not even the four whose credentials were fine.
+#
+# Reads the repository list from the same bake "ci" group the workflow pushes,
+# so this cannot disagree with what is actually published.
+#
+# Usage: DOCKERHUB_USERNAME=... DOCKERHUB_TOKEN=... check_push_access.sh
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO="$SCRIPT_DIR/.."
+
+: "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME must be set}"
+: "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN must be set}"
+
+# Bare `namespace/name` for every published image, e.g. skiplabs/skip.
+repos=()
+while IFS= read -r r; do
+    repos+=("$r")
+done < <(
+    docker buildx bake -f "$REPO/docker-bake.hcl" --print ci |
+        jq -r '.group.ci.targets[] as $t
+               | .target[$t].tags[0]
+               | sub(":.*$"; "")'
+)
+if [[ ${#repos[@]} -eq 0 ]]; then
+    echo 'Error: bake group "ci" resolved no images' >&2
+    exit 1
+fi
+
+# Decode a JWT payload. The token is base64url with the padding stripped, so
+# translate the alphabet and pad back to a multiple of four before decoding.
+decode_payload() {
+    local payload=$1
+    case $(( ${#payload} % 4 )) in
+        2) payload="$payload==" ;;
+        3) payload="$payload=" ;;
+    esac
+    printf '%s' "$payload" | tr '_-' '/+' | base64 -d 2>/dev/null
+}
+
+failed=()
+for repo in "${repos[@]}"; do
+    response=$(curl -sS --max-time 30 -u "$DOCKERHUB_USERNAME:$DOCKERHUB_TOKEN" \
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$repo:pull,push")
+
+    token=$(jq -r '.token // empty' <<< "$response")
+    if [[ -z "$token" ]]; then
+        # No token at all means the credentials themselves were rejected, which
+        # is a different failure from being granted too little.
+        echo "  $repo: FAILED to obtain any token" >&2
+        jq -r '.details // .errors // .' <<< "$response" 2>/dev/null | sed 's/^/    /' >&2
+        failed+=("$repo")
+        continue
+    fi
+
+    granted=$(decode_payload "$(cut -d. -f2 <<< "$token")" |
+        jq -r --arg repo "$repo" '
+            [.access[]? | select(.type == "repository" and .name == $repo)
+             | .actions[]?] | join(",")')
+
+    if [[ ",$granted," == *",push,"* ]]; then
+        echo "  $repo: push ok"
+    else
+        echo "  $repo: NO PUSH ACCESS (granted: ${granted:-none})" >&2
+        failed+=("$repo")
+    fi
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    cat >&2 <<EOF
+
+Error: the Docker Hub credentials cannot push ${#failed[@]} of ${#repos[@]} image(s):
+$(printf '  %s\n' "${failed[@]}")
+
+Grant the account behind DOCKERHUB_TOKEN push access to those repositories --
+if the token is scoped to a repository list, add them to it. A newly published
+image needs this even when the repository already exists on Docker Hub.
+EOF
+    exit 1
+fi
+
+echo "OK: credentials can push all ${#repos[@]} image(s) in bake group \"ci\""


### PR DESCRIPTION
## Problem

Docker Hub's token endpoint **does not reject a scope you lack**. It returns `200` with a token carrying only the scopes you *do* have — so a missing push right surfaces as `401 ... insufficient scopes` at the **final push**, after every image has already been built.

Reproduced against the live registry (anonymous, i.e. no push rights, asking for `pull,push`):

```
requested: pull,push
granted:   pull          ← silently downgraded, no error
```

That's what run [29592057098](https://github.com/SkipLabs/skip/actions/runs/29592057098) hit after #1371 added `skdb-dev-server` to the `ci` group: **~10 minutes in, on both architectures at once.** The credentials could push the four toolchain repositories but not `skdb-dev-server`, which the token predated.

The expensive part is the blast radius: because the push failed, the **`merge` job never ran**, so *no* image's `:latest` was updated that run — not even the four whose credentials were fine. One missing right silently disabled the entire weekly publish.

## Fix

`bin/check_push_access.sh` asks Docker Hub for a `pull,push` token per repository and asserts `push` actually came back, decoding the returned JWT's granted `access[].actions`. A new `check-push-access` job gates `build` on it.

The repository list is read from the **same bake `ci` group the workflow pushes**, so it cannot disagree with what's actually published — the same property `check_ci_images.sh` relies on.

Failure now takes about a second and names every repository missing the right:

```
Error: the Docker Hub credentials cannot push 1 of 5 image(s):
  skiplabs/skdb-dev-server

Grant the account behind DOCKERHUB_TOKEN push access to those repositories --
if the token is scoped to a repository list, add them to it. A newly published
image needs this even when the repository already exists on Docker Hub.
```

## Deliberately *not* checking pulls

You asked about pull rights too. I left them out on purpose: base image resolution is the **first** thing a build does, so a pull failure already fails within seconds — there's no wasted build to prevent. It's only the push, at the very end, that throws away the whole run. Happy to add it if you'd rather have the symmetry.

## Test plan

- [x] **The real failure mode is detected.** A genuine token granting `pull` but not `push` (anonymous against `skiplabs/skdb-dev-server`) → `NO PUSH ACCESS (granted: pull)`, exit 1.
- [x] **Bad credentials** (no token at all) → distinct error surfacing Hub's message (`incorrect username or password`), exit 1, all 5 repos named.
- [x] Scope matching is exact — `pull,push` and `push` pass; `pull` fails (no false positive from substring overlap).
- [x] `shellcheck --exclude SC2181 --exclude SC2002` clean (matches `Makefile:104`).
- [x] `actionlint` **v1.7.7** — the version CI pins — clean on the modified workflow.
- [x] Job graph verified: `check-push-access` needs `check-images`; `build` needs both; guard matches `build`'s, so fork PRs skip it and a skipped job skips `build`.
- [ ] CI green
- [ ] Next publish shows `check-push-access` passing in seconds

**Not verified:** the success path against real credentials — I have no Docker Hub auth here, so I could only prove the *deny* branches. The pass branch is the same parsed structure with `push` present, exercised on the next dispatch.

## Note

This is a follow-up to a failure I caused: #1371 added a published image without ensuring the token could push it. I flagged the runner-resource risks in that PR but missed this prerequisite, which was foreseeable. This makes the same mistake cheap for whoever adds the next image.

— Claude Opus 4.8 (1M context), effort xhigh