### PR TITLE
skargo: track the manifest in the fingerprint so [[bin]] edits rebuild (merged mode)

### DIFF
--- a/skiplang/skargo/src/build_runner.sk
+++ b/skiplang/skargo/src/build_runner.sk
@@ -133,12 +133,12 @@ mutable class BuildRunner(
   private mutable fun fingerprint_for(unit: Unit): Int {
     if (!this.fingerprints.containsKey(unit)) {
       srcs = unit.target.srcs;
+      merged_lib =
+        unit.target.kind is LibTarget(LibraryTypeSklib _) &&
+        should_merge_unit(unit, this.bctx.ws.package);
       // In merged mode, test sources are compiled into the lib,
       // so they must be included in the fingerprint.
-      if (
-        unit.target.kind is LibTarget(LibraryTypeSklib _) &&
-        should_merge_unit(unit, this.bctx.ws.package)
-      ) {
+      if (merged_lib) {
         unit.pkg.manifest.test_target().each(t -> !srcs = srcs.concat(t.srcs));
       };
       this.fingerprints![unit] = (
@@ -151,6 +151,14 @@ mutable class BuildRunner(
           )
           .collect(Array),
         this.bctx.unit_graph[unit].map(dep -> this.fingerprint_for(dep)),
+        // In merged mode, the generated dispatcher is derived from the
+        // manifest's bin/test target list, so a manifest edit must rebuild the
+        // lib even when no source file changed.
+        if (merged_lib) {
+          Some(FileSystem.getLastModificationTime(unit.pkg.manifest_path))
+        } else {
+          None()
+        },
         if (
           unit.target.is_build_script() &&
           unit.mode is CompileModeRunBuildScript _

--- a/skiplang/skargo/tests/manifest_fingerprint.sk
+++ b/skiplang/skargo/tests/manifest_fingerprint.sk
@@ -1,0 +1,120 @@
+module alias T = SKTest;
+
+module SkargoManifestFingerprintTests;
+
+const kManifestDir: String = #env ("SKARGO_MANIFEST_DIR");
+
+private fun write_file(path: String, contents: String): void {
+  _ = system(`mkdir -p ${Path.dirname(path)}`);
+  FileSystem.writeTextFile(path, contents)
+}
+
+// A two-bin `app` manifest. `alpha`/`beta` point at `alpha_main`/`beta_main`,
+// which lets the test swap the two entry points with a manifest-only edit.
+private fun app_toml(
+  prelude: String,
+  alpha_main: String,
+  beta_main: String,
+): String {
+  `[package]\nname = "app"\nversion = "0.1.0"\n\n[dependencies]\nstd = { path = "${prelude}" }\n\n[[bin]]\nname = "alpha"\nmain = "${alpha_main}"\n\n[[bin]]\nname = "beta"\nmain = "${beta_main}"\n`
+}
+
+// `untracked` (not just `@allow_tracked_call`) is load-bearing: these helpers
+// are called twice with identical arguments across a rebuild, and a plain
+// tracked wrapper around the untracked `Posix`/`system` primitives is itself
+// CSE-able, so the second call would be merged into the first and observe the
+// pre-rebuild result. `@allow_tracked_call` keeps them callable from the
+// tracked `@test`.
+@allow_tracked_call
+untracked fun run_build(skargo: String, app_dir: String): (Bool, String) {
+  proc = Posix.Popen::create{
+    args => Array[skargo, "build"],
+    // Route the merged binary to `skargo` rather than to this test harness.
+    env => Map["SKARGO_BIN" => "skargo"],
+    cwd => Some(app_dir),
+    stdout => true,
+    stderr => true,
+  }.fromSuccess();
+  _out = proc.stdout.fromSome().read_to_string().fromSuccess();
+  err = proc.stderr.fromSome().read_to_string().fromSuccess();
+  (proc.wait().success(), err)
+}
+
+@allow_tracked_call
+untracked fun run_bin(bin_path: String, name: String): (Bool, String, String) {
+  proc = Posix.Popen::create{
+    args => Array[bin_path],
+    // Select which bin the merged dispatcher runs.
+    env => Map["SKARGO_BIN" => name],
+    stdout => true,
+    stderr => true,
+  }.fromSuccess();
+  out = proc.stdout.fromSome().read_to_string().fromSuccess();
+  err = proc.stderr.fromSome().read_to_string().fromSuccess();
+  (proc.wait().success(), out, err)
+}
+
+// Regression test for #1394: in the dev profile, `skargo` merges a package's
+// bin and test targets into a single binary dispatched at runtime by a
+// generated `SkipInternal.dispatch` whose content is derived from the
+// manifest's `[[bin]]` list. `Skargo.toml` used to be absent from every unit's
+// fingerprint, so editing `[[bin]]` entries produced no rebuild and left the
+// binary dispatching according to the *previous* manifest. The fix adds the
+// manifest's mtime to the merged lib unit's fingerprint.
+//
+// (Distinct from #1380's `compute_hash(..., merged)` change, which put
+// merged-*ness* in a unit's artifact identity; this is about the merged
+// dispatcher's *contents* tracking the manifest.)
+@test
+fun test_manifest_edit_rebuilds_merged_bin(): void {
+  // Only meaningful in the dev profile, where the merged binary that runs this
+  // test is also a full `skargo` and can be re-executed as one.
+  if (Environ.varOpt("SKARGO_BIN") != Some("test")) {
+    print_string(
+      "skipping: merged-mode only, run `skargo test` in the dev profile",
+    );
+    return void
+  };
+
+  skargo = Environ.current_exe();
+  prelude = Path.join(Path.dirname(kManifestDir), "prelude");
+  root = Path.join(kManifestDir, "target", "it-manifest-fingerprint");
+  _ = system(`rm -rf ${root}`);
+
+  app_dir = Path.join(root, "app");
+  manifest = Path.join(app_dir, "Skargo.toml");
+  alpha_bin = Path.join(app_dir, "target/host/dev", "alpha");
+
+  write_file(manifest, app_toml(prelude, "ALPHA.main", "BETA.main"));
+  write_file(
+    Path.join(app_dir, "src/lib.sk"),
+    "module ALPHA;\nfun main(): void {\n  print_string(\"ALPHA v1\")\n}\nmodule end;\n\nmodule BETA;\nfun main(): void {\n  print_string(\"BETA v1\")\n}\nmodule end;\n",
+  );
+
+  (ok1, build_err1) = run_build(skargo, app_dir);
+  T.expectTrue(ok1, `first build failed:\n${build_err1}`);
+  (ran1, out1, run_err1) = run_bin(alpha_bin, "alpha");
+  T.expectTrue(ran1, `first run of alpha failed:\n${run_err1}`);
+
+  // `st_mtime` has one-second resolution, so guarantee the rewritten manifest
+  // lands in a strictly later second than the one the first build recorded.
+  _ = system("sleep 1");
+
+  // Manifest-only edit: swap the two bins' entry points. No source touched.
+  write_file(manifest, app_toml(prelude, "BETA.main", "ALPHA.main"));
+
+  (ok2, build_err2) = run_build(skargo, app_dir);
+  T.expectTrue(ok2, `second build failed:\n${build_err2}`);
+  (ran2, out2, run_err2) = run_bin(alpha_bin, "alpha");
+  T.expectTrue(ran2, `second run of alpha failed:\n${run_err2}`);
+
+  // After the swap, bin `alpha` must dispatch to `BETA.main`. If the manifest
+  // is not a fingerprint input the merged binary is stale and `out2 == out1`.
+  T.expectTrue(
+    out1 != out2,
+    `manifest edit did not rebuild the merged binary: bin \`alpha\` still ` +
+      `printed the pre-edit output.\nbefore: ${out1}after:  ${out2}`,
+  )
+}
+
+module end;


### PR DESCRIPTION
Fixes #1394.

## Problem

In the dev profile `skargo` merges a package's bin and test targets into a single `__merged` binary, dispatched at runtime by a generated `SkipInternal.dispatch` shim (`build_runner.sk:635-688`) whose content is derived from the manifest's `[[bin]]`/test target list. `Skargo.toml` was not an input to any unit's fingerprint: `fingerprint_for` (`build_runner.sk:133-191`) hashed only source mtimes, dependency fingerprints, and the build script's `rerun-if-changed` list. So editing `[[bin]]` entries (renaming a bin, repointing `main =`, adding/removing one) produced no rebuild, and left a binary dispatching according to the *previous* manifest until `skargo clean`.

Outside merged mode this is fine — a bin's entry point lives in its unit *kind* (`BinTarget(entry_point)`), which `compute_hash` already covers. In merged mode `generate_root_units` rewrites every bin/test to `HardlinkTarget("__merged")`, so the entry point survives only inside the generated dispatcher, which is regenerated only when the lib unit is judged dirty.

## Fix

`build_runner.sk` — add the manifest's last-modification time to the merged lib unit's fingerprint tuple, gated on `should_merge_unit` (exactly when the dispatcher is embedded). `Package.manifest_path` (`build_context.sk`) is reachable from this module.

This is **distinct from #1380's `compute_hash(…, merged)` change**, which put merged-*ness* into a unit's artifact *identity* (so a package built as workspace vs. as a dependency doesn't share an `.sklib`). This change makes the merged dispatcher's *contents* track the manifest that produced them.

## Regression test

`tests/manifest_fingerprint.sk`, following the self-re-exec pattern of `dispatch_collision.sk`: build a two-bin fixture app, run bin `alpha`, then swap the two bins' `main =` entry points with a manifest-only edit, rebuild, and run `alpha` again — asserting the output changed (the rebuild happened). The `run_build`/`run_bin` helpers are `untracked` + `@allow_tracked_call`: they are invoked twice with identical arguments across the rebuild, and a plain tracked wrapper around the untracked `Posix`/`system` primitives is itself CSE-able, so the second call would otherwise be merged into the first and observe the pre-rebuild result.

## Verification

`cd skiplang/skargo && skargo test` (the bootstrap `skargo` compiles this `skargo` source including the fix; the test then re-execs the freshly-built `skargo` via `Environ.current_exe()`):

```
    Compiling: skargo v0.3.5 [lib] (/tmp/pr-1394/skiplang/skargo)
    Compiling: skargo v0.3.5 [__merged] (/tmp/pr-1394/skiplang/skargo)
    Finished: dev target(s) in 4.814s
[OK] SkargoDispatchTests test_bin_declaring_dependency_dev_build
[OK] SkargoManifestFingerprintTests test_manifest_edit_rebuilds_merged_bin
Failures: 0, successes: 2 (total: 2)
```

Both the new test and the existing `dispatch_collision` test pass.

Teeth check — temporarily reverting only the fingerprint change (in a scratch copy, not committed) makes the new test fail while `dispatch_collision` still passes:

```
ExpectationError: manifest edit did not rebuild the merged binary: bin `alpha` still printed the pre-edit output.
before: ALPHA v1
after:  ALPHA v1

	expected: true
	actual: false

Failures: 1, successes: 1 (total: 2)
```

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
