### PR TITLE
skc: emit llvm.memcpy/memset intrinsics directly

### DIFF
--- a/skiplang/compiler/src/AsmOutput.sk
+++ b/skiplang/compiler/src/AsmOutput.sk
@@ -3195,9 +3195,10 @@ private fun llvmWrite(instr: Stmt, asm: mutable FunAsmDefBuilder): void {
         instr,
     );
     if (zero) {
-      // call wrapper for llvm.memset. we know alignment=8, volatile=false
+      // Emit the llvm.memset intrinsic directly. The trailing `i1 false` is the
+      // (non-volatile) `isvolatile` immarg.
       asm.print(
-        "  call void @SKIP_llvm_memset(%N, i8 0, i64 %s), %D\n" %
+        "  call void @llvm.memset.p0.i64(%N, i8 0, i64 %s, i1 false), %D\n" %
           instr %
           byteSize %
           instr,

--- a/skiplang/compiler/src/lower.sk
+++ b/skiplang/compiler/src/lower.sk
@@ -386,25 +386,22 @@ mutable class .Lower{
       true,
     );
 
-    // call wrapper for llvm.memcpy intrinsic
-    // The wrapper returns its `dest` argument (like C `memcpy`), so the call
-    // site is typed as a (non-GC) pointer rather than void; the result is
-    // unused. Matching the callee's return type lets the always-inliner inline
-    // the preamble's `SKIP_llvm_memcpy` definition even at -O0 (a void call of
-    // a ptr-returning function is left un-inlined). See #1472.
+    // Emit the llvm.memcpy intrinsic directly. Skip only ever copies between
+    // freshly-allocated, non-overlapping obstack memory, so plain (non-volatile)
+    // memcpy semantics apply. The trailing `isvolatile` operand must be an
+    // immediate (immarg); a ConstantBool lowers to an inline `i1 0`.
     _ = this.emitNamedCall{
       args => Array[
-        mem.id,
-        v.value,
+        mem.id, // dest
+        v.value, // src
         numBytes.id, // bytes to copy
-        // alignment = vtableByteSize
-        // volatile = false
+        this.constantBool(false).id, // isvolatile = false
       ],
-      typ => tNonGCPointer,
+      typ => tVoid,
       pos,
       canThrow => false,
       allocAmount => AllocNothing(),
-      name => "SKIP_llvm_memcpy",
+      name => "llvm.memcpy.p0.p0.i64",
     }
   }
 


### PR DESCRIPTION
Part of #1381 §4. Follow-on to #1469 (which introduced the inline `SKIP_llvm_memcpy`/`memset` preamble definitions) and #1474.

skc now emits the LLVM memory intrinsics **directly** instead of calling the `SKIP_llvm_memcpy`/`SKIP_llvm_memset` runtime wrappers (which opt then had to inline to recover the intrinsic):

- `lower.sk` `lowerArrayClone` → `call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 %len, i1 false)`
- `AsmOutput.sk` zeroed-alloca path → `call void @llvm.memset.p0.i64(ptr, i8 0, i64 %len, i1 false)`

The `isvolatile` operand is emitted as an inline `i1` **immarg** — for memcpy via a `constantBool(false)` argument (skc already emits immargs this way for `llvm.lifetime.start`), for memset as a literal in the printed IR. Skip only copies between freshly-allocated, non-overlapping obstack memory, so plain non-volatile semantics apply.

Emitting the intrinsic directly removes the wrapper→inline step, so the optimizer sees a real memcpy/memset with **no inlining dependency** — the benefit (dead-copy elimination, store forwarding, constant-size expansion, lowering to `memory.copy`/`memory.fill` on wasm) applies at every opt level, including `-O0`.

### Wrappers are kept (removal deferred)

The `SKIP_llvm_memcpy`/`memset` preamble definitions and `runtime.c` functions are now dead for a skc built from this change, but are **deliberately kept**. The wasm CI (`skdb-wasm`/`skipruntime`) compiles with the currently-**published** skc, which still emits `call SKIP_llvm_memcpy`; removing the wrappers would make those calls undefined symbols. Their removal is a follow-up gated on a bootstrap bump that publishes a skc emitting intrinsics.

### Verification (stage1 skc built from this change; clang/LLVM 20.1.8; + 3 adversarial reviews)

**Emission / immarg** — every emitted memcpy is `call void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1 0)` with the immarg as an inline `i1 0` (never an SSA register; structural, since it's a compile-time constant). Operand types are exactly `(ptr, ptr, i64, i1)`; length is `i64`. `opt -passes=verify` clean on every emitted module and after an `-O2` roundtrip; **zero** `@SKIP_llvm_mem*` calls in emitted user modules. The whole stdlib recompiles; a Base64-decode round-trip (the one genuine skc-emitted memcpy in a whole-prelude compile) and mixed clone + zeroed-`mfill` programs across many element types run correctly.

**Bootstrap-ordering safety** — the intrinsic declares and the `SKIP_llvm_*` wrappers are different symbols (no double-definition); the module's `linkonce_odr` wrapper vs `runtime.c`'s strong def resolves strong-wins with no error. Removing the wrappers was confirmed to break the published-skc calls at link on **both** native (`undefined reference`) and wasm (`undefined symbol`, once reachable from `_start`) — proving they must stay. The mixed new-skc(direct) + published-skc(wrapper call) + kept-wrapper link — the exact transition state — links and runs on both targets.

**wasm equivalence** — `llc` (wasm32, LLVM 20 default `+bulk-memory`) lowers the direct intrinsics to `memory.copy`/`memory.fill` with **zero** undefined symbols; byte-identical to #1469's post-inline IR and to clang's `__builtin_memcpy`/`memset`. #1469 already merged the identical intrinsic declares + post-opt `call llvm.memcpy` and passed `skdb-wasm`, so this IR is independently wasm-validated.

**CI coverage** — the direct-emit path is exercised natively by the `compiler` job (`make STAGE=1`, then sktest with the branch-built skc). `skdb-wasm`/`skipruntime` are unaffected (published skc + kept wrappers).

### Honest caveats

- The skc-emitted **memset** path is currently unreachable in the default pipeline: `alloc.sk` unconditionally forces `anythingEscapes = true`, disabling stack-alloca promotion, so skc emits no memsets across a whole-prelude compile. The direct `llvm.memset` format is correct by inspection but has no live runtime coverage until Alloca promotion is re-enabled (a separate pre-existing issue). This is **not a regression** — the same dead path emitted `SKIP_llvm_memset` before.
- Removing the now-dead wrappers is out of scope here (deferred to the post-bootstrap-bump follow-up).

---
<sub>Written by Claude (Opus 4.8, 1M-context, high reasoning effort) via Claude Code, on behalf of @mbouaziz. Verified end-to-end on a from-source stage1 skc and by three independent adversarial reviews against the pinned LLVM 20.1.8 toolchain.</sub>
