### PR TITLE
SKStore: sanctioned region/sync API so SKJSON and SKDB stop reaching into privates

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1549,11 +1549,16 @@ private native base class Page
 
 @debug
 @cpp_extern("SKIP_new_Obstack")
-private native fun newObstack(): Obstack;
+// Public part of the region API, alongside destroyObstack,
+// destroyObstackWithValue, and the preferred with* wrappers below. Prefer
+// withRegion/withRegionVoid/withRegionValue; reach for the raw pair only when
+// control flow escapes the region lexically (a loop `break`, or `skipExit`
+// from a program entry point) and so cannot be a `~>` lambda.
+native fun newObstack(): Obstack;
 
 @debug
 @cpp_extern("SKIP_destroy_Obstack")
-private native fun destroyObstack(Obstack): void;
+native fun destroyObstack(Obstack): void;
 
 @debug
 @cpp_extern("SKIP_destroy_Obstack_with_value")
@@ -2226,6 +2231,52 @@ fun runWithResult<T>(
     if (synchronizer.isNone()) gGlobalUnlock();
     Failure(exn)
   }
+}
+
+// Commit the context produced by `f` into `contexts`, inside a fresh region.
+//
+// `f` receives the current context for `fork` and returns the context to
+// commit, plus an optional callback for the synchronizer to run while it
+// holds the lock. Once the sync returns, readers are notified and the
+// actions it produced are run. The region is reclaimed on both the normal
+// and the exception path, and the returned `Contexts` outlives it.
+//
+// This is the counterpart of `runWithResult` for callers that own a
+// `Contexts` themselves (e.g. from `gUnsafeContextsGet`) rather than going
+// through the global registry and its lock. It exists so that such callers
+// do not need `newObstack`/`destroyObstack`/`gContextSync` directly.
+fun syncContexts(
+  contexts: Contexts,
+  fork: ?String,
+  synchronizer: Synchronizer,
+  sync: UInt32,
+  f: Context ~> (
+    Context,
+    ?((mutable Context, mutable Context, Context) ~> void),
+  ),
+): Contexts {
+  startTick = contexts.get(fork).getTick();
+  pos = newObstack();
+  (newContext, underLockF) = try {
+    f(contexts.get(fork))
+  } catch {
+  | exn ->
+    cexn = destroyObstackWithValue(pos, exn);
+    throw cexn
+  };
+  new = gContextSync(
+    startTick,
+    contexts,
+    newContext,
+    Some(synchronizer),
+    sync,
+    underLockF,
+    fork,
+  );
+  new.contexts.get(fork).notifyAll(startTick);
+  new.actions.each(fn -> fn());
+  destroyObstack(pos);
+  new.contexts
 }
 
 /*****************************************************************************/

--- a/skiplang/skjson/src/Main.sk
+++ b/skiplang/skjson/src/Main.sk
@@ -125,10 +125,10 @@ fun gen(): (Cli.Command, Cli.ParseResults ~> void) {
 
 fun execGen(args: Cli.ParseResults): void {
   for (i in Range(0, args.getInt("n"))) {
-    saved = SKStore.newObstack();
-    r = RandomJSON::mcreate(i);
-    print_string(r.genValue().prettyPrint());
-    SKStore.destroyObstack(saved);
+    SKStore.withRegionVoid(() ~> {
+      r = RandomJSON::mcreate(i);
+      print_string(r.genValue().prettyPrint())
+    })
   }
 }
 
@@ -152,12 +152,12 @@ fun execCheck(args: Cli.ParseResults): void {
     readLineOpt() match {
     | None() -> break void
     | Some(str) ->
-      saved = SKStore.newObstack();
-      checkJSON(schema, decode(str, x -> x)) match {
-      | CROk() -> void
-      | CRError(msg) -> print_error(msg)
-      };
-      SKStore.destroyObstack(saved)
+      SKStore.withRegionVoid(() ~> {
+        checkJSON(schema, decode(str, x -> x)) match {
+        | CROk() -> void
+        | CRError(msg) -> print_error(msg)
+        }
+      })
     }
   }
 }

