### PR TITLE
sqlparser: drop dead [[bin]] stanza and give the package a CI job

### DIFF
--- a/.circleci/generate_config.sh
+++ b/.circleci/generate_config.sh
@@ -129,7 +129,6 @@ for dir in "${!SK_CHANGED[@]}"; do
         echo "      - compiler"
         NAMES+=(compiler)
         ;;
-      skiplang/sqlparser) ;;
       *)
         name=$(basename "$dir")
         if [ -d "$dir/tests" ]; then

--- a/skiplang/sqlparser/Skargo.toml
+++ b/skiplang/sqlparser/Skargo.toml
@@ -4,7 +4,3 @@ version = "0.1.0"
 
 [dependencies]
 std = { "path" = "../prelude" }
-
-[[bin]]
-name = "test"
-main = "main"


### PR DESCRIPTION
Fixes #1391.

`skiplang/sqlparser/Skargo.toml:8-10` declared a binary target whose entry point does not exist:

```toml
[[bin]]
name = "test"
main = "main"
```

There is no top-level `main` anywhere in the package (`grep -rn "fun main" skiplang/sqlparser/` is empty; the only top-level funcs are `SQLParser.*`, none of which is an unqualified `main`). sqlparser is a pure library — `Makefile:59,62` list its sources only as inputs to `skdb`, and nothing builds or runs a `sqlparser` binary. With the bin declared, every dev-profile `skargo` command (`build`/`check`/`test`) in the package failed: the dispatch shim compiled into the *library* carries a dangling `main()` reference, so even a plain type check was unbuildable.

It has been dead since day one. `git log --follow --diff-filter=A -- skiplang/sqlparser/Skargo.toml` points at `82656c68a` (2023-11-09, "[skdb] Introduce `SQLParser` package."), which added the manifest and 16 `src/*.sk` files but no `main` — `git show 82656c68a:sqlparser/Skargo.toml` already contains the stanza. This is *not* #1380: it reproduces identically with the pre-#1380 bootstrap and with a `skargo` built from #1380.

Why nobody noticed: `.circleci/generate_config.sh:132` carried a bare `skiplang/sqlparser) ;;` case that excluded the package from job generation. It was added by `823a12e32` — the same commit that introduced the `skip-package-build` fallback — so the exclusion existed only to keep CI green around the broken bin (that fallback job runs `skargo build --all-targets` in the dev profile, i.e. exactly the failing command).

## Changes (two independent commits)

1. **`skiplang/sqlparser/Skargo.toml`** — remove the dead `[[bin]]` stanza (and its orphaned blank line).
2. **`.circleci/generate_config.sh`** — remove the `skiplang/sqlparser) ;;` case so the package falls through to the default `*)` branch; having no `tests/` directory it lands in the build-only branch and gets a normal `skip-package-build` job (now green).

## Verification

Bootstrap `skargo`, run in the worktree (sqlparser depends only on `std`; with no bin it no longer enters merged mode):

```
$ cd skiplang/sqlparser && skargo build --all-targets
    Compiling: sqlparser v0.1.0 [lib] (…/skiplang/sqlparser)
    Finished: dev target(s) in 21.76s          # exit 0

$ cd skiplang/sqlparser && skargo check
    Fresh: sqlparser v0.1.0 [lib] (…/skiplang/sqlparser)
    Finished: dev target(s) in 0.034s          # exit 0
```

Both were exit 3 (`Unbound variable: main`) before this change.

```
$ bash .circleci/generate_config.sh </dev/null    # exit 0, no stderr
```

Its emitted config is valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"` → `YAML valid; top-level keys: ['version', 'commands', 'jobs', 'workflows']`), and with the special-case gone a diff touching `skiplang/sqlparser` now schedules the package's own job:

```
      - skip-package-build:
          dir: skiplang/sqlparser
          name: sqlparser
```

I did **not** build `sql`: the bootstrap `skargo` in this environment still hits the pre-#1380 dependency-`[[bin]]` collision there until the bootstrap is bumped, so a local `cd sql && skargo build` is not a valid check yet. That path is unaffected by this change (sqlparser stays a `std`-only library).

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)