### PR TITLE
skc: fix --release by not emitting the undefined @SKIP_unreachable

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -3563,12 +3563,15 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
     llvmWriteIntrinsicCall(asm, x, "SKIP_throw", Array[e]);
     asm.print("  unreachable, %D\n" % x)
   | Unreachable{why} ->
+    // In debug builds, call the runtime to report which `Unreachable` was
+    // hit before the `unreachable` terminator. There is no release-mode
+    // equivalent symbol (`@SKIP_unreachable` is declared nowhere), so in
+    // release we emit only the terminator, which is what tells LLVM the
+    // path cannot be reached anyway.
     if (!asm.common.config.release) {
       asm.print("  call void @SKIP_unreachableWithExplanation(");
       asm.common.writeCStringRef(asm, UTF8String::make(why + "\0"));
       asm.print("), %D\n" % instr)
-    } else {
-      asm.print("  call void @SKIP_unreachable(), %D\n" % instr)
     };
     asm.print("  unreachable, %D\n" % instr)
   | ArrayUnsafeGet{id, typ, pos, obj, index, tupleIndex} ->


### PR DESCRIPTION
Fixes #1382. Stacked on #1388 (`fix-1388-zeroext`) for shared build verification; independent change (different region of `AsmOutput.sk`).

Lowering an `Unreachable` instruction in release mode emitted

```llvm
call void @SKIP_unreachable()
unreachable
```

but `@SKIP_unreachable` is declared and defined **nowhere** in the tree (the debug path uses `@SKIP_unreachableWithExplanation`, which exists). So any release build of a program containing a reachable `Unreachable` — e.g. the completeness `unreachable` after an exhaustive match — produced IR that fails to parse. **`skc --release` was broken for most non-trivial programs.**

The fix emits only the `unreachable` terminator in release mode (the LLVM idiom that marks the path unreachable); the debug-only diagnostic call is kept for debug builds.

## Verification

A three-line program with an exhaustive `match`:

```
# before (stage0):  skc --release  ->  error: use of undefined value '@SKIP_unreachable'
# after  (stage1):  skc --release  ->  exit 0, binary runs, prints the correct result
```

On the fixed compiler's `--release` IR: `@SKIP_unreachable` references = **0**, bare `unreachable` terminators = 157, and `opt -passes=verify` is clean. Full compiler test suite green.

Note: that `--release` was broken at all suggests it isn't exercised in CI; worth a follow-up to add a release-mode smoke build.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
