### PR TITLE
ci: base native-addon test image on node:bookworm-slim, not ubuntu+nodesource

### DIFF
--- a/skipruntime-ts/tests/native_addon_unreleased/Dockerfile
+++ b/skipruntime-ts/tests/native_addon_unreleased/Dockerfile
@@ -1,15 +1,24 @@
-FROM ubuntu:latest
+# Node comes baked into the base image. Bookworm matches the glibc floor (2.36)
+# of the debian:bookworm image that builds libskipruntime.so (see
+# skiplang/Dockerfile), so the copied-in .so loads. Deliberately NOT
+# `ubuntu:latest` + a nodesource apt repo: that downloaded Node over the network
+# on every CI run -- setup_remote_docker gives an ephemeral daemon, so the apt
+# cache never persists -- ballooning this step from ~30s to ~500s whenever those
+# mirrors were slow.
+FROM node:22.13.1-bookworm-slim
 
 ARG TARGETARCH
 
-# install dependencies needed to build the node addon
+# Install only the node-gyp toolchain (g++, make, python3), CA certificates, and
+# curl -- build/install_runtime.sh uses it to copy the .so from the file:// source
+# below. curl, not wget: GNU wget does not support file:// URLs. (This slipped by
+# under the old ubuntu base only because that image happened to ship curl, which
+# install_runtime.sh prefers; node:*-slim does not, so it must be installed here.)
 RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/root/.npm,sharing=locked \
     apt-get update --quiet \
- && apt-get install --quiet --yes --no-install-recommends ca-certificates g++ make python3 wget \
- && wget --quiet --output-document=- https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get install --quiet --yes --no-install-recommends nodejs \
+ && apt-get install --quiet --yes --no-install-recommends ca-certificates curl g++ make python3 \
  && npm install --global typescript
 
 # copy the npm pack archives, libskipruntime.so files, and install_runtime.sh


### PR DESCRIPTION
Fixes #1470.

## Problem

The `skipruntime` CI job's wall-time jumped from a steady ~9.8 min to 15–18 min on 2026-07-22. It localizes entirely to one Docker build layer in the native-addon test — the dependency install:

| stage | fast #18685 (07-21) | slow #19333 (07-22) |
|------|--------------------:|--------------------:|
| `FROM ubuntu:latest` | 1.9s | 1.9s |
| **apt + nodesource + `npm i -g typescript`** | **30.4s** | **503.9s** |
| everything else | ~10s | ~10s |

The blow-up tracks wall-clock, not commits (the *same commit* ran this layer at 32s and 111s hours apart; `ubuntu:latest`'s digest never changed). Root cause: the Dockerfile installs Node from the nodesource apt repo **on every run**, and since the job uses `setup_remote_docker` (an ephemeral daemon) the BuildKit apt cache never persists — so every run re-downloads Node and is fully exposed to mirror slowness. At 503.9s it was closing on the step's 10 min `no_output_timeout`.

## Fix

Bake Node into the base image; stop installing it at build time.

- `FROM node:22.13.1-bookworm-slim` — **bookworm** matches the glibc floor (2.36) of the `debian:bookworm` image that builds `libskipruntime.so` (`skiplang/Dockerfile`), so the copied-in `.so` loads. Pinned to `22.13.1`, consistent with the example Dockerfiles.
- Install **curl** instead of wget for the toolchain: `bin/install_runtime.sh` copies the `.so` from a `file://` source, and GNU wget does not support `file://` URLs. The old `ubuntu:latest` base happened to ship curl (which `install_runtime.sh` prefers), so this went unnoticed; `node:*-slim` does not, so curl is now explicit. (The first CI run on this branch confirmed both halves: the apt layer dropped to **16.2s**, then `install_runtime.sh` failed silently on the missing curl — now fixed.)

Net effect: the ~30–500s network-bound layer is gone; the remaining apt install is a small, fixed build-tool set. No behavior change to the test itself.

## Note

`skipruntime-ts/tests/native_addon/Dockerfile` (the "released" variant, not run by this job) has the identical pattern and can get the same treatment as a follow-up — kept out of this PR to keep the diff focused.

---
— Claude Opus 4.8 (xhigh effort)
