### PR TITLE
skargo: don't compile the dispatch shim into dependency libraries

### DIFF
--- a/skiplang/skargo/Skargo.toml
+++ b/skiplang/skargo/Skargo.toml
@@ -8,6 +8,9 @@ toml = { path = "../toml" }
 cli = { path = "../cli" }
 semver = { path = "../semver" }
 
+[dev-dependencies]
+sktest = { path = "../sktest" }
+
 [[bin]]
 name = "skargo"
 main = "Skargo.main"

--- a/skiplang/skargo/src/build_context.sk
+++ b/skiplang/skargo/src/build_context.sk
@@ -98,6 +98,14 @@ fun should_merge(profile: String, manifest: Manifest): Bool {
   profile == "dev" && manifest.has_bins()
 }
 
+// Merging only ever applies to the workspace package. A dependency is built as
+// a plain library, even when it declares bins of its own: giving it the test
+// sources and the generated `SkipInternal.dispatch` shim would make every such
+// dependency define `dispatch`, and linking two of them collides.
+fun should_merge_unit(unit: Unit, ws_package: Package): Bool {
+  unit.pkg == ws_package && should_merge(unit.profile, unit.pkg.manifest)
+}
+
 // TODO: Return Result<...>
 fun create_bctx(
   gctx: GlobalContext,
@@ -121,7 +129,7 @@ fun create_bctx(
     opts.build_config,
     target_data.target_triple_for_arch(TargetArchHost()),
   );
-  unit_graph = build_unit_dependencies(roots, resolved_packages);
+  unit_graph = build_unit_dependencies(roots, resolved_packages, ws.package);
   target_dir = ws.target_dir();
   BuildContext{
     ws,
@@ -248,10 +256,16 @@ private fun find_named_target(
 fun build_unit_dependencies(
   roots: Array<Unit>,
   resolved_packages: Map<String, Package>,
+  ws_package: Package,
 ): UnitGraph {
   unit_graph = mutable UnitGraph[];
   for (unit in roots) {
-    build_unit_dependencies_for_unit(unit, resolved_packages, unit_graph)
+    build_unit_dependencies_for_unit(
+      unit,
+      resolved_packages,
+      ws_package,
+      unit_graph,
+    )
   };
 
   unit_graph.chill()
@@ -260,6 +274,7 @@ fun build_unit_dependencies(
 private fun build_unit_dependencies_for_unit(
   unit: Unit,
   resolved_packages: Map<String, Package>,
+  ws_package: Package,
   unit_graph: mutable UnitGraph,
   parents: List<Unit> = List.Nil(),
 ): void {
@@ -274,12 +289,13 @@ private fun build_unit_dependencies_for_unit(
     return void
   };
 
-  unit_deps = compute_deps(unit, resolved_packages);
+  unit_deps = compute_deps(unit, resolved_packages, ws_package);
   unit_graph![unit] = unit_deps;
   for (dep in unit_deps) {
     build_unit_dependencies_for_unit(
       dep,
       resolved_packages,
+      ws_package,
       unit_graph,
       List.Cons(unit, parents),
     )
@@ -289,6 +305,7 @@ private fun build_unit_dependencies_for_unit(
 private fun compute_deps(
   unit: Unit,
   resolved_packages: Map<String, Package>,
+  ws_package: Package,
 ): Array<Unit> {
   if (
     unit.target.kind is CustomBuildTarget _ &&
@@ -351,8 +368,7 @@ private fun compute_deps(
     | BinTarget _ -> false
     | LibTarget _ ->
       dep.kind is NormalDep _ ||
-        (should_merge(unit.profile, unit.pkg.manifest) &&
-          dep.kind is DevelopmentDep _)
+        (should_merge_unit(unit, ws_package) && dep.kind is DevelopmentDep _)
     | TestTarget _ -> dep.kind is DevelopmentDep _
     | CustomBuildTarget _ -> dep.kind is BuildDep _
     | HardlinkTarget _ -> false

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -723,13 +723,28 @@ private fun hash_of(
       dep_hashes.push(hash_of(dep, bctx, out))
     };
 
-    out.set(unit, compute_hash(unit, dep_hashes.collect(Array)))
+    out.set(
+      unit,
+      compute_hash(
+        unit,
+        dep_hashes.collect(Array),
+        should_merge_unit(unit, bctx.ws.package),
+      ),
+    )
   };
 
   out[unit]
 }
 
-private fun compute_hash(unit: Unit, dep_hashes: Array<Int>): Int {
+// NOTE: `merged` is part of the artifact's identity, not just of its
+// freshness: a merged library additionally embeds the package's test sources
+// and the generated dispatcher, so the same package built as the workspace
+// package and as a dependency must not share an `.sklib`.
+private fun compute_hash(
+  unit: Unit,
+  dep_hashes: Array<Int>,
+  merged: Bool,
+): Int {
   (
     unit.pkg.manifest.package_id,
     dep_hashes,
@@ -739,6 +754,7 @@ private fun compute_hash(unit: Unit, dep_hashes: Array<Int>): Int {
     unit.target.name,
     unit.target.kind,
     unit.build_opts,
+    merged,
   ).hash()
 }
 

--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -137,7 +137,7 @@ mutable class BuildRunner(
       // so they must be included in the fingerprint.
       if (
         unit.target.kind is LibTarget(LibraryTypeSklib _) &&
-        should_merge(unit.profile, unit.pkg.manifest)
+        should_merge_unit(unit, this.bctx.ws.package)
       ) {
         unit.pkg.manifest.test_target().each(t -> !srcs = srcs.concat(t.srcs));
       };
@@ -416,7 +416,7 @@ mutable class BuildRunner(
     // __merged (and all hardlinked bins/test) can link against it.
     if (
       unit.target.kind is LibTarget(LibraryTypeSklib _) &&
-      should_merge(unit.profile, unit.pkg.manifest)
+      should_merge_unit(unit, this.bctx.ws.package)
     ) {
       unit.pkg.manifest.test_target().each(t -> skc.args(t.srcs));
       dispatcher_path = this.generate_dispatcher(unit);

--- a/skiplang/skargo/tests/dispatch_collision.sk
+++ b/skiplang/skargo/tests/dispatch_collision.sk
@@ -1,0 +1,78 @@
+module alias T = SKTest;
+
+module SkargoDispatchTests;
+
+const kManifestDir: String = #env ("SKARGO_MANIFEST_DIR");
+
+private fun write_file(path: String, contents: String): void {
+  _ = system(`mkdir -p ${Path.dirname(path)}`);
+  FileSystem.writeTextFile(path, contents)
+}
+
+private fun package_toml(
+  name: String,
+  prelude: String,
+  deps: Array<String>,
+): String {
+  dep_lines = deps.map(d -> `${d} = { path = "../${d}" }\n`).join("");
+  `[package]\nname = "${name}"\nversion = "0.1.0"\n\n[dependencies]\nstd = { path = "${prelude}" }\n${dep_lines}\n[[bin]]\nname = "${name}"\nmain = "${name.uppercase()}.main"\n`
+}
+
+// Regression test for #1378: in the dev profile, `skargo` merges a package's
+// bin and test targets into a single binary dispatched at runtime by a
+// generated `SkipInternal.dispatch`. That shim used to be compiled into *every*
+// library whose package declared a bin, dependencies included, so as soon as
+// two such libraries were linked together the build failed with
+// `Name already bound: dispatch`.
+//
+// The smallest trigger is two bin-declaring packages anywhere in the dependency
+// closure, counting the root: an `app` with a `[[bin]]` depending on a `dep`
+// with a `[[bin]]`.
+@test
+fun test_bin_declaring_dependency_dev_build(): void {
+  // Only meaningful in the dev profile, where the merged binary that runs this
+  // test is also a full `skargo` and can be re-executed as one.
+  if (Environ.varOpt("SKARGO_BIN") != Some("test")) {
+    print_string(
+      "skipping: merged-mode only, run `skargo test` in the dev profile",
+    );
+    return void
+  };
+
+  skargo = Environ.current_exe();
+  prelude = Path.join(Path.dirname(kManifestDir), "prelude");
+  root = Path.join(kManifestDir, "target", "it-dispatch-collision");
+  _ = system(`rm -rf ${root}`);
+
+  write_file(
+    Path.join(root, "dep", "Skargo.toml"),
+    package_toml("dep", prelude, Array[]),
+  );
+  write_file(
+    Path.join(root, "dep", "src/lib.sk"),
+    "module DEP;\nfun main(): void {\n  void\n}\nmodule end;\n",
+  );
+  write_file(
+    Path.join(root, "app", "Skargo.toml"),
+    package_toml("app", prelude, Array["dep"]),
+  );
+  write_file(
+    Path.join(root, "app", "src/main.sk"),
+    "module APP;\nfun main(): void {\n  void\n}\nmodule end;\n",
+  );
+
+  proc = Posix.Popen::create{
+    args => Array[skargo, "build"],
+    // Route the merged binary to `skargo` rather than to this test harness.
+    env => Map["SKARGO_BIN" => "skargo"],
+    cwd => Some(Path.join(root, "app")),
+    stdout => true,
+    stderr => true,
+  }.fromSuccess();
+  _out = proc.stdout.fromSome().read_to_string().fromSuccess();
+  err = proc.stderr.fromSome().read_to_string().fromSuccess();
+
+  T.expectTrue(proc.wait().success(), `dev-profile build failed:\n${err}`)
+}
+
+module end;


### PR DESCRIPTION
Fixes #1378 — `cd sql && skargo build` (dev profile) failed at link time with `Name already bound: dispatch`.

## What was wrong

In the dev profile `skargo` merges a package's bin and test targets into a single `__merged` binary, dispatched at runtime by a generated `SkipInternal.dispatch` shim compiled into that package's library.

`should_merge()` answers a *workspace-level* question, but it was being handed arbitrary units. So every package in the dependency closure that declared a `[[bin]]` also got the shim — plus its test sources and its dev-dependencies — compiled into its `.sklib`. Link two of those and they collide.

`sql` depends on both `skjson` and `sqlparser`, which each declare a bin. The trigger turns out to be narrower than the issue guessed: **two bin-declaring packages anywhere in the closure, counting the root**, so a single bin-declaring dependency is enough. Verified on a two-package fixture.

Release builds were unaffected, which is why CI missed it: `Makefile:12` defaults to `SKARGO_PROFILE=release` and merging is dev-only.

## The fix

Three commits, each independently reviewable:

1. **Scope merging to the workspace package.** The invariant is stated once, as `should_merge_unit()`, and the workspace package is threaded through unit-graph construction. This also closes a latent *release*-mode variant: `compute_deps()` forces `profile => "dev"` onto build-script chains, so a `[build-dependencies]` package declaring a bin would otherwise enter merged mode even under `--release`.

2. **Make merged-ness part of a unit's artifact identity.** Without this the fix does not take effect on an existing `target/`: the dependency's hash is unchanged, and its fingerprint covers only source mtimes — which also do not change for a dependency with no `tests/` directory. It is reported `Fresh`, the stale `.sklib` (still carrying the dispatcher) is relinked, and the build keeps failing until someone runs `skargo clean`. A merged library genuinely *is* a different artifact, so this belongs in the hash. **This invalidates every existing `target/` directory once, in both profiles.**

3. **A regression test** — `skargo`'s first. It had none: `.circleci/generate_config.sh` picks `skip-package-tests` over `skip-package-build` purely on whether a `tests/` directory exists, so `skargo` was getting a bare `skargo build --all-targets`. Adding the directory flips the job over with no `.circleci` changes.

## Verification

Everything below was run locally against a `skargo` built from this branch.

| check | result |
| --- | --- |
| `cd sql && skargo build` (the issue's repro) | stock: `Name already bound: dispatch` → fixed: `Finished: dev target(s) in 141.8s` |
| `cd sql && skargo build --release --bin skdb` | `Finished: release target(s) in 143.5s` |
| `cd skiplang/skjson && skargo test` (merged mode at the root still works) | `Failures: 0, successes: 9` |
| `cd skiplang/skargo && skargo test` (the new test) | `[OK] SkargoDispatchTests test_bin_declaring_dependency_dev_build` |
| two-package fixture, stock `skargo` | reproduces in 28s |
| stale `target/` built by the old `skargo`, commit 1 only | dependency reports `Fresh`, collision persists — this is what commit 2 is for |
| stale `target/` built by the old `skargo`, commits 1+2 | everything recompiles, build succeeds |

## Notes for the reviewer

- **The new test costs CI time.** The fixture builds the prelude from source: `skiplang/skargo`'s job goes from 48s to 78s of build work locally, so budget 1–2 min extra on the `medium` executor. It only runs when `skiplang/{skargo,prelude,toml,cli,semver}` changes. Happy to drop it if that trade isn't wanted.
- **The test can only skip under `--release`,** since merged mode is dev-only and the trick it relies on — the test binary also being a full `skargo`, re-executed via `Environ.current_exe()` — only exists there. `skargo test` defaults to dev and `bin/run-sktest.sh` doesn't override it, so CI does exercise it.
- **This does not fix released images.** `/usr/bin/skargo` in `skiplabs/skiplang:latest` is built from the bootstrap, so #1378 stays reproducible for anyone on a released image until a separate bootstrap bump.

## Deliberately out of scope

Found while investigating; each wants its own change, and I'm happy to file them as issues if useful:

- `skiplang/skjson/Skargo.toml:10` has `sktest = { path = "../skiplang/sktest" }`, which resolves to a nonexistent `skiplang/skiplang/sktest`. It is inert only because the resolver keys solved packages by name and never re-fetches a name it has already seen.
- `skiplang/sqlparser/Skargo.toml` declares `[[bin]] main = "main"`, but the package has no `main`. `skargo build --bin test` there is broken before and after this PR.
- The diagnostic itself. `render_pos` (`skiplang/compiler/src/skipError.sk:254-270`) drops `InputSource.pkg_opt`, so both traces render the identical `File "…/__skargo_dispatch.sk"` and the message looks self-contradictory. Appending the package name looks like a ~5-line change that churns no active golden file.

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)