### PR TITLE
skc: declare and define SKIP_llvm_memset

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -7,6 +7,7 @@ declare void @SKIP_unreachableMethodCall(ptr, ptr)
 declare void @SKIP_unreachableWithExplanation(ptr)
 declare ptr @SKIP_intern(ptr)
 declare ptr @SKIP_llvm_memcpy(ptr, ptr, i64)
+declare void @SKIP_llvm_memset(ptr, i8, i64)
 
 ; LLVM intrinsics
 

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -6,6 +6,7 @@ declare void @SKIP_unreachableMethodCall(ptr, ptr)
 declare void @SKIP_unreachableWithExplanation(ptr)
 declare ptr @SKIP_intern(ptr)
 declare ptr @SKIP_llvm_memcpy(ptr, ptr, i64)
+declare void @SKIP_llvm_memset(ptr, i8, i64)
 
 ; LLVM intrinsics
 

--- a/skiplang/prelude/runtime/runtime.c
+++ b/skiplang/prelude/runtime/runtime.c
@@ -53,6 +53,10 @@ void* SKIP_llvm_memcpy(char* dest, char* val, SkipInt len) {
   return memcpy(dest, val, (size_t)len);
 }
 
+void SKIP_llvm_memset(char* dest, int8_t val, SkipInt len) {
+  memset(dest, val, (size_t)len);
+}
+
 /*****************************************************************************/
 /* Global context synchronization. */
 /*****************************************************************************/


### PR DESCRIPTION
Fixes #1383.

`AsmOutput.sk` emits `call void @SKIP_llvm_memset(ptr, i8 0, i64 <size>)` when a zeroed stack alloca is lowered, but — unlike its sibling `SKIP_llvm_memcpy` — the symbol was **declared and defined nowhere**. Any module reaching that emission path would fail to parse/link on an undefined value.

The fix mirrors `SKIP_llvm_memcpy`:
- `declare void @SKIP_llvm_memset(ptr, i8, i64)` in `preamble64.ll` and `preamble32.ll`, matching the emitted call's type exactly;
- `void SKIP_llvm_memset(char*, int8_t, SkipInt)` in `runtime.c`, a thin wrapper over libc `memset`.

## Verification

- **Symbol now defined** in the linked runtime lib: `nm` → `T SKIP_llvm_memset`.
- **Declaration present** in emitted IR (from the updated preamble): `declare void @SKIP_llvm_memset(ptr, i8, i64)`.
- **Resolves at link:** a C caller of `SKIP_llvm_memset` linked against the new runtime no longer reports it undefined (it was undefined against the old runtime).
- **Full suite green:** `Failures: 0, successes: 1724`.

The emission path is currently latent — I could not reach it from ordinary Skip programs (zeroed small allocas didn't stack-promote in my tests) — so this is a correctness-if-reached fix; it introduces no IR change for programs that don't hit it (suite unchanged). A follow-up (#1381 §4) can replace the wrapper with a real `llvm.memset` intrinsic, which the optimizer can expand and eliminate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
