### PR TITLE
Clear the us-fixable CVEs in skiplabs/skip (npm bundled deps + base gzip/tar)

### DIFF
--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -68,6 +68,13 @@ for step in "${steps[@]}"; do
             echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_22.x nodistro main" >> /etc/apt/sources.list.d/nodejs.list
             apt-get update
             apt-get install -q -y --no-install-recommends nodejs jq
+            # NodeSource's nodejs bundles npm 10.9.8, whose own bundled
+            # dependencies (tar, brace-expansion, sigstore, ...) carry CVEs
+            # including a critical in tar. Update npm to current 11.x, which
+            # bundles fixed versions. Major-pinned, not floating to @latest, so
+            # a rebuild self-heals within 11.x without jumping to a major that
+            # would require a newer node than the pinned node_22.x.
+            npm install -g npm@11
             ;;
         other-CI-tools)
             # Assumes other steps have been run before

--- a/bin/apt-install.sh
+++ b/bin/apt-install.sh
@@ -51,6 +51,10 @@ for step in "${steps[@]}"; do
             echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-$LLVM_VERSION main" >> /etc/apt/sources.list.d/llvm.list
             apt-get update
             apt-get install -q -y --no-install-recommends automake clang-$LLVM_VERSION file gawk git lld-$LLVM_VERSION llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev make openssh-client
+            # gzip and tar ship in the ubuntu base with fixable CVEs; the base
+            # image lags the Noble security updates, so pull the patched
+            # versions explicitly. Runs in skiplang-base, inherited downstream.
+            apt-get install -q -y --only-upgrade gzip tar
 
             update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$LLVM_VERSION $PRIORITY \
                 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-$LLVM_VERSION \


### PR DESCRIPTION
## Summary

Docker Hub flags several **fixable** advisories on `skiplabs/skip`. This clears the ones we actually control — two edits in `bin/apt-install.sh` — and documents precisely why the rest are upstream.

Correcting my own earlier claim: I'd said the npm findings were "vendored, not fixable by us." That was wrong. They live in `/usr/lib/node_modules/npm/node_modules` — bundled inside **npm 10.9.8**, which *we* install — so we control them by bumping npm.

## Measured on the rebuilt `skip` image (not version arithmetic)

| edit | clears | severity |
|---|---|---|
| **npm 10.9.8 → 11.x** | `tar` 7.5.11→7.5.19, brace-expansion→5.0.7, sigstore→4.1.1, picomatch→4.0.4, @sigstore/core→3.2.1, ip-address→10.2.0 | **−1C −4H** −6M |
| **`apt --only-upgrade gzip tar`** | base `gzip`, `tar` → Noble security revs | −4M |

**Net: −1 critical, −4 high, −11 medium.** Fixable C/H goes `1C 12H` → **`0C 8H`**. I confirmed each cleared package physically (npm 11.18.0, bundled tar 7.5.19) and that all cleared packages drop off Scout's `--only-fixed` list on the rebuilt image.

## What's left, and why it's genuinely not ours

The residual `0C 8H` is exclusively:
- **containerd (3H), docker (1H), grpc (1H)** — Go modules vendored inside `docker-buildx-plugin 0.35.0` / `docker-ce-cli 29.6.2`, both already the newest on `download.docker.com`. The fixes (containerd 2.2.5, grpc 1.82.1) postdate 0.35.0's vendoring. buildx can't be dropped — it drives `bake` (#1341).
- **setuptools (2H), wheel (1H)** — apt-owned by `python3-pip` on Noble (Candidate == Installed). A `pip --upgrade` leaves the old dist-info in `/usr/lib` that Scout still matches (verified previously), and they can't be apt-removed without breaking `python3-pip`, which `make fmt-py` needs.

## Breaking-change assessment (npm 10 → 11, a major bump)

**None affecting this repo.** Evidence:
- npm 11 requires node `^20.17 || >=22.9`; the image has **22.23.1**. Verified npm 11 installs and runs on it.
- All 6 `package-lock.json` files are **lockfileVersion 3**, which npm 11 keeps unchanged — no lockfile migration.
- Repo usage is only `npm install` and `npm run <script>` (no `npm ci`), whose behaviour is stable across the bump.
- `tsc` reinstalls and runs after the bump (7.0.2).
- **CI is the end-to-end gate**: `check-ts`, `skipruntime`, `skipruntime-bun` all run npm builds against this image.

Pinned to `npm@11` (major), not `@latest` — a rebuild self-heals within 11.x for future patches without risking a jump to a major needing a newer node than the pinned `node_22.x`.

## Test plan

- [x] Full `skip` image builds `--no-cache` with both edits
- [x] `npm --version` → 11.18.0; bundled `tar` → 7.5.19 in the image
- [x] Every npm + gzip + tar package drops off `docker scout cves --only-fixed`; residual is only the upstream/apt-pinned set above
- [x] `shellcheck --exclude SC2181 --exclude SC2002` clean
- [x] CI green (`check-ts` / `skipruntime` / `skipruntime-bun` exercise npm 11)
- [ ] Republish after merge to realise it

— Claude Opus 4.8 (1M context), effort xhigh