### PR TITLE
build: install llvm-$LLVM_VERSION-dev for the LLVM C API headers

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -50,7 +50,7 @@ for step in "${steps[@]}"; do
             wget -qO /etc/apt/keyrings/llvm.asc https://apt.llvm.org/llvm-snapshot.gpg.key
             echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
             apt-get update
-            apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION make openssh-client
+            apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev make openssh-client
 
             update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$LLVM_VERSION $PRIORITY \
                 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-$LLVM_VERSION \

--- a/skiplang/Dockerfile
+++ b/skiplang/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=lo
     apt-get install --quiet --yes --no-install-recommends \
         clang-${LLVM_VERSION} \
         llvm-${LLVM_VERSION} \
+        llvm-${LLVM_VERSION}-dev \
         lld-${LLVM_VERSION} && \
     update-alternatives \
       --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 101 \


### PR DESCRIPTION
The `llvm-N` package ships the tools and `libLLVM.so`, but **not** the `llvm-c/` headers or the static libraries. Without `llvm-N-dev`:

```
$ ls /usr/lib/llvm-20/include/llvm-c/     # empty
$ llvm-config --shared-mode
llvm-config: error: component libraries and shared library
$ llvm-config --libs                       # nothing
```

so nothing can compile or link against the LLVM C API.

After adding the package, on the same image:

```
$ ls /usr/lib/llvm-20/include/llvm-c/ | wc -l
29                                        # incl. Core.h, DebugInfo.h, TargetMachine.h
$ llvm-config --shared-mode
shared
$ llvm-config --libs
-lLLVM-20
```

## Coverage

Both toolchain install paths are updated, which together cover every image that carries LLVM:

| Image | Built from | Path |
|---|---|---|
| `skip`, `skiplang` | root `Dockerfile` | `bin/apt-install.sh skiplang-build-deps` |
| `skiplang-bin-builder` | `skiplang/Dockerfile` | inline `apt-get install` |

`.github/workflows/codeql.yml` also installs LLVM packages, but only `clang-20`/`lld-20` to build the C/C++ runtime for analysis — it never compiles against the C API, so it is deliberately left alone.

## Why

Groundwork for #1139 (use libLLVM instead of textual IR), which needs `llvm-c/Core.h` and friends available at build time. Landing the build dependency on its own keeps it out of the diff of the actual migration work.

Version-matched to the existing toolchain (`llvm-20-dev` 1:20.1.8, same as the installed `llvm-20`), and pulled in with `--no-install-recommends` like its neighbours. Verified installed on a `skiplabs/skip`-derived container.

`shellcheck bin/apt-install.sh` is clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
