### PR TITLE
SKStore: add withRegionLoop; use it in SKDB's tailer

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1951,6 +1951,35 @@ fun withRegionValue<T>(f: () ~> T): T {
   }
 }
 
+// Run `f` in a loop, each iteration inside a fresh region that is reclaimed
+// before the next one — and before the loop returns or a throw propagates. `f`
+// returns None() to keep looping or Some(v) to stop the loop with v.
+//
+// Unlike withRegion/withRegionVoid/withRegionValue, `f` is a `->` lambda: it may
+// read and write outer state and block (e.g. on a lock or condition wait), which
+// a frozen `~>` lambda cannot. In exchange the caller takes the same
+// responsibility as calling newObstack/destroyObstack directly — no value
+// allocated in the region may escape into outer state, since the region is torn
+// down after each iteration. (`Some`'s value is copied out, so it is safe to
+// return region-allocated data from the loop.)
+fun withRegionLoop<T>(f: () -> ?T): T {
+  loop {
+    saved = newObstack();
+    step = try {
+      f()
+    } catch {
+    | exn ->
+      cexn = destroyObstackWithValue(saved, exn);
+      replaceExn(cexn);
+      throw cexn
+    };
+    destroyObstackWithValue(saved, step) match {
+    | Some(v) -> break v
+    | None() -> void
+    }
+  }
+}
+
 // Run `f` on a throwaway copy-on-write clone of `context`, inside a fresh
 // region. The clone isolates any mutations `f` makes (they never touch
 // `context`), and the region reclaims the clone's memory when `f` returns —

--- a/sql/src/SqlTailer.sk
+++ b/sql/src/SqlTailer.sk
@@ -244,8 +244,7 @@ fun tailSub(
     }
   };
 
-  loop {
-    localObstack = SKStore.newObstack();
+  SKStore.withRegionLoop(() -> {
     tick = SKStore.withContext<?Int>(context -> {
       context.getSession(sessionID) match {
       | None() ->
@@ -352,43 +351,41 @@ fun tailSub(
     };
     !init = false;
 
-    !tailWatermark = tick match {
+    tick match {
     // if we cannot follow changes from here - regardless of whether
     // we want to - this is a failure to honour the request. i.e.
     // the since value is too far in the past. the user should be
     // made aware and take action, probably using the rebuild
-    // mechanism.
-    | None() -> break false
-    | Some(_) -> tick
-    };
+    // mechanism. Stop the loop with false.
+    | None() -> Some(false)
+    | Some(_) ->
+      !tailWatermark = tick;
 
-    lock = SKStore.unfreezeLock(sub.lock);
-    cond = SKStore.unfreezeCond(sub.cond);
-    SKStore.mutexLock(lock);
-    while ({
-      SKStore.withContext(newContext -> {
-        shouldWait =
-          follow &&
-          !tailShouldWake(
-            newContext,
-            sub,
-            SKStore.Tick(tailWatermark.fromSome()),
-            userIDOpt,
-          );
-        shouldWait
-      })
-    }) {
-      timeoutSecs = 10;
-      _ = SKStore.condTimedWait(cond, lock, UInt32::truncate(timeoutSecs));
-      print_raw(":" + tailWatermark.fromSome().toString() + "\n");
-      flushStdout();
-    };
-    SKStore.mutexUnlock(lock);
-    SKStore.destroyObstack(localObstack);
-    if (!follow) {
-      break true
+      lock = SKStore.unfreezeLock(sub.lock);
+      cond = SKStore.unfreezeCond(sub.cond);
+      SKStore.mutexLock(lock);
+      while ({
+        SKStore.withContext(newContext -> {
+          shouldWait =
+            follow &&
+            !tailShouldWake(
+              newContext,
+              sub,
+              SKStore.Tick(tailWatermark.fromSome()),
+              userIDOpt,
+            );
+          shouldWait
+        })
+      }) {
+        timeoutSecs = 10;
+        _ = SKStore.condTimedWait(cond, lock, UInt32::truncate(timeoutSecs));
+        print_raw(":" + tailWatermark.fromSome().toString() + "\n");
+        flushStdout();
+      };
+      SKStore.mutexUnlock(lock);
+      if (!follow) Some(true) else None()
     }
-  }
+  })
 }
 
 module end;


### PR DESCRIPTION
`SqlTailer`'s replication poll loop is the one consumer that couldn't use the `withRegion*` wrappers: its region must span a `mutex`/`condTimedWait` while mutating outer state (`init`, `tailWatermark`) and it breaks out of the loop mid-region — none of which a frozen `~>` lambda allows. So it hand-rolled `newObstack`/`destroyObstack`. This adds a helper for exactly that shape and uses it.

## `SKStore.withRegionLoop`

```skip
fun withRegionLoop<T>(f: () -> ?T): T
```

Runs `f` in a loop, each iteration in a fresh region reclaimed before the next one — and before the loop returns or a throw propagates, **including on break**. `f` returns `None()` to keep looping or `Some(v)` to stop with `v`; the value is copied out of the region, so returning region-allocated data is safe. Unlike the `~>` wrappers, `f` is a `->` lambda, so it may read/write outer state and block — with the same "don't let region-allocated values escape into outer state" responsibility as calling the raw pair by hand.

## The SqlTailer change

The loop body is unchanged except for the control flow, which maps one-to-one:

| before | after |
| --- | --- |
| `break false` (can't follow changes) | `Some(false)` |
| `break true` (`!follow`) | `Some(true)` |
| fall through → next iteration | `None()` |

It also fixes two latent leaks in the original: the `break false` path jumped over `destroyObstack`, and a throw from the iteration body did too. `withRegionLoop` reclaims the region on both.

## Verification

- `skargo build --release --bin skdb` green.
- **Ran the actual tailer**: `subscribe` to a table, then a one-shot `tail` of the session — output the inserted rows and a checkpoint, exit 0. Built the *origin* `SqlTailer` the same way and diffed: **byte-identical output** (`^t / 1|100 / 2|200 / :5`). So the restructure is behaviorally faithful on the real replication path, not just a typecheck.
- I did not run `make test-native` (matched-toolchain build), and the `break false` "can't follow changes" path is exercised only by inspection (it's a direct `break false` → `Some(false)` swap), not at runtime — CI's `skdb` job covers the fuller suite.

## Note

Independent of #1436 (the entry-point PR) — different regions of `Context.sk`, no conflict. Once both land, #1436's `newObstack` doc comment names SqlTailer as the raw-pair "motivating case"; with this PR that's no longer true, so it's worth a one-line follow-up (or fold into whichever merges second).

— Claude Opus 4.8 (1M context)
