### PR TITLE
skc: strip DWARF from release wasm (wasm-ld -S)

### DIFF
--- a/skiplang/compiler/src/compile.sk
+++ b/skiplang/compiler/src/compile.sk
@@ -116,6 +116,10 @@ fun getLinkArgs(
         ],
       )
       .map(x -> `-export=${x}`);
+    // Strip DWARF from release wasm (the browser bundle). `-S` (not `-s`)
+    // keeps the `name` section, so JS stack traces still resolve Skip
+    // function names; `--debug` builds keep full debug info.
+    stripArgs = if (config.debug) Array<String>[] else Array["-S"];
     runShell(
       Array[
         "wasm-ld",
@@ -125,7 +129,8 @@ fun getLinkArgs(
         output,
         "--no-entry",
         "-allow-undefined",
-      ].concat(exportJs)
+      ].concat(stripArgs)
+        .concat(exportJs)
         .concat(linker_args)
         .concat(static_libs),
       config.verbose,


### PR DESCRIPTION
skc emits debug info (`DICompileUnit`) unconditionally and the C runtime is built with `-g3`, so the browser wasm bundle carries a large amount of DWARF it never uses. This passes **`-S` (`--strip-debug`)** to `wasm-ld` for non-`--debug` builds — a substantial size reduction for the shipped `skdb-wasm` / `skipruntime` bundles (the earlier audit measured ~47% on `libskdb.wasm`).

`-S`, **not** `-s`: the `name` section is preserved, so JavaScript stack traces still resolve Skip function names (`-s`/`--strip-all` would drop it). `--debug` builds keep full debug info.

Part of #1381 §6.

## Verification note

This is a `compile.sk` change and I can't build `skc` locally in this environment, so it's **CI-verified**: the `compiler` job is the syntax/build gate, and `skdb-wasm`/`skipruntime` exercise the new link path (correctness + that `-S` doesn't break the wasm). If the `compiler` job flags a syntax issue with the conditional concat, I'll fix it. No native codegen is affected (the flag is wasm-link-only).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)