### PR TITLE
Makefile: make `check` fail when any package fails, and skip node_modules/target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,9 @@ libbacktrace:
 
 .PHONY: check
 check: libbacktrace
-	find * -name Skargo.toml -exec sh -c 'bin/cd_sh $$(dirname {}) "skargo check"' \;
+	@set -e; \
+	find . \( -name node_modules -o -name target \) -prune -o -name Skargo.toml -print | \
+	while read -r manifest; do bin/cd_sh "$$(dirname "$$manifest")" "skargo check"; done
 
 .PHONY: check-ts
 check-ts:	


### PR DESCRIPTION
Fixes #1393

The root `Makefile` `check` target ran `skargo check` in every package via `find * -name Skargo.toml -exec sh -c ... \;`. `find` does not propagate an `-exec` command's exit status — a non-zero `-exec` just makes that predicate evaluate false — so `make check` exited 0 even when packages failed. Since `default: check check-ts` (`Makefile:4-5`), a bare `make` reported success while printing compile errors. Two smaller problems on the same line: `find *` pruned nothing, so it descended into `node_modules/` and `target/` and checked any `Skargo.toml` buried there; and `$(dirname {})` was unquoted.

## The change

```make
 check: libbacktrace
-	find * -name Skargo.toml -exec sh -c 'bin/cd_sh $$(dirname {}) "skargo check"' \;
+	@set -e; \
+	find . \( -name node_modules -o -name target \) -prune -o -name Skargo.toml -print | \
+	while read -r manifest; do bin/cd_sh "$$(dirname "$$manifest")" "skargo check"; done
```

Iterating in a `set -e` shell loop over `find`'s `-print` output makes the first `skargo check` failure propagate out; `-prune` skips the non-source trees. The target's `.PHONY` and `libbacktrace` dependency are unchanged.

## Verification

No real toolchain build. I reproduced the mechanism in a scratch fixture: a tree with `Skargo.toml` under two normal packages (`pkgA`, `pkgB`) plus buried copies under `node_modules/foo/` and `pkgA/target/host/dev/build/gen/`; the repo's real `bin/cd_sh` copied in verbatim; and a stub `skargo` on `PATH` (failing variant `exit 1`, succeeding variant `exit 0`, each echoing its cwd). The recipe body was driven both as an extracted script and through real `make` (recipe lines copied verbatim from this branch's Makefile, only the `libbacktrace` dep dropped).

**Old recipe (the bug) — exits 0 despite every package failing, and visits the pruned trees:**

```
$ ( cd fixture && PATH=stub-fail:$PATH bash old_recipe.sh )
make: Entering directory 'node_modules/foo'
make: Entering directory 'pkgA'
make: Entering directory 'pkgA/target/host/dev/build/gen'
make: Entering directory 'pkgB'
old recipe exit=0
```

**(a) New recipe + FAILING stub → non-zero (fail-fast on first failure):**

```
$ ( cd fixture && PATH=stub-fail:$PATH bash recipe.sh )
make: Entering directory './pkgB'
skargo check: FAILING in .../fixture/pkgB
recipe exit=1
```

**(b) New recipe + SUCCEEDING stub → exit 0:**

```
$ ( cd fixture && PATH=stub-ok:$PATH bash recipe.sh )
make: Entering directory './pkgB' ... make: Leaving directory './pkgB'
make: Entering directory './pkgA' ... make: Leaving directory './pkgA'
recipe exit=0
```

**(c) Pruning — only the two real packages are visited; `node_modules/` and `target/` manifests are not:**

```
$ ( cd fixture && PATH=stub-ok:$PATH bash recipe.sh 2>&1 ) | grep 'Entering directory'
make: Entering directory './pkgB'
make: Entering directory './pkgA'
```

**Driven through real `make` (verbatim recipe, exit status survives make):**

```
FAILING stub: make exit=2      # non-zero
SUCCEEDING stub: make exit=0
```

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)