### PR TITLE
ci: base released native-addon test image on node:bookworm-slim, not ubuntu+nodesource

### DIFF
--- a/skipruntime-ts/tests/native_addon/Dockerfile
+++ b/skipruntime-ts/tests/native_addon/Dockerfile
@@ -1,15 +1,21 @@
-FROM ubuntu:latest
+# Node comes baked into the base image. Bookworm matches the glibc floor (2.36)
+# of the debian:bookworm image that builds the released libskipruntime.so, so the
+# downloaded .so loads. Deliberately NOT `ubuntu:latest` + a nodesource apt repo:
+# that pulled Node over the network on every run and, under an ephemeral Docker
+# daemon, balloons whenever those mirrors are slow (see #1470).
+FROM node:22.13.1-bookworm-slim
 
 ARG TARGETARCH
 
-# install dependencies needed to build the node addon
+# Install only the node-gyp toolchain (g++, make, python3), CA certificates, and
+# wget -- used below and by install_runtime.sh to fetch over HTTPS. (Unlike the
+# native_addon_unreleased variant, which copies the .so from a file:// source and
+# so needs curl, these are https:// downloads, which wget handles.)
 RUN --mount=type=cache,id=apt-cache-$TARGETARCH,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lists-$TARGETARCH,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/root/.npm,sharing=locked \
     apt-get update --quiet \
  && apt-get install --quiet --yes --no-install-recommends ca-certificates g++ make python3 wget \
- && wget --quiet --output-document=- https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get install --quiet --yes --no-install-recommends nodejs \
  && npm install --global typescript
 
 # copy the test code


### PR DESCRIPTION
Follow-up to #1471, per its note. Applies the same base-image fix to the **released** native-addon test (`skipruntime-ts/tests/native_addon/`).

## Why

This variant carries the identical `FROM ubuntu:latest` + nodesource pattern that #1471 fixed in `native_addon_unreleased`: Node is installed from the nodesource apt repo on every build, so under an ephemeral Docker daemon (no persistent apt cache) it re-downloads Node each run and balloons whenever those mirrors are slow — the mechanism behind #1470.

## Change

- `FROM node:22.13.1-bookworm-slim` — bookworm matches the glibc floor (2.36) of the `debian:bookworm` image that builds the released `libskipruntime.so`, so the downloaded `.so` loads. Drop the two nodesource lines.
- **Keeps wget, does not add curl** — unlike `native_addon_unreleased` (which copies the `.so` from a `file://` source, and GNU wget can't do `file://`), this variant fetches `install_runtime.sh` and the `.so` over **HTTPS**, which wget handles fine.

## Validation note

This variant is a **manual runner** (`run.sh` just `docker build` + `docker run`) and is **not wired into any CI job**, so this PR's checks do not exercise the Dockerfile. The change is a direct analogue of the CI-validated #1471 (which went green), reviewed by hand for the HTTPS-vs-`file://` difference above.

---
— Claude Opus 4.8 (xhigh effort)
