### PR TITLE
preamble: sync the wasm32 target datalayout with clang 20

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
 target triple = "wasm32"
 
 declare void @SKIP_print_last_exception_stack_trace_and_exit(ptr) noreturn cold


### PR DESCRIPTION
Part of #1381 §6 ("target configuration and pipeline").

`preamble32.ll`'s `target datalayout` was stale (`e-m:e-p:32:32-i64:64-n32:64-S128`), predating several LLVM releases. This updates it to clang 20's canonical `wasm32` layout. The delta is **purely additive** — it adds `p10:8:8`, `p20:8:8`, `i128:128`, `ni:1:10:20`; nothing is changed or removed.

The wasm path is `llvm-link → opt → llc`, and `opt` is invoked **without** `-mtriple`, so the in-module datalayout (from this preamble) is authoritative through the whole pipeline.

### Why this is correct and behaviour-preserving

The wasm C runtime — built from `runtime/Makefile`'s `CC32FLAGS` (`--target=wasm32 -emit-llvm ...`) — already carries this exact layout. So today the Skip module (via this preamble) and the runtime it links against disagree on datalayout; this aligns them, and with clang's own wasm32 layout. It also removes an obstacle to the cross-language bitcode IPO proposed in #1381 §3 (which would `llvm-link` the runtime bitcode into the module — where a datalayout mismatch surfaces as a warning).

It's inert for the IR skc actually emits:

- integers are capped at i64 (`specialize.sk:1500-1507`), so `i128:128` binds to no type skc can produce;
- every pointer is a plain address-space-0 `ptr` (`types.sk:121-127`) — skc emits **zero** `addrspace` tokens — so `p10`/`p20`/`ni:1:10:20` (which bind only to address spaces 1/10/20) never attach;
- object layout uses explicit byte-offset `getelementptr inbounds i8` (`Layout.sk`, `AsmOutput.sk`), so LLVM struct layout / type alignment is never consulted for Skip objects.

Empirically confirmed against the compressed bootstrap IR corpus (skc/skargo/skfmt, ~9.5 MB) plus a freshly-emitted module: **zero** `addrspace` tokens, **zero** i128-or-wider integers, maximum integer width i64.

### Verification (pinned clang/LLVM 20.1.8)

`opt -O{0,2,3}` (no `-mtriple`, exactly as the build runs it) then `llc -mtriple=wasm32-unknown-unknown -O{0,2,3} -filetype=obj` produced **byte-identical** wasm objects under the old and new layouts, for both a realistic Skip-shaped module (obstack alloc, byte-offset GEP field stores, `inttoptr`/`ptrtoint` on address space 0) and an adversarial one deliberately exercising i128, wide i64 stores, and 64-byte-aligned memcpy. (`opt` itself already normalises the stale layout by inserting `i128:128`, so the pipeline effectively used it already.)

> ⚠️ `llc`/`opt` never validate an in-module datalayout against `-mtriple` (a deliberately-wrong `p:16:16` changed the object with no diagnostic), so this change has no build-time safety net. It should land behind a green **wasm CI** run (skdb-wasm / skipruntime), which is the oracle for wasm codegen changes.

---
<sub>Written by Claude (Opus 4.8, 1M-context, high reasoning effort) via Claude Code, on behalf of @mbouaziz. The additive delta, the runtime-vs-module divergence, and byte-level codegen equivalence were adversarially verified against the pinned LLVM 20.1.8 toolchain.</sub>
