### PR TITLE
skc: actually emit internal/private linkage

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -420,13 +420,21 @@ mutable class AsmDef{
       };
 
       // Locate the next upcoming special value.
+      //
+      // linkageOffset must be a candidate too, otherwise the cursor never
+      // stops there and the linkage keyword is never written. The `> i` guard
+      // both skips it once passed -- so the trailing writeExternal() below
+      // still returns Int::max -- and handles the -1 ("no linkage") case.
       min(
-        if (refsIndex == this.numDefinitionRefs) {
-          Int::max
-        } else {
-          refs[refsIndex].i0
-        },
-        if (debugIndex == dbg.size()) Int::max else dbg[debugIndex].i0,
+        if (this.linkageOffset > i) this.linkageOffset else Int::max,
+        min(
+          if (refsIndex == this.numDefinitionRefs) {
+            Int::max
+          } else {
+            refs[refsIndex].i0
+          },
+          if (debugIndex == dbg.size()) Int::max else dbg[debugIndex].i0,
+        ),
       )
     };
 

--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -1045,7 +1045,7 @@ fun writeOutputFiles(
         if (!d.hasDefinition()) {
           d.write(sstr, metadata, false)
         } else {
-          d.write(sstr, metadata, !def.forceExternal)
+          d.write(sstr, metadata, !d.forceExternal)
         }
       }
     }


### PR DESCRIPTION
`skc` has had a complete mechanism for emitting `internal`/`private` linkage since forever, and it has **never emitted a single byte of it**. Every definition in every module comes out external-linkage — not by design, but because of two independent bugs.

Fixes #1384, fixes #1385. One commit each; they must land together, so they are in one PR.

## 1. The cursor never stopped at `linkageOffset` (#1384)

`AsmDefBuilder.writeLinkage()` records the character offset at which the linkage keyword must be spliced into the emitted text, and `AsmDef.write`'s `writeExternal` closure does the splice when the cursor reaches it.

But the closure only runs when the cursor equals the *next stop*, and that stop was `min(next definition-ref, next debug-ref)` — `linkageOffset` was not a candidate. The cursor only ever landed on it by coincidence.

The `> i` guard on the new candidate does double duty: it skips the offset once passed, so the trailing `writeExternal()` still returns `Int::max` and its invariant holds; and it naturally excludes the `-1` sentinel meaning "no linkage to insert".

## 2. Linkage was read from the referrer, not the referent (#1385)

`writeOutputFiles` DFSes the reference graph, popping referents off a stack. The emit call consulted `def.forceExternal` — the *outer loop's* def, i.e. whichever referrer reached this node first — instead of `d.forceExternal`, the def actually being written. So linkage depended on an unrelated definition's flag and on traversal order.

Latent while nothing was emitted; live the moment the first commit lands, which is why they ship together.

## Verification

Built stage1 with the fix and compiled the same program with the unmodified stage0 and the fixed stage1:

| | before | after |
|---|---:|---:|
| `define internal` | 0 | **244** |
| globals `= private` | 0 | **282** |
| globals `= internal` | 0 | 1 |
| total `define` | 296 | 296 |
| total `declare` | 35 | 35 |

The definition and declaration counts are unchanged — the same symbols are emitted, only their linkage differs. Before the fix the emitted IR contains **zero** occurrences of `internal`/`private` anywhere.

Both modules pass `opt -passes=verify` cleanly, and both binaries link and produce identical correct output.

## Why it matters beyond correctness

Internal linkage is what lets LLVM infer attributes for functions that have bodies, and enables argument promotion, dead-function elimination and IPSCCP. None of that can fire while every symbol is externally visible. This is the root cause of the "every function is external-linkage" finding in #1381 and, per the plan in #1139, the largest single IPO unlock available.

I have deliberately **not** claimed a code-size or performance win here — that should be measured on top of this, not assumed. #1381 asserts it is the largest unlock; this PR makes it possible to substantiate that with numbers.

## Testing note

Verified locally as described above (build, IR diff, verifier, execution). I have not run the full compiler test suite locally; CI should be the gate on that, and the blast radius is every function in every module, so it deserves a careful look.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
