### PR TITLE
skargo: reject a [[bin]] named "test" at manifest-parse time

### DIFF
--- a/skiplang/skargo/src/manifest.sk
+++ b/skiplang/skargo/src/manifest.sk
@@ -304,6 +304,19 @@ private fun manifest_targets(
   };
 
   for (bin in manifest.bin) {
+    // `test` is reserved for the implicit test target below. In merged (dev)
+    // builds a bin and the test target sharing that name collide in the
+    // generated dispatcher, so reject it here with an actionable manifest error
+    // rather than surfacing a compile error in generated code (or, when there
+    // is no `tests/` directory, silently running the bin as `skargo test`).
+    if (bin.name == "test") {
+      invariant_violation(
+        `Failed to parse manifest at \`${Path.join(
+          package_root,
+          kManifestFile,
+        )}\`: a \`[[bin]]\` target may not be named "test"; that name is reserved for the package's implicit test target (run by \`skargo test\`). Rename the binary.`,
+      )
+    };
     res.push(Target(BinTarget(bin.main), bin.name, Array[]))
   };
 

--- a/skiplang/skargo/tests/bin_named_test.sk
+++ b/skiplang/skargo/tests/bin_named_test.sk
@@ -1,0 +1,70 @@
+module alias T = SKTest;
+
+module SkargoBinNamedTestTests;
+
+const kManifestDir: String = #env ("SKARGO_MANIFEST_DIR");
+
+private fun write_file(path: String, contents: String): void {
+  _ = system(`mkdir -p ${Path.dirname(path)}`);
+  FileSystem.writeTextFile(path, contents)
+}
+
+// Regression test for #1395: skargo names a package's implicit test target
+// `test`, so a `[[bin]]` also named `test` collides with it in merged (dev)
+// builds. That collision must be rejected at manifest-parse time with a clear
+// error naming the offending target and the manifest, rather than surfacing a
+// compile error inside generated dispatch code (or silently running the bin as
+// `skargo test`).
+@test
+fun test_bin_named_test_is_rejected(): void {
+  // Only meaningful in the dev profile, where the merged binary that runs this
+  // test is also a full `skargo` and can be re-executed as one.
+  if (Environ.varOpt("SKARGO_BIN") != Some("test")) {
+    print_string(
+      "skipping: merged-mode only, run `skargo test` in the dev profile",
+    );
+    return void
+  };
+
+  skargo = Environ.current_exe();
+  prelude = Path.join(Path.dirname(kManifestDir), "prelude");
+  root = Path.join(kManifestDir, "target", "it-bin-named-test");
+  _ = system(`rm -rf ${root}`);
+
+  write_file(
+    Path.join(root, "Skargo.toml"),
+    `[package]\nname = "binnamedtest"\nversion = "0.1.0"\n\n[dependencies]\nstd = { path = "${prelude}" }\n\n[[bin]]\nname = "test"\nmain = "BINNAMEDTEST.main"\n`,
+  );
+  write_file(
+    Path.join(root, "src/main.sk"),
+    "module BINNAMEDTEST;\nfun main(): void {\n  void\n}\nmodule end;\n",
+  );
+
+  proc = Posix.Popen::create{
+    args => Array[skargo, "build"],
+    // Route the merged binary to `skargo` rather than to this test harness.
+    env => Map["SKARGO_BIN" => "skargo"],
+    cwd => Some(root),
+    stdout => true,
+    stderr => true,
+  }.fromSuccess();
+  _out = proc.stdout.fromSome().read_to_string().fromSuccess();
+  err = proc.stderr.fromSome().read_to_string().fromSuccess();
+
+  T.expectFalse(
+    proc.wait().success(),
+    `build of a package with a bin named \`test\` should fail, but it succeeded:\n${err}`,
+  );
+  // The error must be actionable: it names the offending target and the
+  // manifest it came from.
+  T.expectTrue(
+    err.contains(`may not be named "test"`),
+    `error should explain the reserved name, got:\n${err}`,
+  );
+  T.expectTrue(
+    err.contains(Path.join(root, "Skargo.toml")),
+    `error should name the offending manifest, got:\n${err}`,
+  )
+}
+
+module end;


