### PR TITLE
preamble: declare the native x86_64 target datalayout

### DIFF
--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -1,3 +1,4 @@
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-linux-gnu"
 
 declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr) noreturn cold


### PR DESCRIPTION
Part of #1381 §6 ("target configuration and pipeline").

`preamble64.ll` carried only a `target triple` and no `target datalayout` — the only preamble missing one (`preamble32.ll` has always had one). This adds clang 20's exact inferred `x86_64-pc-linux-gnu` layout.

**This is a consistency/robustness change, not a codegen change.** The native path is a single `clang++ --target=<t> module.ll` invocation, and clang already infers this exact string from the triple. Making it explicit stops relying on that inference and makes the native preamble symmetric with the wasm one.

### Verification (pinned clang/LLVM 20.1.8)

- The string is byte-for-byte clang's own inferred layout: `clang --target=x86_64-pc-linux-gnu -S -emit-llvm -x c /dev/null` emits exactly `e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128`.
- Toggling **only** this line on the host target yields **byte-identical** object files (`.text`/`.rodata`/`.data` unchanged; the sole diff in a naïve `cmp` is the embedded source filename in `.strtab`).
- On a non-x86_64 `--target`, clang silently overrides the module datalayout via the same `-Woverride-module` path the *already-hardcoded triple* relies on, so the line stays inert there and adds no new warning.
- `opt -passes=verify` is clean; the full preamble still `opt -O2`s without error.

### Note

This adds a second hardcoded artifact (alongside the triple) to keep in sync with clang across future LLVM bumps; within the pinned 20.x range the x86_64 layout is stable. A real cross-compilation path (the `Target` TODO in `Config.sk`) would eventually let skc derive both the triple and the datalayout from the target instead of hardcoding them.

---
<sub>Written by Claude (Opus 4.8, 1M-context, high reasoning effort) via Claude Code, on behalf of @mbouaziz. All datalayout facts re-derived and adversarially verified against the pinned LLVM 20.1.8 toolchain.</sub>
