### PR TITLE
skc: drop textual LLVM type strings from NamedCall

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -2347,52 +2347,22 @@ private fun llvmWriteNamedCall(
 ): void {
   optinfo = asm.optinfo();
 
-  // Cast arguments as needed.
-  castArgs = call.casts.mapWithIndex((i, cast) -> {
-    if (cast == "") {
-      ""
-    } else {
-      arg = optinfo.getInstr(call.args[i]);
-      castVar = asm.llvmIdentifier("%cast");
-      asm.print("  %s = bitcast %N to %s, %D\n" % castVar % arg % cast % call);
-      cast + " " + castVar
-    }
-  });
-
-  retSrc = "";
   asm.print("  ");
   if (call.typ != tVoid) {
-    if (call.llvmRetCast.isEmpty()) {
-      asm.print("%n" % call);
-    } else {
-      !retSrc = asm.llvmIdentifier();
-      asm.print(retSrc);
-    };
+    asm.print("%n" % call);
     asm.print(" = ")
   };
 
   asm.print("call ");
-  if (call.llvmRetType.isEmpty()) {
-    asm.print("%A%t" % call % call)
-  } else {
-    asm.print(call.llvmRetType);
-  };
+  asm.print("%A%t" % call % call);
   asm.print(" @%s(" % call.name);
 
   call.args.eachWithIndex((i, input) -> {
     if (i > 0) asm.print(", ");
     arg = optinfo.getInstr(input);
-
-    castArgs.maybeGet(i) match {
-    | Some(castVar) if (castVar != "") -> asm.print(castVar)
-    | _ -> asm.print("%N" % arg)
-    }
+    asm.print("%N" % arg)
   });
   asm.print("), %D\n" % call);
-
-  if (!call.llvmRetCast.isEmpty()) {
-    asm.print("  %n = %s %s, %D\n" % call % retSrc % call.llvmRetCast % call)
-  }
 }
 
 private fun llvmWriteVTableRef(

--- a/skiplang/compiler/src/IR.sk
+++ b/skiplang/compiler/src/IR.sk
@@ -1161,22 +1161,10 @@ class NamedCall{
   // for example, that it's illegal to batch ObstackAlloc calls across such
   // a call.
   mayRelocatePointers: Bool = false,
-  // Normally we assume each argument is already the expected type, but
-  // sometimes they won't be, e.g. a C runtime function might want i8**
-  // but we call it i8*. In those cases you can specify the callee's type
-  // for each parameter here. Arguments whose indices are past the end of
-  // the casts array, or whose entry is "", will not receive any casts.
-  casts: Array<String> = Array[],
   // Interprocedural results are normally stashed in an OptDone in
   // Function.status. These are here because there is no target Function.
   canThrow: Bool,
   allocAmount: AllocAmount,
-  // If the called function returns a different type and needs a raw cast to
-  // turn it into the proper type retType can be used to declare the proper
-  // function type and retCast can be used to cast it to the typ. In the retCast
-  // string "%s" will be replaced by the value returned by the function.
-  llvmRetType: String = "",
-  llvmRetCast: String = "",
 } extends Stmt
 
 base class BinOp final {lhs: InstrID, rhs: InstrID} extends Stmt {

--- a/skiplang/compiler/src/Rewrite.sk
+++ b/skiplang/compiler/src/Rewrite.sk
@@ -913,11 +913,8 @@ mutable base class .RewriteBase{
     name: String,
     args: Array<InstrID>,
     mayRelocatePointers: Bool = false,
-    casts: Array<String> = Array[],
     canThrow: Bool,
     allocAmount: AllocAmount,
-    llvmRetType: String = "",
-    llvmRetCast: String = "",
     typ: Type,
     pos: Pos,
     id: InstrID = this.iid(),
@@ -932,11 +929,8 @@ mutable base class .RewriteBase{
         name,
         args,
         mayRelocatePointers,
-        casts,
         canThrow,
         allocAmount,
-        llvmRetType,
-        llvmRetCast,
       },
     )
   }

--- a/skiplang/compiler/src/gc.sk
+++ b/skiplang/compiler/src/gc.sk
@@ -293,7 +293,6 @@ mutable class .LowerLocalGC{
 
         _ = this.emitNamedCall{
           args => Array[this.gcNote, buf, this.constantInt(live.size()).id],
-          casts => Array["", "i8**"],
           typ => tVoid,
           pos,
           mayRelocatePointers => true,


### PR DESCRIPTION
Part of #1139 (use libLLVM instead of textual IR). This removes embedded LLVM IR *syntax* from the compiler's own IR data structures, so the future libLLVM backend has no textual type strings to interpret.

## What

`NamedCall` carried three fields holding raw LLVM type text:

- `casts: Array<String>` — per-argument textual callee types, used to emit `bitcast %arg to <type>` before a call;
- `llvmRetType: String` / `llvmRetCast: String` — a textual return-type override and a textual post-call cast.

`llvmRetType`/`llvmRetCast` had **no producer anywhere** — always empty, dead since before opaque pointers. `casts` had exactly one producer: the GC-collect call in `gc.sk`, setting `["", "i8**"]` to bitcast the buffer argument to `i8**`. Under opaque pointers that argument is already `ptr` and the callee parameter is `ptr`, so the emitted `bitcast ptr %buf to ptr` is a no-op — one of the leftovers explicitly flagged when opaque pointers landed (#946).

Removed: all three fields (`IR.sk`), the `emitNamedCall` parameters that forwarded them (`Rewrite.sk`), the `casts` usage (`gc.sk`), and the three now-dead branches in `llvmWriteNamedCall` (`AsmOutput.sk`).

## Verification

Built stage0 (from the recorded bootstrap = pre-change compiler) and stage1 (with this change) — same lineage, differing only by this patch — and compared their emitted IR on a GC-exercising program.

**Normalized structural diff** (SSA value numbers erased, so only real changes remain) is *exactly*:

```
removed:  32 ×  %x = bitcast ptr %buf to i8**
removed:  32 ×  call void @SKIP_Obstack_inl_collect(ptr %n, i8** %x, i64 2)
added:    32 ×  call void @SKIP_Obstack_inl_collect(ptr %n, ptr %buf, i64 2)
```

Nothing else. The buffer is now passed directly as `ptr` instead of through a no-op `i8**` cast; every call that had no casts (i.e. all of them but the GC call) is byte-identical. Collect-call count is unchanged (127 → 127); no-op `i8**` bitcasts go 32 → 0.

- `opt -passes=verify` clean on the new IR.
- Both binaries link and produce identical output.
- **Full compiler test suite: `Failures: 0, successes: 1724`.**

## Note

This touches the emission path used by every runtime call, hence the full-suite run rather than a spot check — but the common (no-cast) path is provably byte-identical, and the only behavioural change is the elimination of a dead no-op bitcast on GC-collect calls.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
