### PR TITLE
skc: stop emitting duplicate zeroext on @cpp_extern declarations

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -3935,9 +3935,11 @@ fun llvmWriteFunctionDeclaration(
       // OuterIstToIR checks that user-defined native functions have
       // @cpp_extern or @cpp_runtime.
       asm.print("declare ");
-      if (f.funType.returnType.size() == 1) {
-        llvmWriteTypeCallAttribute(asm, f.funType.returnType[0], false, true)
-      };
+      // `llvmWriteReturnTypeName` already emits the return-type call
+      // attribute (e.g. `zeroext`) for the single-return case; emitting it
+      // here too produced `declare zeroext zeroext ...`. The function
+      // definition path (`llvmWriteFunctionDefinition`) relies on
+      // `llvmWriteReturnTypeName` alone, so match it.
       llvmWriteReturnTypeName(asm, f.funType.returnType);
       asm.print(" %n(" % asm);
       writeFunParams(f, asm);


### PR DESCRIPTION
Fixes #1388.

`llvmWriteFunctionDeclaration` emitted the return-type call attribute **twice** for `@cpp_extern` functions with a single sub-i32 return type: once via an explicit `llvmWriteTypeCallAttribute` call, and again inside `llvmWriteReturnTypeName` (which emits it for the single-return case, `writeAttributes` defaulting to true). The result:

```llvm
declare zeroext zeroext i8 @SKIP_String_getByte(ptr, i64)
```

The function *definition* path (`llvmWriteFunctionDefinition`) relies on `llvmWriteReturnTypeName` alone and emits a single `zeroext`, so the declaration path just had a redundant call. Removed it for parity.

## Verification

Built stage0 (pre-fix) vs stage1 (with fix) from the same bootstrap and compiled a program using `String.getByte` (an `@cpp_extern` returning `i8`):

```
declare zeroext zeroext i8 @SKIP_String_getByte(...)   # before  (count: 1 → 0)
declare zeroext i8 @SKIP_String_getByte(...)           # after   (single zeroext preserved)
```

`zeroext zeroext` occurrences 1 → 0; single `declare zeroext` declarations preserved. Full compiler test suite green (see stacked note).

## Stacking

Second in a small stack of independent emitter-bug fixes off `main`; the branch below it is #1382 (`--release`). They touch different regions of `AsmOutput.sk` and can merge in any order.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
