### PR TITLE
preamble: sound LLVM attributes on the low-risk SKIP_* runtime functions

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -6,24 +6,18 @@ declare void @SKIP_throw(ptr) noreturn cold
 declare void @SKIP_unreachableMethodCall(ptr, ptr) noreturn cold
 declare void @SKIP_unreachableWithExplanation(ptr) noreturn cold
 declare ptr @SKIP_intern(ptr)
-declare ptr @SKIP_llvm_memcpy(ptr, ptr, i64)
-declare void @SKIP_llvm_memset(ptr, i8, i64)
+declare ptr @SKIP_llvm_memcpy(ptr writeonly, ptr readonly captures(none), i64) memory(argmem: readwrite) mustprogress nounwind willreturn nofree
+declare void @SKIP_llvm_memset(ptr writeonly captures(none), i8, i64) memory(argmem: write) mustprogress nounwind willreturn nofree
 
 ; LLVM intrinsics
 
-; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start(i64 immarg, ptr nocapture)
-; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end(i64 immarg, ptr nocapture)
 
-; Function Attrs: nounwind readnone
 declare i32 @llvm.eh.typeid.for(ptr)
 
-; Function Attrs: nounwind readnone
 declare i64 @llvm.ctlz.i64(i64, i1)
-; Function Attrs: nounwind readnone
 declare i64 @llvm.cttz.i64(i64, i1)
-; Function Attrs: nounwind readnone
 declare i64 @llvm.ctpop.i64(i64)
 
 declare i32 @__gxx_personality_v0(...)
@@ -38,28 +32,23 @@ declare void @SKIP_Obstack_vectorUnsafeSet(ptr, ptr)
 declare void @SKIP_Obstack_collect(ptr, ptr, i64)
 declare ptr @SKIP_Obstack_shallowClone(i32, ptr)
 
