### PR TITLE
ci: automate the skiplang bootstrap bump (manual workflow)

### DIFF
--- a/.github/workflows/bump-bootstrap.yml
+++ b/.github/workflows/bump-bootstrap.yml
@@ -53,6 +53,11 @@ jobs:
           submodules: recursive
           # Full history so the compiler's own git-describe versioning is sane.
           fetch-depth: 0
+      - name: Check the token can push before building
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.BOOTSTRAP_BUMP_TOKEN }}
+        run: ./bin/check_bootstrap_token.sh
       - name: Install the skiplang build toolchain
         shell: bash
         run: sudo ./bin/apt-install.sh skiplang-build-deps

--- a/.github/workflows/bump-bootstrap.yml
+++ b/.github/workflows/bump-bootstrap.yml
@@ -1,0 +1,123 @@
+name: bump-bootstrap
+
+# Rebuild the skiplang bootstrap compiler from the current main, verify it, push
+# the new IR to SkipLabs/skiplang-bootstrap, and open a PR bumping the submodule
+# pointer here. Manual only: whether to bump is a judgement call (the prelude
+# needs a language feature the current bootstrap lacks), so a human triggers it;
+# the automation just removes the toil and guarantees the verification runs.
+#
+# The bump is only ever published if the rebuilt compiler passes the self-hosting
+# fixpoint and the full test suite (see bin/bump_bootstrap.sh). Merging the
+# resulting PR -- the step that actually changes what everyone builds from --
+# stays a human decision.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and verify only; do not push or open a PR'
+        type: boolean
+        default: false
+
+# The pushes and the PR use BOOTSTRAP_BUMP_TOKEN, not GITHUB_TOKEN, so no repo
+# write is needed from the workflow token itself.
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    # Never publish a bootstrap from a fork.
+    if: github.repository == 'SkipLabs/skip'
+    # Gate the cross-repo token behind an environment whose deployment-branch
+    # policy allows only main. workflow_dispatch runs this workflow AND the
+    # scripts it calls from the SELECTED ref with full access to secrets, so
+    # without this a user with write access could dispatch a crafted branch that
+    # exfiltrates BOOTSTRAP_BUMP_TOKEN (which can write the compiler everyone
+    # builds from). The main-only policy blocks the job -- and the secret -- for
+    # any other ref. The token MUST be stored as an environment secret here, not
+    # a repo/org secret (a repo secret is not gated by the environment).
+    environment: bootstrap-publish
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Cross-repo token. Persisted so the branch push to this repo's origin
+          # and the PR use it (the skiplang-bootstrap push uses its own explicit
+          # URL). A PR opened under a real token, not GITHUB_TOKEN, runs CI --
+          # which is what validates the bump end to end.
+          token: ${{ secrets.BOOTSTRAP_BUMP_TOKEN }}
+          # The bootstrap IR and libbacktrace both live in submodules.
+          submodules: recursive
+          # Full history so the compiler's own git-describe versioning is sane.
+          fetch-depth: 0
+      - name: Install the skiplang build toolchain
+        shell: bash
+        run: sudo ./bin/apt-install.sh skiplang-build-deps
+      - name: Rebuild and verify the bootstrap
+        shell: bash
+        run: ./bin/bump_bootstrap.sh
+      - name: Push the new bootstrap IR
+        id: push
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.BOOTSTRAP_BUMP_TOKEN }}
+        run: |
+          commit=$(git rev-parse --short HEAD)
+          # Explicit tokenised URL rather than the persisted submodule remote, so
+          # this does not depend on how checkout wires submodule credentials.
+          url="https://x-access-token:${TOKEN}@github.com/SkipLabs/skiplang-bootstrap.git"
+          cd skiplang/compiler/bootstrap
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          # Reparent the promoted IR onto the CURRENT remote main tip so the push
+          # is always a fast-forward. The submodule is checked out at the SHA skip
+          # pins, which may be BEHIND bootstrap main -- e.g. an earlier bump whose
+          # skip PR has not merged -- and committing on top of it would push a
+          # sibling of main, be rejected non-fast-forward, and wedge every future
+          # run. IR snapshots are self-contained, so the parent commit does not
+          # affect what the bootstrap does; only its content (the promoted files)
+          # matters.
+          git fetch --depth 1 "$url" main
+          git reset --soft FETCH_HEAD
+          git add -A
+          git commit -m "Update to $commit"
+          git push "$url" HEAD:main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Open the submodule-bump PR
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.BOOTSTRAP_BUMP_TOKEN }}
+          PR_BODY: |
+            Rebuilds the bootstrap compiler from ${{ github.sha }} and bumps the
+            `skiplang/compiler/bootstrap` submodule to
+            `SkipLabs/skiplang-bootstrap@${{ steps.push.outputs.short }}`.
+
+            Produced by the `bump-bootstrap` workflow, which published the new IR
+            only after it passed, on a clean rebuild from that IR:
+
+            - the self-hosting **fixpoint** (`stage2` and `stage3` `skc.ll` identical), and
+            - the **full compiler test suite**.
+
+            Merging is the human gate: CI re-runs both against this pointer before it lands.
+        run: |
+          commit=$(git rev-parse --short HEAD)
+          branch="bump-bootstrap-$commit"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          # The submodule's HEAD advanced when its IR was committed above; record
+          # the moved pointer.
+          git switch -c "$branch"
+          git add skiplang/compiler/bootstrap
+          git commit -m "Update bootstrap compiler to $commit"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "Update bootstrap compiler to $commit" \
+            --body "$PR_BODY"

