### PR TITLE
SKStore: make newObstack/destroyObstack private again

### DIFF
--- a/skiplang/prelude/src/skstore/Context.sk
+++ b/skiplang/prelude/src/skstore/Context.sk
@@ -1547,20 +1547,17 @@ private native base class Obstack
 @cpp_extern
 private native base class Page
 
+// The low-level region primitives, private because callers reach the region
+// through the public with* wrappers (withRegion, withRegionVoid,
+// withRegionValue, ...), which reclaim the region on both the normal and the
+// exception path. Reach for these directly only to build another such wrapper.
 @debug
 @cpp_extern("SKIP_new_Obstack")
-// Public part of the region API, alongside destroyObstack,
-// destroyObstackWithValue, and the preferred with* wrappers below. Prefer
-// withRegion/withRegionVoid/withRegionValue: they reclaim the region on both
-// the normal and the exception path. Reach for the raw pair only when the
-// region cannot be a `~>` lambda — because it must mutate outer state or span
-// a lock/condition wait, or because control flow breaks out of it. SqlTailer's
-// poll loop is the motivating case.
-native fun newObstack(): Obstack;
+private native fun newObstack(): Obstack;
 
 @debug
 @cpp_extern("SKIP_destroy_Obstack")
-native fun destroyObstack(Obstack): void;
+private native fun destroyObstack(Obstack): void;
 
 @debug
 @cpp_extern("SKIP_destroy_Obstack_with_value")

