### PR TITLE
preamble: attributes on the allocating / write-barrier SKIP_* functions

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -28,9 +28,9 @@ declare void @__cxa_end_catch()
 
 declare noalias align 8 ptr @SKIP_Obstack_alloc(i32) nofree
 declare noalias align 8 ptr @SKIP_Obstack_calloc(i32) nofree
-declare void @SKIP_Obstack_vectorUnsafeSet(ptr, ptr)
+declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
 declare void @SKIP_Obstack_collect(ptr, ptr, i64)
-declare ptr @SKIP_Obstack_shallowClone(i32, ptr)
+declare noalias align 4 ptr @SKIP_Obstack_shallowClone(i32, ptr readonly captures(none) nonnull) nofree
 
 define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) alwaysinline nounwind uwtable {
   ret void
@@ -55,10 +55,10 @@ define void @SKIP_Obstack_store(ptr %obj, ptr %val) alwaysinline nounwind uwtabl
 
 ; String
 
-declare ptr @SKIP_String_concat2(ptr, ptr)
+declare noalias align 8 ptr @SKIP_String_concat2(ptr readonly captures(none), ptr readonly captures(none)) nofree willreturn
 declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argmem: read) willreturn nounwind
 declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
-declare ptr @SKIP_Float_toString(double)
+declare align 8 ptr @SKIP_Float_toString(double) nofree
 
 define i1 @SKIP_String_eq(ptr captures(none) %0, ptr captures(none) %1) nounwind willreturn memory(argmem: read) {
   %3 = call i64 @SKIP_String_cmp(ptr %0, ptr %1)

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -41,9 +41,9 @@ define void @SKIP_awaitableThrow(ptr, ptr) {
 
 declare noalias align 8 ptr @SKIP_Obstack_alloc(i64) nofree
 declare noalias align 8 ptr @SKIP_Obstack_calloc(i64) nofree
-declare void @SKIP_Obstack_vectorUnsafeSet(ptr, ptr)
+declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
 declare void @SKIP_Obstack_collect(ptr, ptr, i64)
-declare ptr @SKIP_Obstack_shallowClone(i64, ptr)
+declare noalias align 8 ptr @SKIP_Obstack_shallowClone(i64, ptr readonly captures(none) nonnull) nofree
 
 define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) alwaysinline nounwind uwtable {
   ret void
@@ -68,10 +68,10 @@ define void @SKIP_Obstack_store(ptr %obj, ptr %val) alwaysinline nounwind uwtabl
 
 ; String
 
-declare ptr @SKIP_String_concat2(ptr, ptr)
+declare noalias align 8 ptr @SKIP_String_concat2(ptr readonly captures(none), ptr readonly captures(none)) nofree willreturn
 declare i64 @SKIP_String_cmp(ptr captures(none), ptr captures(none)) memory(argmem: read) willreturn nounwind
 declare i64 @SKIP_String_hash(ptr captures(none)) memory(argmem: read) willreturn nounwind
-declare ptr @SKIP_Float_toString(double)
+declare align 8 ptr @SKIP_Float_toString(double) nofree
 
 define i1 @SKIP_String_eq(ptr captures(none) %0, ptr captures(none) %1) nounwind willreturn memory(argmem: read) {
   %3 = call i64 @SKIP_String_cmp(ptr %0, ptr %1)


### PR DESCRIPTION
Follow-up to #1456 (the low-risk tier), for the `SKIP_*` functions that **allocate on the obstack** or act as **GC write barriers**. Kept separate and **gated on the wasm CI jobs** because they interact with allocation/GC — the category where a wrong attribute is a silent wasm-only miscompile (cf. the reverted `allocsize`/`inaccessiblemem` regression that passed native and corrupted wasm vtables). From the same adversarial soundness audit. Part of #1381 §2.

| Function | Attributes | Key soundness point |
|---|---|---|
| `SKIP_String_concat2` | `noalias align 8 (ptr readonly captures(none), ptr readonly captures(none)) nofree willreturn` | fresh alloc; String header is 8 bytes on **both** targets so `align 8` is sound on wasm. **No `nounwind`** — obstack alloc can OOM-throw (unwinds) |
| `SKIP_Obstack_shallowClone` | `noalias …(…, ptr readonly captures(none) nonnull) nofree` — **`align 8` native / `align 4` wasm** | ⚠️ the return is `mem+leftsize`; a class's `leftsize` is 8 on SKIP64 but **4 on SKIP32**, so `align 8` in the wasm preamble would be a miscompile. No `nounwind`/`memory`/`allocsize` |
| `SKIP_Float_toString` | `align 8 … nofree` | returns a fresh 8-aligned Skip String |
| `SKIP_Obstack_vectorUnsafeSet` | `(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)` | today a plain `*arr = x`; second arg **bare** (stored value escapes). ⚠️ `memory(argmem: write)`/`nounwind` hold only while the barrier is trivial — revisit with any GC re-enablement (noted in the source commit) |

Still deliberately bare: `SKIP_intern`, `SKIP_Obstack_collect`.

**Verification:** both preambles `opt -passes=verify` clean; correctness is on the **wasm jobs** (`skdb-wasm`/`skipruntime`), not the host suite. If wasm flags anything, I'll reduce the offending attribute — the `shallowClone` alignment and the `vectorUnsafeSet` `memory` narrowing are the two to watch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
