### PR TITLE
skc: pass --target to clang++ on the native link path

### DIFF
--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -142,6 +142,12 @@ fun getLinkArgs(
       Array[
         "clang++",
         `-O${config.optLevel}`,
+        // Honor the requested target instead of letting clang default to the
+        // host. For the host target this is a no-op; it is the first step
+        // toward a real cross-compilation path (the module triple, still
+        // hardcoded in the preamble, is the remaining piece -- see the
+        // `Target` TODO in Config.sk).
+        `--target=${config.target}`,
         "-o",
         config.output,
         llFile,


### PR DESCRIPTION
Fixes #1387.

`Config.target` (default `llvm-config --host-target`, overridable via `--target`) was honored for sklib resolution and the wasm `-mtriple`, but **never passed to `clang++` on the native link path** — so clang silently defaulted to the host and `skc --target <non-host>` produced host code. The fix passes `--target=${config.target}` to the native `clang++` invocation.

## Scope (honest)

This is the **driver half** of native cross-compilation. The module triple is still hardcoded in `preamble64.ll`, and clang honors the module triple over `--target` for codegen — so *full* cross-compilation additionally needs the triple (and the missing `target datalayout`) emitted from `config.target`. That's the `Target`-class refactor noted at `Config.sk:226` and tracked in #1381 §6; this PR is the prerequisite step. For the host target, `--target=<host>` is a no-op.

## Verification

Built `stage1` from current `main` + this change:
- `--no-link` now emits `--target=x86_64-pc-linux-gnu` in the `clang++` argv (was absent).
- A full host build (with linking) compiles, links, and runs correctly.
- **Full compiler test suite: `Failures: 0, successes: 1724`.**

Note on process: an initial run showed a spurious `CompilerVersionCheck` failure caused by an unrelated stale-`GIT_COMMIT_HASH` build-script caching issue (my incremental rebuild left `skc --version` reporting the base commit while the test harness recomputed the current one). A clean `make stage1` — so `skc` and the harness bake the same hash — is green. Filed separately as #1431; not related to this change.

Cross-compilation itself isn't exercised here (this sandbox is host-only); the change is a no-op for host and the mechanism (`--target` reaching clang) is verified.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
