### PR TITLE
preamble: define SKIP_llvm_memcpy/memset via real LLVM intrinsics

### DIFF
--- a/skiplang/prelude/preamble/preamble32.ll
+++ b/skiplang/prelude/preamble/preamble32.ll
@@ -6,13 +6,22 @@ declare void @SKIP_throw(ptr) noreturn cold
 declare void @SKIP_unreachableMethodCall(ptr, ptr) noreturn cold
 declare void @SKIP_unreachableWithExplanation(ptr) noreturn cold
 declare ptr @SKIP_intern(ptr)
-declare ptr @SKIP_llvm_memcpy(ptr writeonly, ptr readonly captures(none), i64) memory(argmem: readwrite) mustprogress nounwind willreturn nofree
-declare void @SKIP_llvm_memset(ptr writeonly captures(none), i8, i64) memory(argmem: write) mustprogress nounwind willreturn nofree
+define linkonce_odr ptr @SKIP_llvm_memcpy(ptr %dest, ptr %src, i64 %len) alwaysinline nounwind uwtable {
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 %len, i1 false)
+  ret ptr %dest
+}
+define linkonce_odr void @SKIP_llvm_memset(ptr %dest, i8 %val, i64 %len) alwaysinline nounwind uwtable {
+  call void @llvm.memset.p0.i64(ptr %dest, i8 %val, i64 %len, i1 false)
+  ret void
+}
 
 ; LLVM intrinsics
 
 declare void @llvm.lifetime.start(i64 immarg, ptr nocapture)
 declare void @llvm.lifetime.end(i64 immarg, ptr nocapture)
+
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias captures(none) writeonly, ptr noalias captures(none) readonly, i64, i1 immarg)
+declare void @llvm.memset.p0.i64(ptr captures(none) writeonly, i8, i64, i1 immarg)
 
 declare i32 @llvm.eh.typeid.for(ptr)
 

--- a/skiplang/prelude/preamble/preamble64.ll
+++ b/skiplang/prelude/preamble/preamble64.ll
@@ -6,13 +6,22 @@ declare void @SKIP_throw(ptr) noreturn cold
 declare void @SKIP_unreachableMethodCall(ptr, ptr) noreturn cold
 declare void @SKIP_unreachableWithExplanation(ptr) noreturn cold
 declare ptr @SKIP_intern(ptr)
-declare ptr @SKIP_llvm_memcpy(ptr writeonly, ptr readonly captures(none), i64) memory(argmem: readwrite) mustprogress nounwind willreturn nofree
-declare void @SKIP_llvm_memset(ptr writeonly captures(none), i8, i64) memory(argmem: write) mustprogress nounwind willreturn nofree
+define linkonce_odr ptr @SKIP_llvm_memcpy(ptr %dest, ptr %src, i64 %len) alwaysinline nounwind uwtable {
+  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 %len, i1 false)
+  ret ptr %dest
+}
+define linkonce_odr void @SKIP_llvm_memset(ptr %dest, i8 %val, i64 %len) alwaysinline nounwind uwtable {
+  call void @llvm.memset.p0.i64(ptr %dest, i8 %val, i64 %len, i1 false)
+  ret void
+}
 
 ; LLVM intrinsics
 
 declare void @llvm.lifetime.start(i64 immarg, ptr nocapture)
 declare void @llvm.lifetime.end(i64 immarg, ptr nocapture)
+
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias captures(none) writeonly, ptr noalias captures(none) readonly, i64, i1 immarg)
+declare void @llvm.memset.p0.i64(ptr captures(none) writeonly, i8, i64, i1 immarg)
 
 declare i32 @llvm.eh.typeid.for(ptr)
 


### PR DESCRIPTION
Part of #1381 §4 ("intrinsics and memory operations").

`SKIP_llvm_memcpy` and `SKIP_llvm_memset` were opaque external `declare`s, so LLVM saw calls it couldn't reason about — it couldn't expand a constant-size copy, forward or eliminate the initializing stores, or drop a dead copy. Both are thin shims over the C library:

