### PR TITLE
skargo: interpolate the binary name in the dispatcher's "Unknown binary" error

### DIFF
--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -672,9 +672,9 @@ mutable class BuildRunner(
       if (test_entry_opt.isSome()) !names = names.concat(Array["test"]);
       lines.push(`  | _ ->`);
       lines.push(
-        `    print_error("Unknown binary '\`\${name}\`'. Set SKARGO_BIN to one of: ${names.join(
+        `    print_error(\`Unknown binary '\${name}'. Set SKARGO_BIN to one of: ${names.join(
           ", ",
-        )}");`,
+        )}\`);`,
       );
       lines.push("    skipExit(1)")
     };

--- a/skiplang/skargo/tests/unknown_binary_message.sk
+++ b/skiplang/skargo/tests/unknown_binary_message.sk
@@ -1,0 +1,88 @@
+module alias T = SKTest;
+
+module SkargoUnknownBinaryTests;
+
+const kManifestDir: String = #env ("SKARGO_MANIFEST_DIR");
+
+private fun write_file(path: String, contents: String): void {
+  _ = system(`mkdir -p ${Path.dirname(path)}`);
+  FileSystem.writeTextFile(path, contents)
+}
+
+// Regression test for #1397: the `SkipInternal.dispatch` shim skargo generates
+// for merged dev builds emitted its "Unknown binary" error as a double-quoted
+// string in the *generated* Skip source, so `${name}` was never interpolated
+// and the user saw the literal `${name}` (wrapped in stray backticks) instead
+// of the name that failed to dispatch.
+//
+// Building a single package with two bins forces the generated dispatcher to
+// take its fallback arm (the one-bin case emits `| _ -> <entry>()` and never
+// errors). Running the merged binary under an unknown `SKARGO_BIN` must report
+// the real name and must not leak the template literal.
+@test
+fun test_unknown_binary_message(): void {
+  // Only meaningful in the dev profile, where the merged binary that runs this
+  // test is also a full `skargo` and can be re-executed as one.
+  if (Environ.varOpt("SKARGO_BIN") != Some("test")) {
+    print_string(
+      "skipping: merged-mode only, run `skargo test` in the dev profile",
+    );
+    return void
+  };
+
+  skargo = Environ.current_exe();
+  prelude = Path.join(Path.dirname(kManifestDir), "prelude");
+  root = Path.join(kManifestDir, "target", "it-unknown-binary");
+  _ = system(`rm -rf ${root}`);
+
+  app_dir = Path.join(root, "app");
+  write_file(
+    Path.join(app_dir, "Skargo.toml"),
+    `[package]\nname = "app"\nversion = "0.1.0"\n\n[dependencies]\nstd = { path = "${prelude}" }\n\n[[bin]]\nname = "alpha"\nmain = "ALPHA.main"\n\n[[bin]]\nname = "beta"\nmain = "BETA.main"\n`,
+  );
+  write_file(
+    Path.join(app_dir, "src/alpha.sk"),
+    "module ALPHA;\nfun main(): void {\n  void\n}\nmodule end;\n",
+  );
+  write_file(
+    Path.join(app_dir, "src/beta.sk"),
+    "module BETA;\nfun main(): void {\n  void\n}\nmodule end;\n",
+  );
+
+  // Build the merged binary in the dev profile.
+  build = Posix.Popen::create{
+    args => Array[skargo, "build"],
+    // Route the merged binary to `skargo` rather than to this test harness.
+    env => Map["SKARGO_BIN" => "skargo"],
+    cwd => Some(app_dir),
+    stdout => true,
+    stderr => true,
+  }.fromSuccess();
+  _bout = build.stdout.fromSome().read_to_string().fromSuccess();
+  berr = build.stderr.fromSome().read_to_string().fromSuccess();
+  T.expectTrue(build.wait().success(), `dev-profile build failed:\n${berr}`);
+
+  // Run the merged binary under a name the dispatcher does not know.
+  merged = Path.join(Path.join(app_dir, "target", "host"), "dev", "__merged");
+  run = Posix.Popen::create{
+    args => Array[merged],
+    env => Map["SKARGO_BIN" => "bogus"],
+    cwd => Some(app_dir),
+    stdout => true,
+    stderr => true,
+  }.fromSuccess();
+  _rout = run.stdout.fromSome().read_to_string().fromSuccess();
+  rerr = run.stderr.fromSome().read_to_string().fromSuccess();
+  _ = run.wait();
+
+  T.expectTrue(
+    rerr.contains("Unknown binary 'bogus'"),
+    `expected the failed name interpolated into the error, got:\n${rerr}`,
+  );
+  T.expectFalse(
+    rerr.contains("${name}"),
+    `error still leaks the literal template, got:\n${rerr}`,
+  )
+}
+
+module end;


### PR DESCRIPTION
Fixes #1397.

`generate_dispatcher` (`skiplang/skargo/src/build_runner.sk:674-678`) emitted the fallback arm's message as a **double-quoted** string in the *generated* Skip source, with stray backticks around `${name}`:

```skip
    print_error("Unknown binary '`${name}`'. Set SKARGO_BIN to one of: alpha, beta");
```

Skip only interpolates inside backtick template literals, so `${name}` was never expanded — the user saw the literal `` `${name}` `` instead of the one piece of information the message exists to convey: the name that failed to dispatch.

The generator now emits a **backtick template literal** (and drops the stray backticks), so `<bins>` is still baked in at generator time while `${name}` interpolates when the generated dispatcher runs:

```skip
    print_error(`Unknown binary '${name}'. Set SKARGO_BIN to one of: alpha, beta`);
```

A regression test (`skiplang/skargo/tests/unknown_binary_message.sk`, in the self-re-exec style of `dispatch_collision.sk`) builds a two-bin fixture so the dispatcher takes its fallback arm, runs the merged binary under `SKARGO_BIN=bogus`, and asserts stderr reports the real name and does not leak the literal `${name}`.

## Verification

`cd skiplang/skargo && skargo test` (builds the modified skargo from source into the merged test binary, which the test then re-execs):

```
    Compiling: skargo v0.3.5 [__merged] (/tmp/pr-1397/skiplang/skargo)
    Finished: dev target(s) in 7.309s
[OK] SkargoUnknownBinaryTests test_unknown_binary_message
[OK] SkargoDispatchTests test_bin_declaring_dependency_dev_build
Failures: 0, successes: 2 (total: 2)
```

Generated dispatcher (fallback arm) and its runtime output under `SKARGO_BIN=bogus`:

```
$ grep print_error target/.../build/dispatch/__skargo_dispatch.sk
    print_error(`Unknown binary '${name}'. Set SKARGO_BIN to one of: alpha, beta`);

$ SKARGO_BIN=bogus ./__merged
Unknown binary 'bogus'. Set SKARGO_BIN to one of: alpha, beta
(exit=1)
```

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)