### PR TITLE
skdate: emit rerun-if-changed with a backtick literal so date.c edits rebuild

### DIFF
--- a/skiplang/skdate/build.sk
+++ b/skiplang/skdate/build.sk
@@ -4,7 +4,7 @@ fun main(): void {
 
   if (!isWasm32) {
     src = "extern/src/date.c";
-    print_string("skargo:rerun-if-changed=${src}");
+    print_string(`skargo:rerun-if-changed=${src}`);
     Cc.Build().flags(Cc.kRecommendedCflags).file(src).compile("date")
   }
 }


### PR DESCRIPTION
Fixes #1396

`skiplang/skdate/build.sk:7` emitted its native dependency directive inside a **double-quoted** string:

```skip
    src = "extern/src/date.c";
    print_string("skargo:rerun-if-changed=${src}");
```

Skip only interpolates inside backticks, so this emits the eight literal characters `${src}`. skargo consumes the directive verbatim (`skiplang/skargo/src/build_runner.sk:44`) and stores it in the unit's `deps` file, which `fingerprint_for` then stats — so skargo faithfully watched a file named `${src}`, which never exists. Editing `extern/src/date.c` reported success while silently relinking the stale object.

The fix is one character: switch to a backtick template literal, matching the correct form in `skiplang/sktest/build.sk:10`.

```diff
-    print_string("skargo:rerun-if-changed=${src}");
+    print_string(`skargo:rerun-if-changed=${src}`);
```

## Verification

In `skiplang/skdate`, after `skargo build`, the recorded build-script dependency is now the real path, not the literal `${src}`:

```
$ cat -A target/.fingerprints/skdate-68d628aee84452f4/deps
extern/src/date.c
```

A no-op rebuild is fully Fresh:

```
$ skargo build
    Fresh: skdate v0.2.0 [build-script-skdate] (.../skiplang/skdate)
    Fresh: skdate v0.2.0 [lib] (.../skiplang/skdate)
    Fresh: skdate v0.2.0 [test] (.../skiplang/skdate)
    Finished: dev target(s) in 0.066s
```

Touching the C source now re-runs the build script and recompiles skdate (before the fix, per #1396, these lines were all `Fresh`):

```
$ touch extern/src/date.c && skargo build
    Fresh: skdate v0.2.0 [build-script-skdate] (.../skiplang/skdate)
    Running: skdate v0.2.0 [build-script-skdate] (.../skiplang/skdate)
    Compiling: skdate v0.2.0 [lib] (.../skiplang/skdate)
    Compiling: skdate v0.2.0 [test] (.../skiplang/skdate)
    Finished: dev target(s) in 5.478s
```

`skfmt -i build.sk` leaves the file unchanged apart from the edited line.

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)