### PR TITLE
preamble: nounwind willreturn on SKIP_Obstack_collect (with a re-enablement warning)

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -29,7 +29,14 @@ declare void @__cxa_end_catch()
 declare noalias align 8 ptr @SKIP_Obstack_alloc(i32) nofree
 declare noalias align 8 ptr @SKIP_Obstack_calloc(i32) nofree
 declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
-declare void @SKIP_Obstack_collect(ptr, ptr, i64)
+; WARNING: SKIP_Obstack_collect is the moving-GC relocation hook (emitted by
+; LowerLocalGC in gc.sk with mayRelocatePointers). Its C body is a no-op today
+; (runtime.c: the collector is disabled), so only `nounwind willreturn` are sound.
+; When the moving collector is re-enabled it will READ the root buffer and WRITE
+; relocated pointers back, and may OOM-throw -- at which point `nounwind` becomes a
+; SILENT MISCOMPILE. Revisit these attributes (drop nounwind; do NOT add
+; memory()/nofree/captures) together with any GC re-enablement.
+declare void @SKIP_Obstack_collect(ptr, ptr, i64) nounwind willreturn
 declare noalias align 4 ptr @SKIP_Obstack_shallowClone(i32, ptr readonly captures(none) nonnull) nofree
 
 define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) alwaysinline nounwind uwtable {

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -42,7 +42,14 @@ define void @SKIP_awaitableThrow(ptr, ptr) {
 declare noalias align 8 ptr @SKIP_Obstack_alloc(i64) nofree
 declare noalias align 8 ptr @SKIP_Obstack_calloc(i64) nofree
 declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
-declare void @SKIP_Obstack_collect(ptr, ptr, i64)
+; WARNING: SKIP_Obstack_collect is the moving-GC relocation hook (emitted by
+; LowerLocalGC in gc.sk with mayRelocatePointers). Its C body is a no-op today
+; (runtime.c: the collector is disabled), so only `nounwind willreturn` are sound.
+; When the moving collector is re-enabled it will READ the root buffer and WRITE
+; relocated pointers back, and may OOM-throw -- at which point `nounwind` becomes a
+; SILENT MISCOMPILE. Revisit these attributes (drop nounwind; do NOT add
+; memory()/nofree/captures) together with any GC re-enablement.
+declare void @SKIP_Obstack_collect(ptr, ptr, i64) nounwind willreturn
 declare noalias align 8 ptr @SKIP_Obstack_shallowClone(i64, ptr readonly captures(none) nonnull) nofree
 
 define void @SKIP_Obstack_inl_collect(ptr, ptr, i64) alwaysinline nounwind uwtable {


### PR DESCRIPTION
Follow-up to #1456/#1457: the one function the audit deliberately left bare, now done *with a warning*, per your call.

`SKIP_Obstack_collect` is the moving-GC relocation hook (emitted by `LowerLocalGC` in `gc.sk` with `mayRelocatePointers`). Its C body is a **no-op today** (the moving collector is disabled), so `nounwind willreturn` are sound and let LLVM prune the unreachable-continuation / EH edges around the call.

These are deliberately the **only** two attributes, and a prominent `;` warning comment sits above the declaration:

```llvm
; WARNING: SKIP_Obstack_collect is the moving-GC relocation hook … Its C body is a
; no-op today …, so only `nounwind willreturn` are sound. When the moving collector
; is re-enabled it will READ the root buffer and WRITE relocated pointers back, and
; may OOM-throw -- at which point `nounwind` becomes a SILENT MISCOMPILE. Revisit
; (drop nounwind; do NOT add memory()/nofree/captures) together with any GC re-enablement.
declare void @SKIP_Obstack_collect(ptr, ptr, i64) nounwind willreturn
```

Both preambles `opt -verify` clean; **gated on the wasm jobs** (`skdb-wasm`/`skipruntime`). Part of #1381 §2.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)