### PR TITLE
compiler: reject `private` type aliases outside a module (#1452)

### DIFF
--- a/skiplang/compiler/invalid_tests/visibility/global_private_type.exp_err
+++ b/skiplang/compiler/invalid_tests/visibility/global_private_type.exp_err
@@ -1,0 +1,5 @@
+File "invalid_tests/visibility/global_private_type.sk", line 1, characters 1-7:
+Cannot declare a type as private outside of a module
+1 | private type T = Int;
+  | ^^^^^^^
+

--- a/skiplang/compiler/invalid_tests/visibility/global_private_type.sk
+++ b/skiplang/compiler/invalid_tests/visibility/global_private_type.sk
@@ -1,0 +1,1 @@
+private type T = Int;

--- a/skiplang/compiler/src/skipExpand.sk
+++ b/skiplang/compiler/src/skipExpand.sk
@@ -935,6 +935,19 @@ fun check_const_privacy(
   }
 }
 
+fun check_type_privacy(
+  env: Env,
+  name: A.Name,
+  x: (FileRange, A.Visibility),
+): void {
+  x match {
+  | (_, A.VPublic()) -> void
+  | (_, A.VProtected()) -> invariant_violation("ICE protected type alias")
+  | (pos, A.VPrivate()) ->
+    check_module_element_privacy("type", env, name, Some(pos))
+  }
+}
+
 fun current_defs_names(context: mutable SKStore.Context, env: Env): DefNames {
   module_names_find(context, env.current_module) match {
   | None() -> empty_defs_names()
@@ -2735,6 +2748,7 @@ fun type_alias_def(
   visibility = t__.visibility;
   name = t__.name;
   tparams = t__.tparams;
+  check_type_privacy(env, name, visibility);
   name1 = make_definition_name(env, name);
   (env1, tparams1) = type_parameters(context, env, tparams);
   body1 = type_alias(context, env1, tyd.body);


### PR DESCRIPTION
Closes #1452.

The declaration-site check that rejects `private` used *outside* a module is wired up for classes, functions, and constants (`check_class_privacy` / `check_fun_privacy` / `check_const_privacy` → `check_module_element_privacy`), but there was no `check_type_privacy` — so a `private` type alias at global scope compiled clean:

```skip
private type T = Int;   // top level, no enclosing module — used to be accepted
```

This adds `check_type_privacy`, mirroring `check_const_privacy` exactly, and calls it from `type_alias_def`. The other three kinds already error with `Cannot declare a <kind> as private outside of a module`; a type alias now does too.

A `private` type alias **inside** a module is unaffected (that's normal module-privacy, enforced by #1343's access check). I confirmed every `private type` in the tree is module-scoped, so nothing existing changes.

### Verification

- New `invalid_tests/visibility/global_private_type` compiles to its exact golden (`Cannot declare a type as private outside of a module`).
- A module-private `type T` used within its module still compiles; cross-module `M.T` still errors (unchanged).

— Claude Opus 4.8 (1M context)