--- a/bin/bump_bootstrap.sh
+++ b/bin/bump_bootstrap.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Rebuild the skiplang bootstrap compiler from the current source and verify it,
+# the mechanical core of a bootstrap bump. The caller (a maintainer, or
+# .github/workflows/bump-bootstrap.yml) commits and pushes the result.
+#
+# Steps, matching the manual process:
+#   1. Build stage1 with the current (old) bootstrap and promote its IR into the
+#      bootstrap submodule -- bootstrap/{skc,skargo,skfmt}_out64.ll.gz.
+#   2. Verify the NEW bootstrap in isolation: a clean rebuild from those files,
+#      through stage3, must satisfy the self-hosting fixpoint (the compiler
+#      recompiles itself to an identical result), and the full test suite must
+#      pass.
+#
+# On success the bootstrap/*.ll.gz files are left modified (promoted) and
+# verified, and the submodule's HEAD is untouched -- the caller commits and
+# pushes. On ANY failure this exits non-zero having pushed nothing, so a broken
+# compiler never reaches the bootstrap repository.
+#
+# Must run from a full checkout with the bootstrap and libbacktrace submodules
+# initialised, and a skiplang build toolchain on PATH (clang, llvm, lld, make).
+#
+# Usage: bin/bump_bootstrap.sh
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$SCRIPT_DIR/../skiplang/compiler"
+
+commit=$(git rev-parse --short HEAD)
+echo "==> Rebuilding bootstrap for source commit $commit"
+
+# 1. Build stage1 with the current bootstrap and promote its IR. `make promote`
+#    builds stage1 (from the old bootstrap's stage0) first. Start clean so the
+#    skc-*.ll glob promote copies from is unambiguous.
+make clean
+make promote
+
+# 2. Verify the promoted bootstrap on its own. `make clean` removes stage*/build
+#    but leaves the freshly promoted bootstrap/*.ll.gz, so this rebuild starts
+#    from the NEW IR. A full clean is required: the stage rules key off stage
+#    directory mtimes, so a partial clean would reuse stale stages.
+make clean
+make stage3
+
+# 2a. Fixpoint: the new compiler must compile itself to the same IR twice over.
+#     The Makefile's own check is `-diff` (leading dash -> exit code ignored), so
+#     it never fails the build; assert it here.
+if ! diff -q stage2/bin/skc.ll stage3/bin/skc.ll; then
+    echo "" >&2
+    echo "ERROR: bootstrap fixpoint failed -- stage2 and stage3 skc.ll differ." >&2
+    echo "The promoted compiler does not converge on itself; refusing to publish." >&2
+    exit 1
+fi
+echo "==> Fixpoint OK: stage2 and stage3 skc.ll are identical"
+
+# 2b. Sanity: stage0, now built from the promoted IR, should report this commit.
+#     Informational -- the fixpoint and tests are the real gates -- so a version
+#     string that does not mention the commit warns rather than fails.
+version=$(stage0/bin/skc --version 2>/dev/null || true)
+echo "==> New stage0 reports: ${version:-<no --version output>}"
+case "$version" in
+    *"$commit"*) ;;
+    *) echo "WARNING: stage0 --version does not mention $commit; double-check the promoted IR" >&2 ;;
+esac
+
+# 3. Full compiler test suite against the newly bootstrapped compiler.
+make test
+
+echo ""
+echo "==> Bootstrap rebuilt and verified for $commit."
+echo "    Promoted, ready to commit: bootstrap/{skc,skargo,skfmt}_out64.ll.gz"