--- a/skiplang/prelude/tests/skfs/TestReuse.sk
+++ b/skiplang/prelude/tests/skfs/TestReuse.sk
@@ -13,153 +13,153 @@ class Handle(v: SK.EHandle<IIKey, SK.IntFile>) extends SK.File
 
 @test
 fun testReuseWithReduce(): void {
-  pos = SK.newObstack();
-  inputsDirName = SK.DirName::create("/inputs/");
-  reducerDirName = SK.DirName::create("/reducer/");
-  mappedDirName = SK.DirName::create("/mapped/");
-  key = v ~> SK.IID(v);
-  val = v ~> SK.IntFile(v);
-  context = SK.Context::create{}.mclone();
-  inputs = context.mkdir(
-    SK.IID::keyType,
-    SK.IntFile::type,
-    inputsDirName,
-    Array[
-      (key(0), val(0)),
-      (key(1), val(1)),
-      (key(2), val(2)),
-      (key(3), val(3)),
-    ],
-  );
-  reducerHdl = context.mkdir(
-    SK.IID::keyType,
-    SK.IntFile::type,
-    reducerDirName,
-    Array[(key(0), val(0))],
-  );
-  mapped = inputs.map(
-    SK.IID::keyType,
-    Handle::type,
-    context,
-    mappedDirName,
-    (context, writer, k, it) ~> {
-      recuder = reducerHdl.maybeGet(context, key(0)) match {
-      | Some(SK.IntFile(0)) -> SK.maxReducer()
-      | _ -> SK.minReducer()
-      };
-      v = it.first.value;
-      supmap = inputs.mapReduce(
-        IIKey::keyType,
-        SK.IntFile::type,
-        context,
-        mappedDirName.sub(`k${k}`),
-        (_context, writer, sk, sv) ~>
-          writer.set(
-            IIKey(k.value, sk.value % 2),
-            SK.IntFile(sv.first.value * v),
-          ),
-        recuder,
-      );
-      writer.set(k, Handle(supmap))
-    },
-  );
-  r0 = mapped.get(context, key(1)).v.get(context, IIKey(1, 1)).value;
-  T.expectEq(r0, 3, "Test reuse with reduce 0");
-  reducerHdl.writeArray(context, key(0), Array[val(1)]);
-  context.update();
-  r1Hdl = mapped.get(context, key(1)).v;
-  r1 = r1Hdl.get(context, IIKey(1, 1)).value;
-  T.expectEq(r1, 1, "Test reuse with reduce 1");
-  start = context.getTick();
-  reducerHdl.writeArray(context, key(0), Array[val(2)]);
-  context.update();
-  r12Hdl = mapped.get(context, key(1)).v;
-  r12 = r12Hdl.get(context, IIKey(1, 1)).value;
-  T.expectEq(r12, 1, "Test reuse with reduce 2");
-  (isReset, changes) = context
-    .unsafeGetEagerDir(r12Hdl.dirName)
-    .getChangesAfter(start);
-  T.expectEq(isReset, false, "Test reuse with reduce 3");
-  T.expectEq(changes, SortedSet[], "Test reuse with reduce 4");
-  SK.destroyObstack(pos);
+  SK.withRegionVoid(() ~> {
+    inputsDirName = SK.DirName::create("/inputs/");
+    reducerDirName = SK.DirName::create("/reducer/");
+    mappedDirName = SK.DirName::create("/mapped/");
+    key = v ~> SK.IID(v);
+    val = v ~> SK.IntFile(v);
+    context = SK.Context::create{}.mclone();
+    inputs = context.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      inputsDirName,
+      Array[
+        (key(0), val(0)),
+        (key(1), val(1)),
+        (key(2), val(2)),
+        (key(3), val(3)),
+      ],
+    );
+    reducerHdl = context.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      reducerDirName,
+      Array[(key(0), val(0))],
+    );
+    mapped = inputs.map(
+      SK.IID::keyType,
+      Handle::type,
+      context,
+      mappedDirName,
+      (context, writer, k, it) ~> {
+        recuder = reducerHdl.maybeGet(context, key(0)) match {
+        | Some(SK.IntFile(0)) -> SK.maxReducer()
+        | _ -> SK.minReducer()
+        };
+        v = it.first.value;
+        supmap = inputs.mapReduce(
+          IIKey::keyType,
+          SK.IntFile::type,
+          context,
+          mappedDirName.sub(`k${k}`),
+          (_context, writer, sk, sv) ~>
+            writer.set(
+              IIKey(k.value, sk.value % 2),
+              SK.IntFile(sv.first.value * v),
+            ),
+          recuder,
+        );
+        writer.set(k, Handle(supmap))
+      },
+    );
+    r0 = mapped.get(context, key(1)).v.get(context, IIKey(1, 1)).value;
+    T.expectEq(r0, 3, "Test reuse with reduce 0");
+    reducerHdl.writeArray(context, key(0), Array[val(1)]);
+    context.update();
+    r1Hdl = mapped.get(context, key(1)).v;
+    r1 = r1Hdl.get(context, IIKey(1, 1)).value;
+    T.expectEq(r1, 1, "Test reuse with reduce 1");
+    start = context.getTick();
+    reducerHdl.writeArray(context, key(0), Array[val(2)]);
+    context.update();
+    r12Hdl = mapped.get(context, key(1)).v;
+    r12 = r12Hdl.get(context, IIKey(1, 1)).value;
+    T.expectEq(r12, 1, "Test reuse with reduce 2");
+    (isReset, changes) = context
+      .unsafeGetEagerDir(r12Hdl.dirName)
+      .getChangesAfter(start);
+    T.expectEq(isReset, false, "Test reuse with reduce 3");
+    T.expectEq(changes, SortedSet[], "Test reuse with reduce 4");
+  })
 }
 
 @test
 fun testReuseWithIntermediateChange(): void {
-  pos = SK.newObstack();
-  inputsDirName = SK.DirName::create("/inputs/");
-  optionDirName = SK.DirName::create("/option/");
-  mappedDirName = SK.DirName::create("/mapped/");
-  key = v ~> SK.IID(v);
-  val = v ~> SK.IntFile(v);
-  context = SK.Context::create{}.mclone();
-  inputs = context.mkdir(
-    SK.IID::keyType,
-    SK.IntFile::type,
-    inputsDirName,
-    Array[
-      (key(0), val(0)),
-      (key(1), val(1)),
-      (key(2), val(2)),
-      (key(3), val(3)),
-    ],
-  );
-  optionHdl = context.mkdir(
-    SK.IID::keyType,
-    SK.IntFile::type,
-    optionDirName,
-    Array[(key(0), val(0))],
-  );
-  mapped = inputs.map(
-    SK.IID::keyType,
-    Handle::type,
-    context,
-    mappedDirName,
-    (context, writer, k, it) ~> {
-      v = it.first.value;
-      o = optionHdl.get(context, key(0)).value % 2;
-      submap = inputs
-        .map(
-          IIKey::keyType,
-          SK.IntFile::type,
-          context,
-          mappedDirName.sub(`k1${k}`),
-          (_context, writer, sk, sv) ~>
-            writer.set(
-              IIKey(k.value, sk.value),
-              SK.IntFile(o + (sv.first.value * v)),
-            )
-          ,
-        )
-        .map(
-          IIKey::keyType,
-          SK.IntFile::type,
-          context,
-          mappedDirName.sub(`k2${k}`),
-          (_context, writer, key, sv) ~> writer.set(key, sv.first),
-        );
-      writer.set(k, Handle(submap))
-    },
-  );
-  r0 = mapped.get(context, key(1)).v.get(context, IIKey(1, 1)).value;
-  T.expectEq(r0, 1, "Test reuse with intermediate change 0");
-  optionHdl.writeArray(context, key(0), Array[val(1)]);
-  context.update();
-  r1Hdl = mapped.get(context, key(1)).v;
-  r1 = r1Hdl.get(context, IIKey(1, 1)).value;
-  T.expectEq(r1, 2, "Test reuse with intermediate change 1");
-  start = context.getTick();
-  optionHdl.writeArray(context, key(0), Array[val(3)]);
-  context.update();
-  r12Hdl = mapped.get(context, key(1)).v;
-  r12 = r12Hdl.get(context, IIKey(1, 1)).value;
-  T.expectEq(r12, 2, "Test reuse with intermediate change 2");
-  (isReset, changes) = context
-    .unsafeGetEagerDir(r12Hdl.dirName)
-    .getChangesAfter(start);
-  T.expectEq(isReset, false, "Test reuse with intermediate change 3");
-  T.expectEq(changes, SortedSet[], "Test reuse with intermediate change 4");
-  SK.destroyObstack(pos);
+  SK.withRegionVoid(() ~> {
+    inputsDirName = SK.DirName::create("/inputs/");
+    optionDirName = SK.DirName::create("/option/");
+    mappedDirName = SK.DirName::create("/mapped/");
+    key = v ~> SK.IID(v);
+    val = v ~> SK.IntFile(v);
+    context = SK.Context::create{}.mclone();
+    inputs = context.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      inputsDirName,
+      Array[
+        (key(0), val(0)),
+        (key(1), val(1)),
+        (key(2), val(2)),
+        (key(3), val(3)),
+      ],
+    );
+    optionHdl = context.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      optionDirName,
+      Array[(key(0), val(0))],
+    );
+    mapped = inputs.map(
+      SK.IID::keyType,
+      Handle::type,
+      context,
+      mappedDirName,
+      (context, writer, k, it) ~> {
+        v = it.first.value;
+        o = optionHdl.get(context, key(0)).value % 2;
+        submap = inputs
+          .map(
+            IIKey::keyType,
+            SK.IntFile::type,
+            context,
+            mappedDirName.sub(`k1${k}`),
+            (_context, writer, sk, sv) ~>
+              writer.set(
+                IIKey(k.value, sk.value),
+                SK.IntFile(o + (sv.first.value * v)),
+              )
+            ,
+          )
+          .map(
+            IIKey::keyType,
+            SK.IntFile::type,
+            context,
+            mappedDirName.sub(`k2${k}`),
+            (_context, writer, key, sv) ~> writer.set(key, sv.first),
+          );
+        writer.set(k, Handle(submap))
+      },
+    );
+    r0 = mapped.get(context, key(1)).v.get(context, IIKey(1, 1)).value;
+    T.expectEq(r0, 1, "Test reuse with intermediate change 0");
+    optionHdl.writeArray(context, key(0), Array[val(1)]);
+    context.update();
+    r1Hdl = mapped.get(context, key(1)).v;
+    r1 = r1Hdl.get(context, IIKey(1, 1)).value;
+    T.expectEq(r1, 2, "Test reuse with intermediate change 1");
+    start = context.getTick();
+    optionHdl.writeArray(context, key(0), Array[val(3)]);
+    context.update();
+    r12Hdl = mapped.get(context, key(1)).v;
+    r12 = r12Hdl.get(context, IIKey(1, 1)).value;
+    T.expectEq(r12, 2, "Test reuse with intermediate change 2");
+    (isReset, changes) = context
+      .unsafeGetEagerDir(r12Hdl.dirName)
+      .getChangesAfter(start);
+    T.expectEq(isReset, false, "Test reuse with intermediate change 3");
+    T.expectEq(changes, SortedSet[], "Test reuse with intermediate change 4");
+  })
 }
 
 module end;

