### PR TITLE
preamble: bisect — allocsize(0) alone on the obstack allocators (toward #1450)

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -26,8 +26,8 @@ declare void @__cxa_end_catch()
 
 ; Obstack
 
-declare noalias align 8 ptr @SKIP_Obstack_alloc(i32) nofree
-declare noalias align 8 ptr @SKIP_Obstack_calloc(i32) nofree
+declare noalias align 8 ptr @SKIP_Obstack_alloc(i32) allocsize(0) nofree
+declare noalias align 8 ptr @SKIP_Obstack_calloc(i32) allocsize(0) nofree
 declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
 declare void @SKIP_Obstack_collect(ptr, ptr, i64)
 declare noalias align 4 ptr @SKIP_Obstack_shallowClone(i32, ptr readonly captures(none) nonnull) nofree

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -39,8 +39,8 @@ define void @SKIP_awaitableThrow(ptr, ptr) {
 
 ; Obstack
 
-declare noalias align 8 ptr @SKIP_Obstack_alloc(i64) nofree
-declare noalias align 8 ptr @SKIP_Obstack_calloc(i64) nofree
+declare noalias align 8 ptr @SKIP_Obstack_alloc(i64) allocsize(0) nofree
+declare noalias align 8 ptr @SKIP_Obstack_calloc(i64) allocsize(0) nofree
 declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
 declare void @SKIP_Obstack_collect(ptr, ptr, i64)
 declare noalias align 8 ptr @SKIP_Obstack_shallowClone(i64, ptr readonly captures(none) nonnull) nofree


### PR DESCRIPTION
Toward #1450 (reintroduce the value attributes the allocator regression forced us to drop). The reduced set that landed in #1443 kept only `noalias align 8 nofree`; the fuller set (`allocsize(0)` + `memory(inaccessiblemem: readwrite)`) miscompiled wasm (`null function / signature mismatch` = vtable corruption), and **which of the two caused it was never pinned down** — native passed either way, and I reduced blindly.

This **isolates one variable**: `allocsize(0)` alone on `SKIP_Obstack_alloc`/`calloc`. It tells LLVM the allocation size is arg 0 (object-size / dereferenceable reasoning, dead-alloc elimination).

- If the **wasm jobs stay green** → `allocsize` is sound; `memory()` was the offender, and a follow-up can add the correctly-spelled `memory`/`allockind` on top.
- If they **go red** → `allocsize` is the offender (most likely its interaction with the object's negative-offset vtable/metadata) → revert + document precisely.

Gated on `skdb-wasm`/`skipruntime`. This is a deliberate experiment using CI as the wasm oracle I lacked when the original regression slipped through.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)