### PR TITLE
fix: export PRETTIER_VERSION so the format hook uses the pinned prettier

### DIFF
--- a/bin/git_hooks/check_format.sh
+++ b/bin/git_hooks/check_format.sh
@@ -7,6 +7,17 @@ exec 1>&2
 PRETTIER_VERSION=$(jq -r '.devDependencies.prettier' package.json)
 BLACK_VERSION=$(grep '^black==' requirements-dev.txt | cut -d'=' -f3)
 
+# `check-file` runs under `parallel`, which executes the exported function in a
+# child shell that inherits only *exported* variables. Without this export,
+# $PRETTIER_VERSION is empty inside check-file and the command becomes
+# `npx prettier@`, which silently pulls the *latest* prettier instead of the
+# pinned one and then reports spurious formatting diffs whenever they disagree.
+export PRETTIER_VERSION
+if [ -z "$PRETTIER_VERSION" ] || [ "$PRETTIER_VERSION" = "null" ]; then
+    echo "Error: could not read prettier version from package.json devDependencies"
+    exit 1
+fi
+
 # Check black version (run `pip install -r requirements-dev.txt` if wrong version)
 if ! black --version 2>/dev/null | grep -q "$BLACK_VERSION"; then
     echo "Error: black==$BLACK_VERSION required. Run: pip install -r requirements-dev.txt"


### PR DESCRIPTION
Fixes #1429.

### Problem

The pre-commit format hook blocks commits with formatting diffs on files that are **already correctly formatted** (often on code the committer never touched), while running the hook's exact prettier command by hand passes — so it reads as flaky.

### Root cause

`bin/git_hooks/check_format.sh` reads the pinned version into a **non-exported** variable and then runs the per-file check via `parallel check-file {}`:

```sh
PRETTIER_VERSION=$(jq -r '.devDependencies.prettier' package.json)   # not exported
...
export -f check-file          # only the function is exported
git diff-index ... | parallel check-file {}
```

GNU `parallel` runs the exported function in a **child shell that inherits only exported variables**, so inside `check-file` `$PRETTIER_VERSION` is empty and the command becomes:

```
npx -y prettier@ --stdin-filepath <file> --loglevel debug
```

`npx prettier@` (empty version) resolves to **`prettier@latest`** (currently `3.9.6`), not the pinned `3.4.1`. When latest's formatting diverges from the pin — as 3.9.6 does on TS `type` unions — the hook flags already-correct code. It also means the hook has **never** actually been validating against the pinned prettier inside `check-file`.

### Fix

Split the assignment from an `export`, and fail fast if the version can't be resolved (so a broken lookup errors loudly instead of silently falling back to latest). One-line behavioral fix + a guard.

### Verification

- `npx -y 'prettier@' --version` → `3.9.6` (confirms the unpinned fallback).
- Instrumented hook run showed `FMT=[npx -y prettier@ …]` (empty version) despite `PRETTIER_VERSION=3.4.1` in the parent shell.
- With the fix, an end-to-end `git commit` staging a file that previously tripped the false positive passes the format check; the `parallel check-file` path reports CLEAN with `3.4.1` and FAILs without the export.

Minor follow-up (left out to keep this focused): line 25's `--loglevel debug` is an unknown option in prettier 3 (`--log-level` is correct) and is currently ignored — worth cleaning up separately.

— Mehdi (Claude Opus 4.8 (1M context), high reasoning effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)