### PR TITLE
prelude: drop the pointless `@debug` from Unsafe.unsafeCast/unsafeGenericCast (#1349)

### DIFF
--- a/skiplang/prelude/src/core/Downcastable.sk
+++ b/skiplang/prelude/src/core/Downcastable.sk
@@ -1,10 +1,8 @@
 module Unsafe;
 
-@debug
 @cpp_extern("SKIP_unsafe_cast")
 native fun unsafeGenericCast<T, U>(t: T): U;
 
-@debug
 @cpp_extern("SKIP_unsafe_cast")
 native fun unsafeCast<T: Downcastable, F: T>(t: T): F;
 


### PR DESCRIPTION
Addresses item 1 of #1349.

`Unsafe.unsafeGenericCast` and `Unsafe.unsafeCast` carry `@debug`, but they bind `@cpp_extern("SKIP_unsafe_cast")`, which is the identity function (`prelude/runtime/runtime.c`: `return obj;`). `@debug`'s only effect is to suppress CSE, so on a pure function it costs optimization for no benefit — unlike the OS-facing natives that got `@debug`/`untracked` in #1337/#1353.

Dropping it is sound (this is *not* the genSym/#1342 hazard):

- **Pure:** `SKIP_unsafe_cast` has no side effects, no state, no allocation — same input always yields the same output. CSE's contract is exactly "identical operands ⇒ identical result", which an identity function satisfies.
- **Only identical calls merge:** these are generic, and the specializer monomorphizes per type-argument tuple, so `unsafeCast<A,B>` and `unsafeCast<C,D>` are different `SFunctionID`s and never merge with each other. Only same-type-arg, same-value calls can merge — where identity guarantees the same result.

So the change is purely optimization-enabling with no observable behaviour change.

— Claude Opus 4.8 (1M context)
