### PR TITLE
preamble: mark the throwing runtime entry points noreturn cold

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -1,10 +1,10 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32"
 
-declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr)
-declare void @SKIP_throw(ptr)
-declare void @SKIP_unreachableMethodCall(ptr, ptr)
-declare void @SKIP_unreachableWithExplanation(ptr)
+declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr) noreturn cold
+declare void @SKIP_throw(ptr) noreturn cold
+declare void @SKIP_unreachableMethodCall(ptr, ptr) noreturn cold
+declare void @SKIP_unreachableWithExplanation(ptr) noreturn cold
 declare ptr @SKIP_intern(ptr)
 declare ptr @SKIP_llvm_memcpy(ptr, ptr, i64)
 declare void @SKIP_llvm_memset(ptr, i8, i64)

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -1,9 +1,9 @@
 target triple = "x86_64-pc-linux-gnu"
 
-declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr)
-declare void @SKIP_throw(ptr)
-declare void @SKIP_unreachableMethodCall(ptr, ptr)
-declare void @SKIP_unreachableWithExplanation(ptr)
+declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr) noreturn cold
+declare void @SKIP_throw(ptr) noreturn cold
+declare void @SKIP_unreachableMethodCall(ptr, ptr) noreturn cold
+declare void @SKIP_unreachableWithExplanation(ptr) noreturn cold
 declare ptr @SKIP_intern(ptr)
 declare ptr @SKIP_llvm_memcpy(ptr, ptr, i64)
 declare void @SKIP_llvm_memset(ptr, i8, i64)


### PR DESCRIPTION
Fixes #1439 (part of #1381 §2).

The four unconditionally-throwing runtime entry points were declared without attributes:
```llvm
; before
declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr)
declare void @SKIP_throw(ptr)
declare void @SKIP_unreachableMethodCall(ptr, ptr)
declare void @SKIP_unreachableWithExplanation(ptr)
; after: + noreturn cold on each
```

`skc` lowers `throw` / `Unreachable` as a call to one of these followed by `unreachable`. Marking the callees `noreturn cold` lets LLVM treat the continuation as dead and lay the throw/abort paths out of line.

## Soundness

Verified in the runtime that each never returns:
- `SKIP_throw` → `throw skip::SkipException` (SKIP64) / `js_throw` (wasm) — never returns normally.
- the other three → `todo()` → `SKIP_throw_cruntime`, which is `__attribute__((noreturn))` (`runtime.h:348`).

**No `nounwind`**, deliberately: `SKIP_throw` leaves by *unwinding*, and `skc` `invoke`s it from `try` scopes, so the landingpad edge must stay live. `noreturn` says nothing about unwinding, so the exception path is preserved.

## Verification

- A `throw` caught by a `try/catch` still returns the handler's value (`99`) — exception handling intact with `noreturn`.
- Emitted IR carries `noreturn cold` and verifies clean.
- **Full suite (incl. the runtime exception tests): `Failures: 0, successes: 1724`.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
