### PR TITLE
preamble: mark pure string accessors read-only / non-capturing

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -67,8 +67,8 @@ define void @SKIP_Obstack_store(ptr %obj, ptr %val) {
 ; String
 
 declare ptr @SKIP_String_concat2(ptr, ptr)
-declare i64 @SKIP_String_cmp(ptr, ptr)
-declare i64 @SKIP_String_hash(ptr)
+declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argmem: read) willreturn nounwind
+declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
 declare ptr @SKIP_Float_toString(double)
 
 ; Function Attrs: noinline nounwind optnone

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -80,8 +80,8 @@ define void @SKIP_Obstack_store(ptr %obj, ptr %val) {
 ; String
 
 declare ptr @SKIP_String_concat2(ptr, ptr)
-declare i64 @SKIP_String_cmp(ptr, ptr)
-declare i64 @SKIP_String_hash(ptr)
+declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argmem: read) willreturn nounwind
+declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
 declare ptr @SKIP_Float_toString(double)
 
 ; Function Attrs: noinline nounwind optnone


### PR DESCRIPTION
Fixes #1440 (part of #1381 §2).

`SKIP_String_cmp` and `SKIP_String_hash` are pure readers of their string argument(s), but were declared bare — so LLVM could not CSE, hoist, or reorder them.

```llvm
; before
declare i64 @SKIP_String_cmp(ptr, ptr)
declare i64 @SKIP_String_hash(ptr)
; after
declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argmem: read) willreturn nounwind
declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
```
(both preambles).

## Soundness (verified against `string.c`)

- `SKIP_String_hash` returns the cached `str->hash` — a single field read.
- `SKIP_String_cmp` reads both strings' sizes (via `SKIP_String_byteSize`) and their bytes in a bounded loop; it **terminates**, **never throws** (the `SKIP_invalid_utf8`/`SKIP_throw_cruntime` calls in `string.c` are in *other* functions), **allocates nothing**, and **captures neither pointer**. All reads are through the arguments (the string header sits just before the data pointer), so `memory(argmem: read)` holds.

Deliberately excludes the allocating/throwing string functions (`SKIP_String_concat2`, …).

## Verification

- `opt -O2` collapses two identical `SKIP_String_cmp` calls to one — the intended CSE win.
- String comparison still produces correct results (`compare("hello","help") == LT`).
- Emitted IR carries the attributes and verifies clean.
- **Full suite: `Failures: 0, successes: 1724`.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
