### PR TITLE
skc: detect wasm target by prefix for pointer size, matching isWasm()

### DIFF
--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -225,8 +225,13 @@ class Config{
     // Does LLVM provide an portable abstraction?
     // TODO: Make a proper `Target` class that holds the relevant platform-specific
     // data, with a constructor that takes the target triple.
-    stackAlign = if (target == "wasm32-unknown-unknown") 8 else 16;
-    ptrByteSize = if (target == "wasm32-unknown-unknown") 4 else 8;
+    // Use the same wasm predicate as `isWasm()` below (prefix match, not an
+    // exact triple). Otherwise a bare `wasm32` triple -- which skargo does
+    // construct -- takes the wasm code paths via `isWasm()` while still being
+    // laid out with 64-bit pointers here.
+    isWasmTarget = target.startsWith("wasm32");
+    stackAlign = if (isWasmTarget) 8 else 16;
+    ptrByteSize = if (isWasmTarget) 4 else 8;
     stackAlignStr = stackAlign.toString();
     ptrBitSize = ptrByteSize * 8;
     vtableByteSize = ptrByteSize;


### PR DESCRIPTION
Fixes #1386. Stacked on #1418 (`fix-1382-release`); independent change (touches `Config.sk`, not `AsmOutput.sk`).

`Config::make` chose `ptrByteSize`/`stackAlign` with an **exact-string** test `target == "wasm32-unknown-unknown"`, while `Config.isWasm()` — which gates the wasm code paths throughout `lower.sk`/`gc.sk` — uses `target.startsWith("wasm32")`.

The two disagree on any wasm triple not spelled exactly `wasm32-unknown-unknown`. A bare `wasm32` is not hypothetical: skargo constructs `TargetTriple("wasm32", …)` (`skiplang/skargo/src/build_runner.sk:630`). Such a target took the wasm code paths via `isWasm()` but was laid out with **8-byte pointers and 16-byte stack alignment — 64-bit layout on a 32-bit target**.

The fix routes both values through the same prefix predicate `isWasm()` uses, so they can no longer drift.

```skip
isWasmTarget = target.startsWith("wasm32");
stackAlign   = if (isWasmTarget) 8 else 16;
ptrByteSize  = if (isWasmTarget) 4 else 8;
```

## Verification scope (stated honestly)

- **Host: no regression, fully verified.** For any `x86_64-*` target the predicate is `false` either way, so host layout is byte-identical. Full compiler test suite green: **Failures: 0, successes: 1724**.
- **Normal wasm (`wasm32-unknown-unknown`): unchanged by construction** — `startsWith("wasm32")` is true, giving `ptrByteSize = 4`, exactly as the old exact match did.
- **The fixed case (bare `wasm32`): correct by inspection, not exercised end-to-end.** Emitting wasm IR needs a wasm32 `std` sklib, which isn't built in my sandbox, so I did not run a bare-`wasm32` compile. The change is a pure consistency correction — it makes `ptrByteSize` agree with the already-existing `isWasm()` predicate — so its correctness follows from that equivalence rather than from a new behavior I could measure. Worth a reviewer's eye on that reasoning.

The `TODO` at `Config.sk:226` (a proper `Target` class parsed from the triple) remains the real long-term fix; this removes the immediate inconsistency.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
