### PR TITLE
ci: fix bump-bootstrap toolchain install (clang alternatives clash)

### DIFF
--- a/.github/workflows/bump-bootstrap.yml
+++ b/.github/workflows/bump-bootstrap.yml
@@ -60,7 +60,19 @@ jobs:
         run: ./bin/check_bootstrap_token.sh
       - name: Install the skiplang build toolchain
         shell: bash
-        run: sudo ./bin/apt-install.sh skiplang-build-deps
+        run: |
+          # The GitHub runner image ships clang with its own update-alternatives
+          # entries (clang++ and friends registered as MASTER alternatives), which
+          # collide with the master+slave layout apt-install.sh installs -- it
+          # aborts with "alternative clang++ can't be slave of clang: it is a
+          # master alternative". Clear the names it manages first so the install
+          # is clean. This is runner-only: the Docker image builds run the same
+          # script from a base image that has none of these.
+          for alt in clang clang++ clang-format llc llvm-ar llvm-config \
+                     llvm-link opt wasm-ld; do
+            sudo update-alternatives --remove-all "$alt" 2>/dev/null || true
+          done
+          sudo ./bin/apt-install.sh skiplang-build-deps
       - name: Rebuild and verify the bootstrap
         shell: bash
         run: ./bin/bump_bootstrap.sh


### PR DESCRIPTION
The first `dry_run` of the `bump-bootstrap` workflow ([run](https://github.com/SkipLabs/skip/actions/runs/30037957036)) got through checkout and the token preflight, then failed installing the toolchain:

```
update-alternatives: error: alternative clang++ can't be slave of clang:
it is a master alternative
```

## Cause

The GitHub `ubuntu-24.04` runner image preinstalls clang with `update-alternatives` entries where `clang++` (and the other LLVM tools) are **master** alternatives. `bin/apt-install.sh skiplang-build-deps` installs `clang` as a master with `clang++`, `llc`, `opt`, … as **slaves** — and `update-alternatives` refuses to demote an existing master to a slave, so it aborts.

The Docker image builds never hit this: they run the same script from a clean base image with no preexisting alternatives. It's specific to running `apt-install.sh` on a bare runner, which only this workflow does.

## Fix

Before the install, `--remove-all` the nine alternative names the script manages, so the setup starts clean. Guarded with `|| true`, so it's a no-op where they're absent.

actionlint clean; the removed-name list matches `apt-install.sh`'s master + slaves exactly. The token preflight and the fast-forward push logic already validated on the failed run (steps 1–3 were green); this unblocks the toolchain step so a re-dispatched `dry_run` can exercise the full build.

— Mehdi (with Claude Opus 4.8, xhigh effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)