### PR DESCRIPTION
Fixes #1395.

## What

skargo names a package's implicit test target `test` unconditionally (`skiplang/skargo/src/manifest.sk:335`). In the dev profile, merged mode turns both bins and the test target into `HardlinkTarget`s carrying their own names, and the generated dispatcher emits one match arm per bin followed by an unconditional `| "test" -> <harness>()`. So a package declaring `[[bin]] name = "test"` collides with its own test suite, in two dev-only failure modes (both documented in #1395):

- **with a `tests/` directory** — the generated dispatcher gets two `| "test" ->` arms and the build fails with `The following pattern is unused: | "test"` pointing at a file under `target/.../build/dispatch/` the user never wrote;
- **without one** — `execTest` resolves the test binary by *name* (`commands/test.sk:93-95`) and matches the bin, so `skargo test` silently runs the binary, exits 0, and reports no tests.

This rejects the name at manifest-parse time instead — a static failure is far better than a compile error inside generated code or a silently-vacuous `skargo test`.

## Change

- `skiplang/skargo/src/manifest.sk` — in `manifest_targets`, where `[[bin]]` targets are built, reject `bin.name == "test"` before the loop pushes the target. The check is unconditional (it fires whether or not a `tests/` directory exists, covering both failure modes). It uses the same `invariant_violation` mechanism the surrounding manifest/`workspace.sk` code already uses for manifest errors, and names both the offending target and the manifest path.
- `skiplang/skargo/tests/bin_named_test.sk` — regression test in the self-re-exec style of `tests/dispatch_collision.sk`: writes a fixture package declaring `[[bin]] name = "test"`, drives `skargo build` on it through the merged dev binary (`Environ.current_exe()`, `SKARGO_BIN=skargo`), and asserts the child build fails with a message naming the reserved name and the manifest. Merged-mode only; early-returns otherwise.

## Interaction with #1391 (prerequisite for any bootstrap bump)

`skiplang/sqlparser/Skargo.toml` currently declares exactly `[[bin]] name = "test"` — that is #1391. This new check is enforced only by a skargo **built from source**, not by the bootstrap skargo the rest of CI uses, so CI stays green here. But **before any bootstrap bump picks up this check, #1391 must land first**: otherwise the bumped skargo would reject `sqlparser`'s manifest, and building `sql` (which depends on `sqlparser`) would then error. #1391 is the natural fix — `sqlparser` is a pure library whose `[[bin]]` `main` does not even exist — so this check and #1391 are complementary.

## Verification

`cd skiplang/skargo && skargo test` (bootstrap skargo orchestrates the build; the merged binary under test — and re-executed by the test — is compiled from this branch's source, so it carries the new check):

```
    Compiling: skargo v0.3.5 [lib] (…/skiplang/skargo)
    Compiling: skargo v0.3.5 [__merged] (…/skiplang/skargo)
    Finished: dev target(s) in 35.8s
[OK] SkargoBinNamedTestTests test_bin_named_test_is_rejected
[OK] SkargoDispatchTests test_bin_declaring_dependency_dev_build
Failures: 0, successes: 2 (total: 2)
```

The new test passes and the pre-existing `dispatch_collision` test still passes. Running the freshly-built skargo directly on a `[[bin]] name = "test"` fixture confirms the error text is clear and names both the target and the manifest:

```
$ SKARGO_BIN=skargo …/target/host/dev/skargo build
Invariant violation: Failed to parse manifest at `/tmp/tmp.m0fPVoVxKP/Skargo.toml`: a `[[bin]]` target may not be named "test"; that name is reserved for the package's implicit test target (run by `skargo test`). Rename the binary.
…
EXIT=134
```

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
