### PR TITLE
Bump bundled Gradle to 9.6.1 to clear a critical in skdb-base

### DIFF
--- a/sql/Dockerfile
+++ b/sql/Dockerfile
@@ -2,7 +2,7 @@ FROM skiplabs/skip AS base
 
 ARG TARGETARCH
 
-# Install system deps, Java 21 (Adoptium Temurin), and Gradle 9.3.1.
+# Install system deps, Java 21 (Adoptium Temurin), and Gradle 9.6.1.
 # The .sdkman stub dirs below are a build-time sentinel that lets
 # sql/ts/tests/service_common.mk skip its SDKMAN install (Java here comes
 # from apt above). Its version string only has to match that Makefile — it
@@ -18,10 +18,10 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
     apt-get install -q -y --no-install-recommends curl sqlite3 unzip zip temurin-21-jdk && \
     npm install -g bun && \
     npx playwright install-deps && \
-    curl -sL https://services.gradle.org/distributions/gradle-9.3.1-bin.zip -o /tmp/gradle.zip && \
+    curl -sL https://services.gradle.org/distributions/gradle-9.6.1-bin.zip -o /tmp/gradle.zip && \
     unzip -q /tmp/gradle.zip -d /opt && \
     rm /tmp/gradle.zip && \
-    ln -s /opt/gradle-9.3.1/bin/gradle /usr/local/bin/gradle && \
+    ln -s /opt/gradle-9.6.1/bin/gradle /usr/local/bin/gradle && \
     mkdir -p /root/.sdkman/bin \
       /root/.sdkman/candidates/java/20.0.2-tem \
       /root/.sdkman/candidates/gradle && \


### PR DESCRIPTION
## Summary

`skiplabs/skdb-base` carried **1 critical / 13 high** fixable advisories — the worst of the images we publish. Four of them, including the **only critical**, come from jars bundled inside the Gradle distribution we download, not from anything this repo builds:

```
/opt/gradle-9.3.1/lib/plugins/bcprov-jdk18on-1.81.jar   CVE-2025-14813 (CRITICAL)
/opt/gradle-9.3.1/lib/plugins/bcpg-jdk18on-1.81.jar     high
/opt/gradle-9.3.1/lib/plugins/plexus-utils-3.5.1.jar    high
/opt/gradle-9.3.1/lib/jackson-databind-2.16.1.jar       2 high
```

Gradle 9.6.1 ships bouncycastle **1.84** and plexus-utils **3.6.1**, clearing the critical (fixed in 1.81.1) and two highs.

## Measured (rebuilt image vs published)

| | published | this change |
|---|---|---|
| critical | **1** | **0** |
| fixable C/H | 1C **13H** | 0C **11H** |

**`jackson-databind` is deliberately not fixed here.** Gradle 9.6.1 bundles 2.18.6 and the advisories need **2.18.8**. Worth flagging the trap: the affected ranges are `>=2.10.0,<2.18.8` **and** `>=2.19.0,<2.21.4` — so "newer" is not sufficient; 2.18.6 is still inside the first range. That one is upstream Gradle's to bump.

The remaining 11 highs are all inherited from `skiplabs/skip` or vendored inside upstream distributions — `containerd` + `docker` inside `docker-ce-cli`/`buildx-plugin`, `setuptools` + `wheel` pinned by `python3-pip`, `picomatch` + `sigstore` bundled in npm. None are fixable from our Dockerfiles.

## Breaking-change assessment: none affecting this repo

The bump stays within Gradle **9.x**, which does not remove APIs across minors.

**What actually uses this Gradle** (`/usr/local/bin/gradle`), as opposed to the 8.1.1 wrapper:
- `sql/ts/tests/service_server.mk:25` — `gradle build`, run by the **skdb-wasm CI job**
- `sql/ts/tests/service_mux.sh:23` — `runMuxTestServer`
- `sql/server/deploy/chaos.sh:37` — `gradle run`

The `sql/server/{core,dev}` Docker builds use `../gradlew` (8.1.1) and are untouched by this.

**Verified empirically**, not reasoned:
- Built the Kotlin server with 9.6.1 in the rebuilt image — `BUILD SUCCESSFUL in 43s`, Kotlin plugin **2.1.20** compiles clean (this was my main concern: KGP 2.1.x against Gradle 9.6).
- The `Deprecated Gradle features ... incompatible with Gradle 10` notice is **pre-existing** — I ran the same build under the published 9.3.1 image and it emits the identical warning and also succeeds. This bump introduces no new deprecations.

## Test plan

- [x] `skdb-base` builds with Gradle 9.6.1; `gradle --version` reports 9.6.1
- [x] Kotlin server builds with it (`BUILD SUCCESSFUL`) — the CI path via `service_server.mk`
- [x] Deprecation warning confirmed pre-existing by A/B against 9.3.1
- [x] Scout delta measured on the rebuilt image (table above)
- [x] Residual 11H confirmed to be inherited/upstream-vendored, not ours
- [x] CI green (`skdb-wasm` exercises this Gradle)
- [ ] Republish after merge to realise it

## Note

`plexus-utils` dropped off the findings entirely even though 9.6.1 ships 3.6.1, below the "Fixed version: 4.0.3" Scout reported — a good reminder that the advisory's *affected range* is what matters, and why I measured the rebuilt image rather than predicting from version numbers.

— Claude Opus 4.8 (1M context), effort xhigh