### PR TITLE
preamble: define SKIP_Obstack_vectorUnsafeSet inline (AA unlock)

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -28,7 +28,10 @@ declare void @__cxa_end_catch()
 
 declare noalias align 8 ptr @SKIP_Obstack_alloc(i32) nofree
 declare noalias align 8 ptr @SKIP_Obstack_calloc(i32) nofree
-declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
+define linkonce_odr void @SKIP_Obstack_vectorUnsafeSet(ptr %arr, ptr %x) alwaysinline nounwind uwtable {
+  store ptr %x, ptr %arr
+  ret void
+}
 ; WARNING: SKIP_Obstack_collect is the moving-GC relocation hook (emitted by
 ; LowerLocalGC in gc.sk with mayRelocatePointers). Its C body is a no-op today
 ; (runtime.c: the collector is disabled), so only `nounwind willreturn` are sound.

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -42,7 +42,10 @@ define void @SKIP_awaitableThrow(ptr, ptr) {
 
 declare noalias align 8 ptr @SKIP_Obstack_alloc(i64) nofree
 declare noalias align 8 ptr @SKIP_Obstack_calloc(i64) nofree
-declare void @SKIP_Obstack_vectorUnsafeSet(ptr writeonly captures(none) nonnull, ptr) nounwind willreturn nofree memory(argmem: write)
+define linkonce_odr void @SKIP_Obstack_vectorUnsafeSet(ptr %arr, ptr %x) alwaysinline nounwind uwtable {
+  store ptr %x, ptr %arr
+  ret void
+}
 ; WARNING: SKIP_Obstack_collect is the moving-GC relocation hook (emitted by
 ; LowerLocalGC in gc.sk with mayRelocatePointers). Its C body is a no-op today
 ; (runtime.c: the collector is disabled), so only `nounwind willreturn` are sound.


### PR DESCRIPTION
Part of #1381 §3 ("Linkage and IPO").

`SKIP_Obstack_vectorUnsafeSet` was an opaque external `declare`, so every array-element store — emitted by the `ArrayUnsafeSet` lowering (`AsmOutput.sk:2840`) — looked to LLVM's alias analysis like a call that may clobber all memory. This defines it inline instead, mirroring the existing `SKIP_Obstack_store` helper. Its C body is a single pointer store:

```c
// runtime.c:46-48
void SKIP_Obstack_vectorUnsafeSet(char** arr, char* x) { *arr = x; }
```

```llvm
define linkonce_odr void @SKIP_Obstack_vectorUnsafeSet(ptr %arr, ptr %x) alwaysinline nounwind uwtable {
  store ptr %x, ptr %arr
  ret void
}
```

Unlike `SKIP_Obstack_store` (which has no C definition and so is a plain external `define`), this function *does* have a strong C definition, so it is marked **`linkonce_odr`** — the runtime's definition still wins at link time. `alwaysinline` fires on every path (including `-O0`), so no un-inlined call site remains and the dead weak definition is DCE'd; nothing external references the symbol (it is not in `compile.sk`'s wasm export list and is called only by skc-generated code).

### Effect

`opt -O2` inlines each call to a bare `store` and then infers `nocapture writeonly initializes(...)` on the receiver — attributes the opaque `declare` blocked entirely — letting AA disambiguate array writes from unrelated memory (loads across an array store can now be forwarded/reordered).

### Why it's behaviour-preserving (verified, pinned clang/LLVM 20.1.8)

- **Semantics**: `store ptr %x, ptr %arr` is exactly the C `*arr = x`. The store carries no explicit `align`, so it defaults to the datalayout's ABI alignment for `ptr` — **8** on x86_64, **4** on wasm32 — byte-identical to what clang emits for the C definition on each target.
- **Inlining**: on both x86_64 and wasm32, `opt -O2` fully inlines the def to a single `store` and DCEs the dead weak def; the always-inliner fires even at `-O0`.
- **Linkage**: linking the (DCE'd) `-O2` object against the strong C def links clean; and in the adversarial case where the weak `W` symbol is forced to survive un-inlined, `wasm-ld`/`ld` link with **no duplicate-symbol error** and the strong runtime definition wins in the output (confirmed with a distinguishable runtime body). `linkonce_odr` coexists cleanly with the plain-external `SKIP_Obstack_store` in the same module (full-preamble `opt -passes=verify` + `-O2` pass).

This was checked directly and by three independent adversarial reviews (wasm end-to-end, linkage/DCE/`-O0`, native + alignment semantics) with the real preambles and a runtime object built exactly as `runtime/Makefile` specifies; none could reproduce a miscompile, lost/duplicate symbol, or link failure.

> ⚠️ Preamble changes are exercised by the wasm CI (the std sklib is rebuilt), so this should land behind a green **skdb-wasm / skipruntime** run — the oracle for wasm codegen.

---
<sub>Written by Claude (Opus 4.8, 1M-context, high reasoning effort) via Claude Code, on behalf of @mbouaziz. Semantics, inlining, linkage and alignment equivalence were adversarially verified against the pinned LLVM 20.1.8 toolchain and the real runtime object.</sub>
