### PR TITLE
skc: name the package in source locations so cross-package collisions are distinguishable

### DIFF
--- a/ide/emacs/skip-flycheck.el
+++ b/ide/emacs/skip-flycheck.el
@@ -24,7 +24,7 @@
   "A syntax checker for skip."
   :command ("skargo" "check")
   :error-patterns
-  ((error line-start "File \"" (file-name) "\", line " line ", characters " column "-" end-column ":\n" (message) line-end))
+  ((error line-start "File \"" (file-name) "\"" (opt " (package " (one-or-more (not (any ")"))) ")") ", line " line ", characters " column "-" end-column ":\n" (message) line-end))
   :modes (skip-mode))
 
 (defun skip-flycheck-setup ()

--- a/skiplang/compiler/src/skipError.sk
+++ b/skiplang/compiler/src/skipError.sk
@@ -258,7 +258,11 @@ private fun render_pos(pos: FileRange): String {
   if (pos.file.path.startsWith(cwd)) {
     !path = path.stripPrefix(cwd + "/");
   };
-  file = `File "${path}"`;
+  file = pos.file.pkg_opt match {
+  | Some(pkg) if (pkg != FileCache.kAnonymousPackageName) ->
+    `File "${path}" (package ${pkg})`
+  | _ -> `File "${path}"`
+  };
 
   position = if (!pos.range.isNone()) {
     `, ${renderTextRange(pos.range)}:`


### PR DESCRIPTION
Fixes #1392.

## What's wrong

`render_pos` ([skiplang/compiler/src/skipError.sk:254-270](skiplang/compiler/src/skipError.sk#L254-L270)) renders a source location as `File "<path>"`, using only `pos.file.path`. But the compiler's identity for a source file is a *pair*: `FileCache.InputSource(pkg_opt: ?String, path: String)` ([skipParse.sk:15-28](skiplang/compiler/src/skipParse.sk#L15-L28)). Dropping `pkg_opt` means two sources from different packages that share an embedded path render identically.

That is exactly what #1378 produced. A generated `__skargo_dispatch.sk` was compiled into two dependency `.sklib`s; linking them collided, and the diagnostic printed the **same** `File "…/__skargo_dispatch.sk", line 2, characters 15-22:` twice — once for each package — with nothing to tell them apart.

## The change

Append ` (package <name>)` when `pkg_opt` is `Some` and not the anonymous sentinel (`FileCache.kAnonymousPackageName`, [skipParse.sk:221](skiplang/compiler/src/skipParse.sk#L221)). Reading the package off a position is already normal in the compiler (e.g. [skipNaming.sk:3700](skiplang/compiler/src/skipNaming.sk#L3700)). The `ide/emacs/skip-flycheck.el` error regex is updated to accept the optional suffix.

The anonymous case — a file compiled outside any package, which is **every** compiler golden today — is left byte-identical, so nothing churns.

## Verification

I built skc from this branch (`skc 0.3.3 (0dcdbdf9b)`) and exercised it directly.

**The feature works.** Compiling a source as a named package now labels it; the anonymous case is unchanged:

```
# my skc, anonymous (no --sklib-name):   unchanged
File "a.sk", line 2, characters 12-15:
# my skc, --sklib-name=a:                new
File "a.sk" (package a), line 2, characters 12-15:
# bootstrap skc, --sklib-name=a:         old — no package
File "a.sk", line 2, characters 12-15:
```

**Zero golden churn**, two ways:

- *Empirically*: the anonymous output of my skc and bootstrap skc is **byte-identical** (`diff` clean).
- *By enumeration*: all 826 active `.exp_err` goldens under `skiplang/compiler/invalid_tests/` reference only `File "invalid_tests/…"` paths — the test files themselves, compiled by the harness (`tests/tests.sk`) as CWD-relative anonymous inputs (`<output> main <input.sk>`, no `--sklib-name`). None reference a packaged path (the only prelude-referencing goldens are `.exp_err.todo`, i.e. inactive). So no active golden meets the `pkg_opt is Some` condition.

## Notes

- Like every compiler change, this reaches released images only after a bootstrap bump (maintainer-gated); `/usr/bin/skc` stays the bootstrap until then.
- Scope is deliberately just the package *name*. Naming the specific `.sklib` (path + hash) would additionally disambiguate two vendored copies of one package, but needs real plumbing (the name→sklib map lives only in `Config`); not worth it here.

— Mehdi, with Claude Opus 4.8 (1M context), high effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)