```c
// runtime.c
void* SKIP_llvm_memcpy(char* dest, char* val, SkipInt len) { return memcpy(dest, val, len); }
void  SKIP_llvm_memset(char* dest, int8_t val, SkipInt len) { memset(dest, val, len); }
```

This defines them inline in the preamble — mirroring `SKIP_Obstack_store` / the just-landed `SKIP_Obstack_vectorUnsafeSet` — calling the **real** `@llvm.memcpy`/`@llvm.memset` intrinsics, so `opt` inlines each wrapper to a real intrinsic:

```llvm
declare void @llvm.memcpy.p0.p0.i64(ptr noalias captures(none) writeonly, ptr noalias captures(none) readonly, i64, i1 immarg)
declare void @llvm.memset.p0.i64(ptr captures(none) writeonly, i8, i64, i1 immarg)

define linkonce_odr ptr @SKIP_llvm_memcpy(ptr %dest, ptr %src, i64 %len) alwaysinline nounwind uwtable {
  call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 %len, i1 false)
  ret ptr %dest
}
define linkonce_odr void @SKIP_llvm_memset(ptr %dest, i8 %val, i64 %len) alwaysinline nounwind uwtable {
  call void @llvm.memset.p0.i64(ptr %dest, i8 %val, i64 %len, i1 false)
  ret void
}
```

Marked `linkonce_odr` (like `vectorUnsafeSet`) so the runtime's strong definition still wins at link time.

### What it unlocks

LLVM now models the copy/fill precisely: dead-copy elimination, store forwarding, constant-size expansion, and target memcpy/memset lowering — none of which fire through an opaque call.

### Verification (pinned clang/LLVM 20.1.8)

**End-to-end with a real skc built from `main`:** recompiled the entire stdlib with the modified preamble, compiled + **ran a test binary correctly** (`Array.clone()` + a zeroed `Array::mfill`), and `opt -O2` on the emitted module leaves **36 real `llvm.mem*` calls and 0 surviving `SKIP_llvm_mem*` wrappers**. A memcpy into a never-read buffer is eliminated entirely (dead-copy elimination) — impossible through the old opaque call.

**Soundness (checked directly + 3 adversarial reviews):**
- **Semantics** — `i1 false` (non-volatile) and the non-overlapping contract match C `memcpy`/`memset` exactly. The C runtime already uses `memcpy` (not `memmove`), so overlap is *already* UB; and the two call sites — `ArrayClone` (`lower.sk`) and zeroing a fresh `alloca` (`AsmOutput.sk`) — always write freshly-allocated, non-aliasing memory. Skip has no volatile/MMIO notion.
- **wasm i64-length** — Skip `Int` is 64-bit, so the `.i64` intrinsic is used on both targets; `llc` lowers it to `memory.copy`/`memory.fill` on wasm32, **byte-identical** to what clang emits for the equivalent C for real (in-address-space) lengths.
- **Linkage** — the `linkonce_odr` (weak) defs link cleanly against the strong C defs on native `ld` and `wasm-ld` in both link orders; the strong runtime def wins; the module def's wasm signature (`(i32,i32,i64)->i32`) matches the runtime's, so no signature-mismatch warning.

### Caveat (honest)

`memset` (void→void) inlines at every opt level. `memcpy` inlines at **-O2+** (release/wasm builds); at **-O0** the skc call site's discarded ptr return blocks the always-inliner, so it stays a correct call to the runtime — **no worse than the previous opaque declare**, just unoptimized in debug builds. Fully aligning the call type is a separate compiler-side follow-up, tracked in #1472.

> ⚠️ Preamble changes are exercised by the wasm CI (std sklib is rebuilt), so this should land behind a green **skdb-wasm / skipruntime** run.

---
<sub>Written by Claude (Opus 4.8, 1M-context, high reasoning effort) via Claude Code, on behalf of @mbouaziz. Verified end-to-end on a from-`main` skc build and by three independent adversarial reviews against the pinned LLVM 20.1.8 toolchain.</sub>
