### PR TITLE
skjson: fix sktest dev-dependency path (../skiplang/sktest -> ../sktest)

### DIFF
--- a/skiplang/skjson/Skargo.toml
+++ b/skiplang/skjson/Skargo.toml
@@ -7,7 +7,7 @@ std = { path = "../prelude" }
 cli = { path = "../cli" }
 
 [dev-dependencies]
-sktest = { path = "../skiplang/sktest" }
+sktest = { path = "../sktest" }
 
 [[bin]]
 name = "skjson"


### PR DESCRIPTION
Fixes #1390

`skiplang/skjson/Skargo.toml:10` declared its `sktest` dev-dependency as `path = "../skiplang/sktest"`. Dependency paths are resolved relative to the declaring package's own directory, so from `skiplang/skjson` that path anchors at the non-existent `skiplang/skiplang/sktest`. Every other in-tree skiplang package (`prelude`, `cli`, `compiler`, `skargo`, `toml`, `skdate`, `semver`, `arparser`) uses `../sktest`; this makes skjson match.

The bad path was **inert**, not broken: skargo keys solved packages by name and short-circuits before ever fetching a package it has already solved. skjson's normal deps (`std`, `cli`) are activated before its dev-deps, and they transitively pull in `sktest` via correct `../sktest` paths, so `sktest` is already in the solved map by the time skjson's own dev-dep line is reached — the wrong path is never opened. It is still wrong, misleading to read, and a latent regression trap for anyone touching the resolver (see #1390 for the full mechanism). This PR is the one-character-class fix; the optional missing-path diagnostic suggested in the issue is left as independent follow-up.

## Verification

`cd skiplang/skjson && skargo test` (bootstrap skargo; this is a manifest-only change):

```
$ cd /tmp/pr-1390/skiplang/skjson && skargo test
    ...
    Compiling: sktest v0.1.1 [lib] (/tmp/pr-1390/skiplang/sktest)
    Compiling: skjson v0.2.0 [lib] (/tmp/pr-1390/skiplang/skjson)
    Compiling: skjson v0.2.0 [__merged] (/tmp/pr-1390/skiplang/skjson)
    Finished: dev target(s) in 33.537s
[OK] SKJSONTest testOrder
[OK] SKJSONTest testPatterns
[OK] SKJSONTest testPathMatch
[OK] SKJSONTest testJSON
[OK] SKJSONTest testUnit
[OK] SKJSONTest testRemoveAll
[OK] SKJSONTest testReconstruct
[OK] SKJSONTest testUnion
[OK] SKJSONTest testRemoveChunks
Failures: 0, successes: 9 (total: 9)
```

`skargo test -vv` confirms `sktest` resolves from the correct `.../skiplang/sktest` directory (i.e. `../sktest` relative to `skiplang/skjson`):

```
$ skargo test -vv 2>&1 | grep -i sktest
    Fresh: sktest v0.1.1 [build-script-sktest] (/tmp/pr-1390/skiplang/sktest)
    Fresh: sktest v0.1.1 [lib] (/tmp/pr-1390/skiplang/sktest)
```

Still green: 0 failures, 9 successes.

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)