### PR TITLE
lower: type the SKIP_llvm_memcpy call site as ptr, not void (fixes #1472)

### DIFF
--- a/skiplang/compiler/src/lower.sk
+++ b/skiplang/compiler/src/lower.sk
@@ -387,6 +387,11 @@ mutable class .Lower{
     );
 
     // call wrapper for llvm.memcpy intrinsic
+    // The wrapper returns its `dest` argument (like C `memcpy`), so the call
+    // site is typed as a (non-GC) pointer rather than void; the result is
+    // unused. Matching the callee's return type lets the always-inliner inline
+    // the preamble's `SKIP_llvm_memcpy` definition even at -O0 (a void call of
+    // a ptr-returning function is left un-inlined). See #1472.
     _ = this.emitNamedCall{
       args => Array[
         mem.id,
@@ -395,7 +400,7 @@ mutable class .Lower{
         // alignment = vtableByteSize
         // volatile = false
       ],
-      typ => tVoid,
+      typ => tNonGCPointer,
       pos,
       canThrow => false,
       allocAmount => AllocNothing(),


### PR DESCRIPTION
Fixes #1472.

`lowerArrayClone` (`lower.sk`) emitted the `SKIP_llvm_memcpy` call site with return type `void`, but the callee returns `ptr` (its `dest`, like C `memcpy`). LLVM tolerates a `void` call of a `ptr`-returning function by discarding the result, so this always worked — but the mismatch **blocks the always-inliner from inlining the preamble's `SKIP_llvm_memcpy` definition** (added in #1469) at `-O0`: the inliner won't inline a call whose result type differs from the callee's.

The fix types the call site as `tNonGCPointer` (→ `call ptr`). The result is unused, and being non-GC it needs no root tracking; matching the callee's return type lets `memcpy` inline at **every** optimization level, not just `-O2+`.

### Verification (stage1 skc built from this change, clang/LLVM 20.1.8)

- skc now emits `%r = call ptr @SKIP_llvm_memcpy(...)` (was `call void`).
- **-O0**: the call now inlines to a real `llvm.memcpy` (`real=1, wrapper=0`). Before, at `-O0` the wrapper survived un-inlined (confirmed on a minimal repro: `call void` of a `define ptr` is valid but the always-inliner leaves it in place).
- **-O2**: unchanged (`real=1, wrapper=0`) — it already inlined there.
- The compiled test binary (`Array.clone()`) runs correctly.

This is a target-agnostic change (call-site type; the always-inliner behaves identically on wasm), and the resulting wasm `llvm.memcpy` codegen was already verified in #1469. The `compiler` CI job builds skc from this change and runs the compiler test suite with it.

---
<sub>Written by Claude (Opus 4.8, 1M-context, high reasoning effort) via Claude Code, on behalf of @mbouaziz. Verified end-to-end on a stage1 skc built from this change.</sub>