--- a/skiplang/prelude/tests/skfs/TestUpdate.sk
+++ b/skiplang/prelude/tests/skfs/TestUpdate.sk
@@ -5,75 +5,75 @@ module SKStoreTest;
 
 @test
 fun testUdpateFromContext(): void {
-  pos = SK.newObstack();
-  inputsDirName = SK.DirName::create("/inputs/");
-  mappedDirName = SK.DirName::create("/mapped/");
-  key = v ~> SK.IID(v);
-  val = v ~> SK.IntFile(v);
-  context = SK.Context::create{}.mclone();
-  inputs = context.mkdir(
-    SK.IID::keyType,
-    SK.IntFile::type,
-    inputsDirName,
-    Array[],
-  );
-  mapped = inputs.map(
-    SK.IID::keyType,
-    Handle::type,
-    context,
-    mappedDirName,
-    (context, writer, k, it) ~> {
-      v = it.first.value;
-      supmap = inputs.mapReduce(
-        IIKey::keyType,
-        SK.IntFile::type,
-        context,
-        mappedDirName.sub(`k${k}`),
-        (_context, writer, sk, sv) ~>
-          writer.set(
-            IIKey(k.value, sk.value % 2),
-            SK.IntFile(sv.first.value * v),
-          ),
-        SK.maxReducer(),
-      );
-      writer.set(k, Handle(supmap))
-    },
-  );
-  context.update();
-  t0 = context.getTick().value;
-  inputs.writeArray(context, key(1), Array[val(1)]);
-  context.update();
-  r0 = mapped.get(context, key(1)).v.get(context, IIKey(1, 1)).value;
-  T.expectEq(r0, 1, "Test update from context 0");
-  context2 = context.mclone();
-  t1 = context.getTick().value;
-  inputs.writeArray(context, key(2), Array[val(2)]);
-  context.update();
-  r1 = mapped.get(context, key(2)).v.get(context, IIKey(2, 0)).value;
-  T.expectEq(r1, 4, "Test update from context 1.0");
-  T.expectTrue(
-    mapped.maybeGet(context2, key(2)).isNone(),
-    "Test update from context 1.1",
-  );
-  inputs.writeArray(context2, key(1), Array[]);
-  context2.update();
-  context2.update();
-  context2.update();
-  T.expectTrue(
-    mapped.maybeGet(context2, key(1)).isNone(),
-    "Test update from context 2",
-  );
-  inputs.writeArray(context2, key(1), Array[val(1)]);
-  inputs.writeArray(context2, key(2), Array[val(2)]);
-  context2.update(Some(context.clone()));
-  r3 = mapped.get(context2, key(2)).v.get(context, IIKey(2, 0)).value;
-  T.expectEq(r3, 4, "Test update from context 3.0");
-  // Check the dirs are copied from context
-  c0 = context2.getEagerDir(mappedDirName.sub(`k1`)).created.value;
-  c1 = context2.getEagerDir(mappedDirName.sub(`k2`)).created.value;
-  T.expectEq(c0, t0, "Test update from context 3.1");
-  T.expectEq(c1, t1, "Test update from context 3.2");
-  SK.destroyObstack(pos);
+  SK.withRegionVoid(() ~> {
+    inputsDirName = SK.DirName::create("/inputs/");
+    mappedDirName = SK.DirName::create("/mapped/");
+    key = v ~> SK.IID(v);
+    val = v ~> SK.IntFile(v);
+    context = SK.Context::create{}.mclone();
+    inputs = context.mkdir(
+      SK.IID::keyType,
+      SK.IntFile::type,
+      inputsDirName,
+      Array[],
+    );
+    mapped = inputs.map(
+      SK.IID::keyType,
+      Handle::type,
+      context,
+      mappedDirName,
+      (context, writer, k, it) ~> {
+        v = it.first.value;
+        supmap = inputs.mapReduce(
+          IIKey::keyType,
+          SK.IntFile::type,
+          context,
+          mappedDirName.sub(`k${k}`),
+          (_context, writer, sk, sv) ~>
+            writer.set(
+              IIKey(k.value, sk.value % 2),
+              SK.IntFile(sv.first.value * v),
+            ),
+          SK.maxReducer(),
+        );
+        writer.set(k, Handle(supmap))
+      },
+    );
+    context.update();
+    t0 = context.getTick().value;
+    inputs.writeArray(context, key(1), Array[val(1)]);
+    context.update();
+    r0 = mapped.get(context, key(1)).v.get(context, IIKey(1, 1)).value;
+    T.expectEq(r0, 1, "Test update from context 0");
+    context2 = context.mclone();
+    t1 = context.getTick().value;
+    inputs.writeArray(context, key(2), Array[val(2)]);
+    context.update();
+    r1 = mapped.get(context, key(2)).v.get(context, IIKey(2, 0)).value;
+    T.expectEq(r1, 4, "Test update from context 1.0");
+    T.expectTrue(
+      mapped.maybeGet(context2, key(2)).isNone(),
+      "Test update from context 1.1",
+    );
+    inputs.writeArray(context2, key(1), Array[]);
+    context2.update();
+    context2.update();
+    context2.update();
+    T.expectTrue(
+      mapped.maybeGet(context2, key(1)).isNone(),
+      "Test update from context 2",
+    );
+    inputs.writeArray(context2, key(1), Array[val(1)]);
+    inputs.writeArray(context2, key(2), Array[val(2)]);
+    context2.update(Some(context.clone()));
+    r3 = mapped.get(context2, key(2)).v.get(context, IIKey(2, 0)).value;
+    T.expectEq(r3, 4, "Test update from context 3.0");
+    // Check the dirs are copied from context
+    c0 = context2.getEagerDir(mappedDirName.sub(`k1`)).created.value;
+    c1 = context2.getEagerDir(mappedDirName.sub(`k2`)).created.value;
+    T.expectEq(c0, t0, "Test update from context 3.1");
+    T.expectEq(c1, t1, "Test update from context 3.2");
+  })
 }
 
 module end;


