### PR TITLE
compiler: add `--allow-module-private-access` to bypass module-private (#1454)

### DIFF
--- a/skiplang/compiler/src/Config.sk
+++ b/skiplang/compiler/src/Config.sk
@@ -82,6 +82,9 @@ class Config{
   canonize_paths: Bool,
   cwd: WorkingDirectory,
   batch_mode: Bool = false,
+  // Escape hatch: allow reaching module-`private` elements from other modules
+  // (e.g. white-box tests). Off by default so enforcement stays on.
+  bypass_module_private: Bool = false,
 } {
   static fun make(results: Cli.ParseResults): this {
     optConfig = Optimize.Config::make(
@@ -184,6 +187,7 @@ class Config{
     autogc = results.getBool("autogc");
     sampleRate = results.getString("sample-rate").toInt();
     useSpecializedNames = results.getBool("use-specialized-names");
+    bypass_module_private = results.getBool("allow-module-private-access");
     check = results.getBool("check");
     no_link = !results.getBool("link");
 
@@ -268,6 +272,7 @@ class Config{
       autogc,
       sampleRate,
       useSpecializedNames,
+      bypass_module_private,
       check,
       no_link,
       stackAlign,

--- a/skiplang/compiler/src/OuterIstToIR.sk
+++ b/skiplang/compiler/src/OuterIstToIR.sk
@@ -4881,9 +4881,12 @@ private const kEmptyMethods: UnorderedMap<
   SFunctionID,
 > = UnorderedMap[];
 
-fun makeOuterIst(context: mutable SKStore.Context): OuterIst.Program {
+fun makeOuterIst(
+  context: mutable SKStore.Context,
+  allowPrivateAccess: Bool,
+): OuterIst.Program {
   // run the compiler front end from parsing to type checking
-  typedAst = SkipMain.type_program(context);
+  typedAst = SkipMain.type_program(context, allowPrivateAccess);
   // OuterIst skeleton is built here, but code is done lazily
   SkipMakeOuterIst.program(context, typedAst)
 }

--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -216,7 +216,10 @@ const backendSinkDir: SKStore.EHandle<
   backendSinkDirName,
 );
 
-fun getOrInitializeBackend(context: mutable SKStore.Context): SKStore.EagerDir {
+fun getOrInitializeBackend(
+  context: mutable SKStore.Context,
+  allowPrivateAccess: Bool,
+): SKStore.EagerDir {
   backendDirName = SKStore.DirName::create("/backend/");
   context.unsafeMaybeGetEagerDir(backendDirName) match {
   | Some(dir) -> return dir
@@ -239,7 +242,7 @@ fun getOrInitializeBackend(context: mutable SKStore.Context): SKStore.EagerDir {
     backendDirName,
   );
 
-  outerIst = OuterIstToIR.makeOuterIst(context);
+  outerIst = OuterIstToIR.makeOuterIst(context, allowPrivateAccess);
 
   defsProj = outerIst.getFunsProj(context);
   constsProj = outerIst.getConstsProj(context);
@@ -396,7 +399,7 @@ fun compile(
   };
 
   runCompilerPhase("backend/init", () -> {
-    getOrInitializeBackend(context).writeArray(
+    getOrInitializeBackend(context, config.bypass_module_private).writeArray(
       context,
       SKStore.UnitID::singleton,
       Array[TickConfigFile((context.getTick().value, config))],
@@ -449,7 +452,7 @@ fun compile(
 // so the backend mapper never fires — leaving a clean "warm" base that carries
 // the typed stdlib and no unit-specific state.
 fun warm_stdlib(config: Config.Config, context: mutable SKStore.Context): void {
-  _ = getOrInitializeBackend(context);
+  _ = getOrInitializeBackend(context, config.bypass_module_private);
   make_input_source_path = (pkg_base_dir, src_path) ~> {
     res = Path.join(pkg_base_dir, src_path);
     if (config.canonize_paths) {

--- a/skiplang/compiler/src/main.sk
+++ b/skiplang/compiler/src/main.sk
@@ -27,6 +27,11 @@ fun main(): void {
     .arg(Cli.Arg::string("sample-rate").default("0"))
     .arg(Cli.Arg::bool("use-specialized-names"))
     .arg(
+      Cli.Arg::bool("allow-module-private-access").about(
+        "Allow reaching module-`private` elements from outside their module.",
+      ),
+    )
+    .arg(
       Cli.Arg::bool("version")
         .long("version")
         .short("V")

--- a/skiplang/compiler/src/skipExpand.sk
+++ b/skiplang/compiler/src/skipExpand.sk
@@ -661,6 +661,9 @@ class Env{
   module_aliases: UMap<A.Module_alias>,
   tparams: SMap<A.Type_parameter>,
   allowMacros: Bool,
+  // When set (via --allow-module-private-access), cross-module access to a
+  // `private` module element is permitted instead of erroring.
+  allowPrivateAccess: Bool,
 }
 
 fun empty_defs(mod_name: Module_): Defs {
@@ -683,7 +686,7 @@ fun empty_defs_names(): DefNames {
   DefNames(Array[])
 }
 
-fun makeEnv(): Env {
+fun makeEnv(allowPrivateAccess: Bool = false): Env {
   Env{
     context_name => "",
     current_module => Unqualified(),
@@ -691,6 +694,7 @@ fun makeEnv(): Env {
     module_aliases => UMap[],
     tparams => SortedMap[],
     allowMacros => false,
+    allowPrivateAccess,
   }
 }
 
@@ -856,6 +860,7 @@ fun check_module(
     (is_private.fromSome(), env.current_module) match {
     | (false, _) -> void
     | (true, Module(n)) if (mname.i1 == n.i1) -> void
+    | (true, _) if (env.allowPrivateAccess) -> void
     | (true, _) ->
       // If a same-named class exposes this name via `::`, the caller most
       // likely meant that; point them at it (M.foo is module access, M::foo is
@@ -1079,6 +1084,7 @@ class DefsFile(value: (?FileRange, SkipExpand.Defs)) extends SKStore.File
 fun program(
   context: mutable SKStore.Context,
   files: SKStore.EHandle<FileCache.InputSource, SkipParse.DefsFile>,
+  allowPrivateAccess: Bool,
 ): (
   SKStore.EHandle<SKStore.SID, GlobalEnv.ExpandedDefFile>,
   SKStore.EHandle<SKStore.SID, SKStore.StringFile>,
@@ -1115,7 +1121,7 @@ fun program(
     },
   );
   ModuleMap.populateCache(context, moduleDefsDir);
-  expandEnv = makeEnv();
+  expandEnv = makeEnv(allowPrivateAccess);
   expandedDefs = moduleDefsDir.map(
     SKStore.SID::keyType,
     DefsFile::type,

--- a/skiplang/compiler/src/skipMain.sk
+++ b/skiplang/compiler/src/skipMain.sk
@@ -12,6 +12,7 @@ module SkipMain;
 
 fun type_program(
   context: mutable SKStore.Context,
+  allowPrivateAccess: Bool,
 ): SKStore.EHandle<SKStore.SID, SkipTyping.DefFile> {
   parsed_program = FileCache.fileDir.map(
     FileCache.InputSource::keyType,
@@ -54,7 +55,7 @@ fun type_program(
     },
   );
 
-  (defsDir, childDir) = SkipExpand.program(context, ast);
+  (defsDir, childDir) = SkipExpand.program(context, ast, allowPrivateAccess);
   inhDir = SkipInherit.populateClassesDir(context);
   SkipNaming.populateClasses(context, defsDir, inhDir, childDir);
   SkipNaming.populateFuns(context, defsDir);


### PR DESCRIPTION
Closes #1454.

Adds `--allow-module-private-access`, a compile flag that permits reaching module-`private` elements from outside their module. The motivation is white-box tests: with module-`private` enforced (#1343), test code in a *different* module can no longer poke at internals without exposing them in the public API. Off by default, so enforcement stays on everywhere else.

## Implementation

The flag threads from `Config` through the front end to the one place that decides:

```
Config.bypass_module_private
  → getOrInitializeBackend → makeOuterIst → type_program
  → SkipExpand.program → Env.allowPrivateAccess
  → check_module: the private-access arm returns void instead of erroring
```

`check_module` already special-cases same-module access; this adds one more guard arm:

```skip
| (true, _) if (env.allowPrivateAccess) -> void
```

Notes:
- The front end is otherwise config-free, so the flag is threaded explicitly rather than read from a global. `Env.allowPrivateAccess` rides `env with { … }` unchanged, so it reaches every `check_module` on the compile path (which all flow from the single `expandEnv`).
- Works in batch mode too: `Config.withUnit` uses `this with { … }`, so the field is inherited by per-unit configs.
- `element_privacy` and the symbol table are untouched — only the *reporting* is gated, so nothing else changes.

## Verification

- Without the flag, `M.secret()` on a `private fun secret` in another module errors as before; **with `--allow-module-private-access` it compiles and runs**.
- Compiler test suite: all behavioural tests pass, and the flag defaults off so flag-off behaviour is byte-identical to `main`. (Locally one meta-test, `CompilerVersionCheck`, tripped on a stale skc version-stamp left by iterative rebuilds; a clean rebuild makes `skc --version` match `HEAD` again, so CI's fresh build passes it.)

No harness test is added: the invalid/valid test framework compiles every unit with a fixed `skc` command (no per-test flags), so there's no place to exercise a custom flag. Happy to add one if a per-test-flags mechanism is wanted.

## Design note

This is the "global compile flag" option from the discussion on #1454 — the simplest, bluntest one. The alternatives (white-box tests in a *same-module* file, which already works since module-`private` is module-scoped; or an explicit per-module "friend" annotation) stay open; this flag doesn't preclude them. Flag name is easy to change if you'd prefer something like `--unsafe-allow-private`.

— Claude Opus 4.8 (1M context)