-; Function Attrs: alwaysinline nounwind uwtable
-define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) {
+define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) alwaysinline nounwind uwtable {
   ret void
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define ptr @SKIP_Obstack_note_inl() {
+define ptr @SKIP_Obstack_note_inl() alwaysinline nounwind uwtable {
   ret ptr null
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define void @SKIP_Obstack_inl_collect0(ptr) {
+define void @SKIP_Obstack_inl_collect0(ptr) alwaysinline nounwind uwtable {
   ret void
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define ptr @SKIP_Obstack_inl_collect1(ptr, ptr) {
+define ptr @SKIP_Obstack_inl_collect1(ptr, ptr) alwaysinline nounwind uwtable {
   ret ptr %1
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define void @SKIP_Obstack_store(ptr %obj, ptr %val) {
+define void @SKIP_Obstack_store(ptr %obj, ptr %val) alwaysinline nounwind uwtable {
   store ptr %val, ptr %obj
   ret void
 }
@@ -71,8 +60,7 @@ declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argm
 declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
 declare ptr @SKIP_Float_toString(double)
 
-; Function Attrs: noinline nounwind optnone
-define i1 @SKIP_String_eq(ptr %0, ptr %1) {
+define i1 @SKIP_String_eq(ptr captures(none) %0, ptr captures(none) %1) nounwind willreturn memory(argmem: read) {
   %3 = call i64 @SKIP_String_cmp(ptr %0, ptr %1)
   %4 = icmp eq i64 %3, 0
   ret i1 %4
@@ -83,5 +71,5 @@ define i1 @SKIP_String_eq(ptr %0, ptr %1) {
 
 @_ZTIN4skip13SkipExceptionE = external constant { ptr, ptr, ptr }, align 8
 
-declare void @SKIP_saveExn(ptr)
+declare void @SKIP_saveExn(ptr) nounwind willreturn memory(write, argmem: none) nofree
 declare void @SKIP_etry(ptr, ptr)

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -5,24 +5,18 @@ declare void @SKIP_throw(ptr) noreturn cold
 declare void @SKIP_unreachableMethodCall(ptr, ptr) noreturn cold
 declare void @SKIP_unreachableWithExplanation(ptr) noreturn cold
 declare ptr @SKIP_intern(ptr)
-declare ptr @SKIP_llvm_memcpy(ptr, ptr, i64)
-declare void @SKIP_llvm_memset(ptr, i8, i64)
+declare ptr @SKIP_llvm_memcpy(ptr writeonly, ptr readonly captures(none), i64) memory(argmem: readwrite) mustprogress nounwind willreturn nofree
+declare void @SKIP_llvm_memset(ptr writeonly captures(none), i8, i64) memory(argmem: write) mustprogress nounwind willreturn nofree
 
 ; LLVM intrinsics
 
-; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start(i64 immarg, ptr nocapture)
-; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end(i64 immarg, ptr nocapture)
 
-; Function Attrs: nounwind readnone
 declare i32 @llvm.eh.typeid.for(ptr)
 
-; Function Attrs: nounwind readnone
 declare i64 @llvm.ctlz.i64(i64, i1)
-; Function Attrs: nounwind readnone
 declare i64 @llvm.cttz.i64(i64, i1)
-; Function Attrs: nounwind readnone
 declare i64 @llvm.ctpop.i64(i64)
 
 declare i32 @__gxx_personality_v0(...)
@@ -51,28 +45,23 @@ declare void @SKIP_Obstack_vectorUnsafeSet(ptr, ptr)
 declare void @SKIP_Obstack_collect(ptr, ptr, i64)
 declare ptr @SKIP_Obstack_shallowClone(i64, ptr)
 
-; Function Attrs: alwaysinline nounwind uwtable
-define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) {
+define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) alwaysinline nounwind uwtable {
   ret void
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define ptr @SKIP_Obstack_note_inl() {
+define ptr @SKIP_Obstack_note_inl() alwaysinline nounwind uwtable {
   ret ptr null
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define void @SKIP_Obstack_inl_collect0(ptr) {
+define void @SKIP_Obstack_inl_collect0(ptr) alwaysinline nounwind uwtable {
   ret void
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define ptr @SKIP_Obstack_inl_collect1(ptr, ptr) {
+define ptr @SKIP_Obstack_inl_collect1(ptr, ptr) alwaysinline nounwind uwtable {
   ret ptr %1
 }
 
-; Function Attrs: alwaysinline nounwind uwtable
-define void @SKIP_Obstack_store(ptr %obj, ptr %val) {
+define void @SKIP_Obstack_store(ptr %obj, ptr %val) alwaysinline nounwind uwtable {
   store ptr %val, ptr %obj
   ret void
 }
@@ -84,8 +73,7 @@ declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argm
 declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
 declare ptr @SKIP_Float_toString(double)
 
-; Function Attrs: noinline nounwind optnone
-define i1 @SKIP_String_eq(ptr %0, ptr %1) {
+define i1 @SKIP_String_eq(ptr captures(none) %0, ptr captures(none) %1) nounwind willreturn memory(argmem: read) {
   %3 = call i64 @SKIP_String_cmp(ptr %0, ptr %1)
   %4 = icmp eq i64 %3, 0
   ret i1 %4
@@ -96,7 +84,7 @@ define i1 @SKIP_String_eq(ptr %0, ptr %1) {
 
 @_ZTIN4skip13SkipExceptionE = external constant { ptr, ptr, ptr }, align 8
 
-declare void @SKIP_saveExn(ptr)
+declare void @SKIP_saveExn(ptr) nounwind willreturn memory(write, argmem: none) nofree
 
 define void @SKIP_etry(ptr %f.0, ptr %onError.1) unnamed_addr uwtable personality ptr @__gxx_personality_v0 {
 b0.entry:


### PR DESCRIPTION
Most `SKIP_*` preamble functions carried **no attributes**, so LLVM treated every call as an opaque full-memory clobber — defeating CSE/DSE/reordering. This adds the attributes an **adversarial per-function soundness audit** found unambiguously sound (verified against the C runtime, the GC relocation model, exception unwinding, capture/escape, and the wasm build), and fixes the stale `; Function Attrs:` comments in the process.

This supersedes the closed #1441/#1447 (its content is included) and is part of #1381 §2.

## What's applied (the low-risk tier)

| Function | Attributes | Why sound |
|---|---|---|
| **intrinsics** (`llvm.lifetime.*`, `ctlz/cttz/ctpop`, `eh.typeid.for`) | comments **deleted** | LLVM applies their canonical attrs from the intrinsic definition regardless of the `declare` — documentation-only, as you noted |
| `SKIP_llvm_memcpy` | `ptr writeonly, ptr readonly captures(none), i64) memory(argmem: readwrite) mustprogress nounwind willreturn nofree` | libc `memcpy` wrapper; dest is the return value so **not** `captures(none)`; no `nonnull` (len may be 0) |
| `SKIP_llvm_memset` | `ptr writeonly captures(none), i8, i64) memory(argmem: write) …` | libc `memset` wrapper |
| `SKIP_saveExn` | `nounwind willreturn memory(write, argmem: none) nofree` | stores the pointer *value* into the `exn` thread-local; arg never dereferenced (`argmem: none`) and **escapes** into the global (**no** `captures(none)`) |
| obstack inline helpers + `SKIP_Obstack_store` | `alwaysinline nounwind uwtable` | trivial/no-op bodies |
| `SKIP_String_eq` | `nounwind willreturn memory(argmem: read)` + `captures(none)` params | pure wrapper over `SKIP_String_cmp`; its recorded `optnone/noinline` were clang's `-O0` stamp, not what it should carry |

## Deliberately left bare (the audit's most important findings)

- **`SKIP_intern`** — returns *existing* interned/shared objects (aliases live pointers), unwinds (throws on changing a const / OOM), frees the superseded const, and transiently mutates + GC-walks the argument graph. Every tempting attribute is unsound.
- **`SKIP_Obstack_collect`** — the moving-GC relocation hook. Its body is a no-op *today*, but `memory(none)`/`nounwind` would become a silent miscompile the instant the disabled collector is re-enabled (it would read roots and write relocated pointers). Same failure family as the reverted allocator regression.

## Follow-up (separate PR)

The allocating string/obstack builders (`SKIP_String_concat2`, `SKIP_Obstack_shallowClone`, `SKIP_Float_toString`) and the write barrier (`SKIP_Obstack_vectorUnsafeSet`) interact with allocation/GC — notably `shallowClone`'s return is `align 8` on native but only **`align 4` on wasm32** (metadata is 4 bytes there) — so they go in a dedicated, separately-wasm-gated PR.

## Verification

Both preambles pass `opt -passes=verify`. Since a wrong attribute here is a **silent miscompile native tests don't catch** (cf. the reverted `allocsize`/`inaccessiblemem` regression that passed native and corrupted wasm vtables), this is **gated on the wasm CI jobs** (`skdb-wasm` / `skipruntime`), not just the host suite.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