### PR DESCRIPTION
Follow-up to #1421 and the region-wrapper migrations (#1436, #1442): now that every external caller of the raw `newObstack()` / `destroyObstack()` pair has moved onto the `with*` region wrappers, return the pair to `private`.

## Background

#1421 made `newObstack` / `destroyObstack` public as an interim measure — a few call sites couldn't be expressed as `~>` region wrappers, and the partner `destroyObstackWithValue` was already public. Those sites have since moved onto wrappers:

- **#1436** — the SKJSON and SKDB entry-point `main`s → `withRegionVoid`.
- **#1442** — the SKDB `SqlTailer` poll loop → `withRegionLoop`.
- **this PR** — the three `SKStoreTest` reuse/update tests → `withRegionVoid`.

With those gone, nothing outside `module SKStore` reaches the raw pair, so it goes back to `private`. `destroyObstackWithValue` stays public but is now effectively unreachable from outside (you can't obtain an `Obstack` to pass it) — I left it as-is rather than widen this change; happy to privatise it too if you'd prefer.

## Changes

1. `SKStoreTest` tests (`TestReuse.sk`, `TestUpdate.sk`) → `withRegionVoid`. Same single region, but now reclaimed on the exception path too (the old `destroyObstack` was skipped when an `expectEq` threw). Bodies are unchanged apart from the wrap and the re-indent.
2. `newObstack` / `destroyObstack` → `private native fun`, with the doc comment rewritten to describe them as the internal primitives behind the `with*` wrappers. The old comment named `SqlTailer` and enumerated the wrappers — both went stale.

## Rebased on #1442

#1442 (which removed `SqlTailer`'s last raw use) has merged, and this branch is rebased onto it, so the tree is consistent end-to-end — no caller of the raw pair remains anywhere outside `module SKStore`. Module-level `private` isn't enforced yet (#1343), so at the type level this is a no-op label tightening today; it's the setup that lets #1343's enforcement pass here rather than break.

## Verification

Built the prelude test target and ran the three migrated tests locally — all pass:

```
[OK] SKStoreTest testReuseWithReduce
[OK] SKStoreTest testReuseWithIntermediateChange
[OK] SKStoreTest testUdpateFromContext
```

`std [lib]` compiles with the re-privatised decls (the `with*` wrappers call them from the same module).

— Claude Opus 4.8 (1M context)