--- a/bin/check_bootstrap_token.sh
+++ b/bin/check_bootstrap_token.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Assert the configured token can push to both repositories a bootstrap bump
+# writes to, BEFORE the ~40-minute rebuild. A fine-grained PAT that is unscoped,
+# read-only, or not yet approved by the org otherwise fails only at the push
+# step, after the whole compiler has already been rebuilt and tested.
+#
+# GET /repos/<repo> reports the token's effective access in .permissions.push
+# (true iff the token has Contents: write on that repo), so this is a one-second
+# check. It does not separately probe Pull requests: write on skip -- that is the
+# same grant toggled alongside Contents on the fine-grained PAT, and the branch
+# push already needs Contents: write here.
+#
+# Usage: GH_TOKEN=<token> check_bootstrap_token.sh
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN must be set (the BOOTSTRAP_BUMP_TOKEN environment secret)}"
+
+repos=(SkipLabs/skiplang-bootstrap SkipLabs/skip)
+failed=()
+for repo in "${repos[@]}"; do
+    push=$(gh api "repos/$repo" --jq '.permissions.push // false' 2>/dev/null || echo unreachable)
+    case "$push" in
+        true)
+            echo "  $repo: push ok"
+            ;;
+        false)
+            echo "  $repo: NO push access (needs Contents: write)" >&2
+            failed+=("$repo")
+            ;;
+        *)
+            echo "  $repo: not reachable with this token (unscoped, invalid, or org approval pending)" >&2
+            failed+=("$repo")
+            ;;
+    esac
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    cat >&2 <<EOF
+
+Error: the token cannot push to ${#failed[@]} of ${#repos[@]} required repositories:
+$(printf '  %s\n' "${failed[@]}")
+
+Fix the fine-grained PAT behind the BOOTSTRAP_BUMP_TOKEN environment secret:
+resource owner SkipLabs, BOTH repositories selected, Repository permissions
+Contents: Read and write (and Pull requests: Read and write on skip). If the org
+requires approval for fine-grained tokens, an owner must approve it first.
+EOF
+    exit 1
+fi
+
+echo "OK: token can push to all ${#repos[@]} repositories"


### PR DESCRIPTION
Automates the bootstrap-compiler bump — today a careful, ~40-minute manual sequence across two repos — behind a single manual trigger, so the toil goes away and the verification is guaranteed to run.

## What it does

`workflow_dispatch` → on `ubuntu-24.04`:

1. `bin/bump_bootstrap.sh`: build stage1 with the current bootstrap, `make promote`, then verify the promoted compiler on a clean rebuild — the self-hosting **fixpoint** (`stage2` and `stage3` `skc.ll` identical) and the **full compiler test suite**. Any failure exits non-zero and nothing is published.
2. Push the new IR to `SkipLabs/skiplang-bootstrap`.
3. Open a PR here bumping the `skiplang/compiler/bootstrap` submodule pointer.

Merging that PR — the step that changes what everyone builds from — stays a human decision, and CI re-runs the fixpoint + tests against the new pointer before it can land. A `dry_run` input builds and verifies without pushing or opening a PR.

## Two issues an adversarial review caught, and how they're handled

- **Non-fast-forward wedge.** Committing the new IR on top of the *pinned* submodule SHA and pushing to `skiplang-bootstrap` main is rejected whenever main has advanced (e.g. an earlier bump whose PR hasn't merged), wedging every future run after a 40-min rebuild. Fixed by reparenting the IR onto the *current* remote main tip (`fetch` + `reset --soft` + `commit`), so the push is always a fast-forward. Reproduced the wedge and confirmed the fix locally; main stays linear with every IR reachable.
- **Token exfiltration.** `workflow_dispatch` runs the workflow *and its scripts from the selected ref* with full secret access, so a write-access user could dispatch a crafted branch to steal the cross-repo token. The job runs in a `bootstrap-publish` **environment** whose deployment-branch policy must allow only `main`, which blocks the secret for any other ref.

The review also flagged — and I verified as **not** an issue — that `SKIP_CAPACITY` is unneeded on the 16 GB runner (the same compiler builds on the same runners in `docker-publish` without it).

## Maintainer setup before the first run

1. **Fine-grained PAT** (org `SkipLabs`), repo access to **both** `skiplang-bootstrap` and `skip`, permissions **Contents: R/W** + **Pull requests: R/W** + Metadata.
2. **Environment `bootstrap-publish`** on `SkipLabs/skip`: deployment-branch policy → **selected branches → `main` only**; store the PAT as an **environment secret** named `BOOTSTRAP_BUMP_TOKEN` (environment, *not* repo/org — a repo secret isn't gated by the environment). Optionally add required reviewers for a per-run approval gate.
3. Validate with a **`dry_run` from `main`** (build + verify, no writes) before the first real bump.

Verified as far as is possible without running it: actionlint + shellcheck clean; the `make` sequence traced against the real Makefile; the `check-bootstrap`/uncommitted-submodule interaction, the fast-forward fix, and the `git submodule status` behaviour reproduced locally. The compiler build/test itself can only be exercised on the runner — hence the `dry_run`-from-main first.

— Mehdi (with Claude Opus 4.8, xhigh effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)