### PR TITLE
[nfc] skjson: contain the ObjectHandle→ObjectProxy cast in a helper

### DIFF
--- a/skiplang/skjson/ts/binding/src/index.ts
+++ b/skiplang/skjson/ts/binding/src/index.ts
@@ -255,6 +255,25 @@ export function clone<T>(value: T): T {
   }
 }
 
+// Wrap an `ObjectHandle` in the `reactiveObject` traps, which are what make it
+// *observably* an `ObjectProxy`: reads of `__pointer`/`clone`/`toJSON`/`keys`
+// and of the underlying JSON fields are all synthesized by the handler, not by
+// the handle itself. TypeScript cannot model a `Proxy` retyping its target, so
+// this `ObjectHandle` -> `ObjectProxy` conversion is intrinsically unchecked.
+// We keep that one unavoidable cast confined and documented here rather than
+// widening the exported `ObjectProxy` type to structurally overlap
+// `ObjectHandle` (which would let a checked cast typecheck, but at the cost of
+// making internal handle members like `.pointer`/`.get`/`.has` spuriously
+// accessible on every proxy and defeating `noPropertyAccessFromIndexSignature`
+// for data keys of those names).
+function newObjectProxy(
+  handle: ObjectHandle<Internal.CJObject>,
+): ObjectProxy<{ [k: string]: Exportable }> {
+  return new Proxy(handle, reactiveObject) as unknown as ObjectProxy<{
+    [k: string]: Exportable;
+  }>;
+}
+
 function interpretPointer<T extends Internal.CJSON>(
   binding: Binding,
   pointer: Nullable<Pointer<T>>,
@@ -281,10 +300,7 @@ function interpretPointer<T extends Internal.CJSON>(
     }
     case Type.Object: {
       const oPtr = binding.SKIP_SKJSON_asObject(pointer);
-      return new Proxy(
-        new ObjectHandle(binding, oPtr),
-        reactiveObject,
-      ) as unknown as ObjectProxy<{ [k: string]: Exportable }>;
+      return newObjectProxy(new ObjectHandle(binding, oPtr));
     }
     case Type.Undefined:
     default:


### PR DESCRIPTION
### Context

An `ObjectProxy` is a `Proxy` wrapping an `ObjectHandle` in the `reactiveObject` traps. Those traps are what make it *observably* an `ObjectProxy` — `__pointer`, `clone`, `toJSON`, `keys`, and the underlying JSON fields are all synthesized by the handler, not by the handle. But `new Proxy(target, handler)` is typed as `typeof target`, i.e. `ObjectHandle`, and TypeScript cannot model a `Proxy` retyping its target. `ObjectHandle` and `ObjectProxy` don't structurally overlap (the private `fields` member), so the `ObjectHandle → ObjectProxy` conversion needs an unchecked cast — today a bare `as unknown as ObjectProxy<…>` at the call site.

### Change

Move that one unavoidable cast into a small `newObjectProxy` helper with a comment explaining why it is intrinsic. No behavior change; the exported `ObjectProxy` type is unchanged and stays faithful to the proxy's observable surface.

### Why this rather than #661

#661 removes the `unknown` by redefining `ObjectProxy` as `ObjectHandle<Internal.CJObject> & Base & { … }`. That does make a single checked `as` typecheck — but it also folds the whole `ObjectHandle` **class** into the *exported* type, which leaks handle-internal members onto every proxy. I verified this against the strict repo config:

- On the #661 type, `p.pointer`, `p.get("x")`, `p.has("x")`, and `p.getOwnPropertyDescriptor("x")` all typecheck as real callable/accessible members.
- At runtime the get-trap does **not** expose those — e.g. `proxy.get` resolves to `hdl.get("get")`, a *data-field* lookup. So the type claims methods the proxy doesn't have, and `noPropertyAccessFromIndexSignature` is silently defeated for any JSON key named `get`/`has`/`pointer`/`getOwnPropertyDescriptor`.

This is exactly the `.pointer` concern raised in the #661 review thread. The `unknown` cast isn't hiding a *checkable* fact — no cast, checked or not, can verify what the handler produces — so the safest move is to keep the type honest and confine the one intrinsic cast, not to widen the public type to make the cast "check."

If this is preferred, #661 can be closed in its favor.

### Verification

- `tsc` typechecks clean under the repo's strict config, including declaration emit (`declaration: true`) — no `TS4023`.
- The emitted `ObjectProxy` `.d.ts` is byte-identical to `main` (members-only, no `ObjectHandle` intersection).

— Mehdi (Claude Opus 4.8 (1M context), high reasoning effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)