--- a/sql/src/SqlEval.sk
+++ b/sql/src/SqlEval.sk
@@ -1808,33 +1808,17 @@ private mutable class SQLContext(
       ) ~> void,
     ),
   ): void {
-    context = this.contexts.get(this.fork);
-    startTick = context.getTick();
-    pos = SKStore.newObstack();
-
-    (newContext, underLockF) = try {
-      f(context.withGlobals(this.globals))
-    } catch {
-    | ex ->
-      cexn = SKStore.destroyObstackWithValue(pos, ex);
-      throw cexn
-    };
-    new = SKStore.gContextSync(
-      startTick,
+    // Read the globals into a local: `~>` is a frozen lambda and cannot
+    // capture `this` (a mutable SQLContext).
+    globals = this.globals;
+    this.!contexts = SKStore.syncContexts(
       this.contexts,
-      newContext,
-      Some(this.synchronizer),
-      this.sync,
-      underLockF,
       this.fork,
+      this.synchronizer,
+      this.sync,
+      context ~> f(context.withGlobals(globals)),
     );
-    this.!contexts = new.contexts;
-    !context = this.contexts.get(this.fork);
-    context.notifyAll(startTick);
-    new.actions.each(fn -> fn());
-    this.!globals = context.globals;
-
-    SKStore.destroyObstack(pos)
+    this.!globals = this.contexts.get(this.fork).globals;
   }
 
   mutable fun exec(
@@ -2473,51 +2457,51 @@ fun manageReactiveQuery(
 
 @wasm_export("SKIP_reactive_print_result")
 fun printReactiveQuery(queryID32: Int32): void {
-  saved = SKStore.newObstack();
-  try {
-    SKStore.runWithGc(SKDB.makeSqlContext(), context ~> {
-      queryID = queryID32.toInt();
-      (rqs, sds) = getReactiveQueryHandle(context);
-      rqs
-        .maybeGet(context, SKStore.IID(queryID))
-        .flatMap(v ~> v.value)
-        .each(queryInfo ->
-          sds.maybeGet(context, SKStore.IID(queryID)).each(rq ->
-            printResult(
-              context,
-              queryID,
-              rq.selectDir.dirName,
-              rq.fieldNames,
-              queryInfo.onlyChanges,
+  SKStore.withRegionVoid(() ~> {
+    try {
+      SKStore.runWithGc(SKDB.makeSqlContext(), context ~> {
+        queryID = queryID32.toInt();
+        (rqs, sds) = getReactiveQueryHandle(context);
+        rqs
+          .maybeGet(context, SKStore.IID(queryID))
+          .flatMap(v ~> v.value)
+          .each(queryInfo ->
+            sds.maybeGet(context, SKStore.IID(queryID)).each(rq ->
+              printResult(
+                context,
+                queryID,
+                rq.selectDir.dirName,
+                rq.fieldNames,
+                queryInfo.onlyChanges,
+              )
             )
-          )
-        );
-      SKStore.CStop(None())
-    })
-  } catch {
-  | exn -> print_error(exn.getMessage())
-  };
-  SKStore.destroyObstack(saved);
+          );
+        SKStore.CStop(None())
+      })
+    } catch {
+    | exn -> print_error(exn.getMessage())
+    }
+  })
 }
 
 @wasm_export("SKIP_delete_reactive_query")
 fun deleteReactiveQuery(queryID32: Int32): void {
-  saved = SKStore.newObstack();
-  try {
-    SKStore.runWithGc(SKDB.makeSqlContext(), context ~> {
-      queryID = queryID32.toInt();
-      getReactiveQueryHandle(context).i0.writeArray(
-        context,
-        SKStore.IID(queryID),
-        Array[QueryInfoFile(None())],
-      );
-      context.update();
-      SKStore.CStop(None())
-    })
-  } catch {
-  | exn -> print_error(exn.getMessage())
-  };
-  SKStore.destroyObstack(saved);
+  SKStore.withRegionVoid(() ~> {
+    try {
+      SKStore.runWithGc(SKDB.makeSqlContext(), context ~> {
+        queryID = queryID32.toInt();
+        getReactiveQueryHandle(context).i0.writeArray(
+          context,
+          SKStore.IID(queryID),
+          Array[QueryInfoFile(None())],
+        );
+        context.update();
+        SKStore.CStop(None())
+      })
+    } catch {
+    | exn -> print_error(exn.getMessage())
+    }
+  })
 }
 
 fun printTable(


### PR DESCRIPTION
The SKStore side of unblocking module-`private` enforcement (#1343), following PR #1376 (the compiler-internal mislabels). SKJSON and SKDB reach across package boundaries into SKStore's memory-region and context-sync primitives, which are `private native fun`; this only compiles because module-`private` isn't enforced yet.

## What this does

**`gContextSync` stays private, behind a new public `SKStore.syncContexts`.** This is the interesting one. `SQLContext._exec` in SKDB hand-rolled the whole commit path over its *own* `Contexts` — obstack, run `f`, `gContextSync`, notify, run actions, destroy. `syncContexts` is exactly that sequence (the counterpart of the existing `runWithResult` for callers that own a `Contexts` rather than driving the global registry), so `_exec` becomes a call and the last external use of `gContextSync` is gone.

**`newObstack` / `destroyObstack` become public.** This is a change from the "keep everything private" framing, and I want to flag it rather than bury it — happy to go the other way if you'd prefer. The reasoning:

- Their partner `destroyObstackWithValue` is *already* public, yet useless from outside, because the only way to obtain an `Obstack` to pass it was the private `newObstack`. The visibility split is incoherent — the same shape as `Config.Config` in #1376.
- Three call sites cannot be expressed as a `withRegion*` lambda, because their control flow escapes the region: `SqlTailer`'s poll loop `break`s the loop from inside the region, and the two `main`s (`sql`, `skjson`) `skipExit` from inside a program-lifetime region. A `~>` lambda can carry neither a `break` nor a mid-body `skipExit` out. Forcing them would mean restructuring a tailer loop and two entry points — real behavioural risk for no real gain.

So the public region API is `withRegion` / `withRegionVoid` / `withRegionValue` (preferred) plus the raw `newObstack` / `destroyObstack` / `destroyObstackWithValue` escape hatch, and `gContextSync` is fully internal.

## Opportunistic cleanup

Four sites that *did* fit a lambda — SKJSON's `execGen`/`execCheck` and SKDB's two `@wasm_export` reactive-query functions — moved to `withRegionVoid`. Each previously had `destroyObstack()` *outside* its `try`, so the region leaked on an uncaught throw; the wrapper reclaims it on both paths. Left alone: the two `main`s, the tailer, and the prelude's own tests, which legitimately use the now-public raw primitives.

## Correctness

The commit-path migration is the sensitive part. `syncContexts` reproduces `_exec`'s sequence exactly — same tick, same `gContextSync` arguments, same notify-then-actions order, same region reclaim on the exception path. The one deliberate difference: `_exec` reads `this.globals` into a local before the closure, because a frozen `~>` cannot capture `this`.

## Verification

`skargo build --release --bin skdb` succeeds (~123s), which compiles `std`, `skjson`, `sqlparser` and `skdb` against these changes. That is what CI's `skdb` job runs.

One caveat I'll be upfront about: I could not exercise the **dev**-profile build locally, because my installed `skargo` (0.3.5, from 5a9a73707) predates the #1378 dispatch fix (#1380) and still hits *that* bug on `sql/` — unrelated to this change (it reproduces on a clean tree). CI's toolchain has #1380, so it will cover the dev path.

I have **not** run SKDB's functional test suite (`make test-native`) locally — it needs a matched toolchain build I haven't done. The release build proves it compiles and links; it does not prove the commit path is behaviourally identical at runtime. Given this touches transaction commit, that's worth a maintainer eye or a green CI run before merge.

— Claude Opus 4.8 (1M context)
