### PR TITLE
ci: add a manual-trigger workflow to publish skdb

### DIFF
--- a/.github/workflows/docker-publish-skdb.yml
+++ b/.github/workflows/docker-publish-skdb.yml
@@ -1,0 +1,175 @@
+name: docker-publish-skdb
+
+# Manual-only publish of skiplabs/skdb.
+#
+# skdb is not in the bake "ci" group, so docker-publish.yml never pushes it --
+# it only builds it as a cacheonly dependency of skdb-dev-server. skdb bakes in
+# repo source, so publishing it is a release of main rather than a routine
+# toolchain rebuild; that is why it stays behind a manual trigger with no
+# schedule. The build machinery mirrors docker-publish.yml (native per-arch
+# build, push by digest, merge into a multi-arch tag, verify attestations), but
+# for the single skdb target.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-publish-skdb-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # setup-buildx-action's version input has no default, and imagetools create
+  # silently dropped attestations before buildx v0.30.0.
+  BUILDX_VERSION: v0.35.0
+  # The skdb target's repository in docker-bake.hcl, without the :tag -- a
+  # push-by-digest build needs a name with no tag.
+  IMAGE: skiplabs/skdb
+
+jobs:
+  check-push-access:
+    # A manual dispatch on a fork should never try to publish.
+    if: github.repository == 'SkipLabs/skip'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+      - name: Check the credentials can push skdb
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: ./bin/check_push_access.sh "$IMAGE"
+
+  build:
+    needs: [check-push-access]
+    if: github.repository == 'SkipLabs/skip'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The compiler is built from source in the image, and its Makefile
+          # needs the pinned bootstrap and libbacktrace submodules.
+          submodules: true
+      - uses: docker/setup-buildx-action@v4
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Show disk space before build
+        shell: bash
+        run: df -h /
+      - name: Build and push by digest
+        id: bake
+        uses: docker/bake-action@v7
+        with:
+          # v6+ defaults to the git context, which would pick up neither the
+          # submodules checked out above nor .dockerignore.
+          source: .
+          files: ./docker-bake.hcl
+          # skdb only; its skip dependency builds as a cacheonly link and is
+          # never pushed.
+          targets: skdb
+          pull: true
+          # Matches bin/docker_build.sh. mode=max records build args: do not
+          # pass secrets as build args.
+          provenance: mode=max
+          sbom: true
+          set: |
+            *.platform=${{ matrix.platform }}
+            *.output=type=image,push-by-digest=true,name-canonical=true,push=true
+            skdb.tags=docker.io/${{ env.IMAGE }}
+      - name: Export digest
+        shell: bash
+        env:
+          METADATA: ${{ steps.bake.outputs.metadata }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p /tmp/digests
+          digest=$(jq -r '.skdb["containerimage.digest"] // empty' <<< "$METADATA")
+          if [[ -z "$digest" ]]; then
+            echo "::error::no digest for skdb in bake metadata"
+            exit 1
+          fi
+          echo "$digest" > "/tmp/digests/$ARCH"
+          echo "skdb $ARCH -> $digest"
+      - name: Show disk space after build
+        if: always()
+        shell: bash
+        run: df -h /
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    if: github.repository == 'SkipLabs/skip'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v4
+        with:
+          # Load bearing: imagetools create runs from the CLI plugin this
+          # installs, and it is what preserves or drops the per-platform
+          # attestations.
+          version: ${{ env.BUILDX_VERSION }}
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create the multi-arch tag
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(/tmp/digests/*)
+          if [[ "${#files[@]}" -eq 0 ]]; then
+            echo "::error::no digests downloaded"
+            exit 1
+          fi
+          refs=()
+          for f in "${files[@]}"; do
+            refs+=("docker.io/$IMAGE@$(cat "$f")")
+          done
+          docker buildx imagetools create -t "docker.io/$IMAGE:latest" "${refs[@]}"
+      - name: Check attestations survived the merge
+        shell: bash
+        run: |
+          # A dropped attestation is silent -- the image still works, it just has
+          # no provenance. Each platform contributes its image manifest plus an
+          # attestation manifest, so assert both are present.
+          shopt -s nullglob
+          files=(/tmp/digests/*)
+          platforms=${#files[@]}
+          expected=$((platforms * 2))
+          raw=$(docker buildx imagetools inspect "docker.io/$IMAGE:latest" --raw)
+          total=$(jq '.manifests | length' <<< "$raw")
+          attested=$(jq '[.manifests[]
+                          | select(.annotations["vnd.docker.reference.type"]
+                                   == "attestation-manifest")] | length' <<< "$raw")
+          echo "$IMAGE:latest: $total manifest(s), $attested attestation(s)"
+          if [[ "$total" -ne "$expected" || "$attested" -ne "$platforms" ]]; then
+            echo "::error::expected $expected manifests and $platforms attestation(s)"
+            exit 1
+          fi

--- a/bin/check_push_access.sh
+++ b/bin/check_push_access.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Assert the configured Docker Hub credentials can push every image in the bake
-# "ci" group, before anything spends ten minutes building them.
+# Assert the configured Docker Hub credentials can push the given images, before
+# anything spends ten minutes building them. With no arguments, checks every
+# image in the bake "ci" group; with arguments, checks exactly those repos (bare
+# namespace/name, e.g. skiplabs/skdb).
 #
 # Docker Hub's token endpoint does not reject a scope you lack. It returns 200
 # with a token carrying only the scopes you DO have, and the push then fails
@@ -14,10 +16,10 @@
 # because the push failed the merge job never ran -- so no image's :latest was
 # updated that run, not even the four whose credentials were fine.
 #
-# Reads the repository list from the same bake "ci" group the workflow pushes,
-# so this cannot disagree with what is actually published.
+# With no arguments, reads the repository list from the same bake "ci" group the
+# workflow pushes, so this cannot disagree with what is actually published.
 #
-# Usage: DOCKERHUB_USERNAME=... DOCKERHUB_TOKEN=... check_push_access.sh
+# Usage: DOCKERHUB_USERNAME=... DOCKERHUB_TOKEN=... check_push_access.sh [REPO...]
 
 set -euo pipefail
 
@@ -27,18 +29,23 @@ REPO="$SCRIPT_DIR/.."
 : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME must be set}"
 : "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN must be set}"
 
-# Bare `namespace/name` for every published image, e.g. skiplabs/skip.
+# Bare `namespace/name` for every image to check, e.g. skiplabs/skip: the
+# explicit arguments if given, otherwise the whole bake "ci" group.
 repos=()
-while IFS= read -r r; do
-    repos+=("$r")
-done < <(
-    docker buildx bake -f "$REPO/docker-bake.hcl" --print ci |
-        jq -r '.group.ci.targets[] as $t
-               | .target[$t].tags[0]
-               | sub(":.*$"; "")'
-)
+if [[ $# -gt 0 ]]; then
+    repos=("$@")
+else
+    while IFS= read -r r; do
+        repos+=("$r")
+    done < <(
+        docker buildx bake -f "$REPO/docker-bake.hcl" --print ci |
+            jq -r '.group.ci.targets[] as $t
+                   | .target[$t].tags[0]
+                   | sub(":.*$"; "")'
+    )
+fi
 if [[ ${#repos[@]} -eq 0 ]]; then
-    echo 'Error: bake group "ci" resolved no images' >&2
+    echo 'Error: no repositories to check' >&2
     exit 1
 fi
 
@@ -94,4 +101,4 @@ EOF
     exit 1
 fi
 
-echo "OK: credentials can push all ${#repos[@]} image(s) in bake group \"ci\""
+echo "OK: credentials can push all ${#repos[@]} image(s)"


### PR DESCRIPTION
Adds a `workflow_dispatch`-only workflow that rebuilds and publishes `skiplabs/skdb`, the one tagged image the automated `docker-publish.yml` doesn't cover.

## Why manual-only

`skdb` isn't in the bake `ci` group, so `docker-publish.yml` never pushes it — it only builds it as a *cacheonly* dependency of `skdb-dev-server`. Unlike the toolchain images, `skdb` bakes in repo source, so publishing it is effectively a release of `main` rather than a routine rebuild. So: dispatch-only, no schedule.

## What it does

Same proven machinery as `docker-publish.yml`, reduced to the single `skdb` target:

- `check-push-access` preflight (see below), then native per-arch build on `ubuntu-24.04` + `ubuntu-24.04-arm`, push by digest, merge into `skiplabs/skdb:latest`, and verify both platforms' provenance/SBOM attestations survived the merge.
- Its `skip` dependency builds as a cacheonly link and is never pushed — confirmed with `bake --print`.
- `skdb` already builds on GitHub runners today (the weekly run builds it as `skdb-dev-server`'s dependency), so no new build risk.

Second commit generalizes `bin/check_push_access.sh` to take explicit repositories (falling back to the `ci` group when none are given), so this workflow reuses the same one-second scope check instead of duplicating it.

## Maintainer prerequisites

`skiplabs/skdb` **does not exist on Docker Hub yet** (it's never been published). Before the first run:

1. Grant the `DOCKERHUB_TOKEN` account push access to `skiplabs/skdb` (add it to the token's repository scope). The `check-push-access` job fails in ~1s with a clear message if this is missing, so a forgotten scope costs nothing — but the build won't publish until it's granted.
2. The first successful push creates the repo (default-private on Docker Hub; flip to public if intended).

Then run it: `gh workflow run docker-publish-skdb.yml --repo SkipLabs/skip --ref main`.

Verified locally as far as is possible without pushing: `bake --print` target resolution (skdb → push-by-digest, skip → cacheonly), the digest-extraction and merge/attestation shell logic against realistic metadata, and actionlint clean. The push→merge→attestation mechanics themselves are the same ones already validated in production by `docker-publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)