### PR TITLE
core: enforce AnySkipService as internal, make runService generic

### DIFF
--- a/skipruntime-ts/addon/src/index.ts
+++ b/skipruntime-ts/addon/src/index.ts
@@ -1,4 +1,7 @@
-import type { Exception as IException } from "@skipruntime/core/internal.js";
+import type {
+  Exception as IException,
+  AnySkipService,
+} from "@skipruntime/core/internal.js";
 import { ServiceInstance, ToBinding } from "@skipruntime/core";
 import type { FromBinding as SkipRuntimeFromBinding } from "@skipruntime/core/binding.js";
 import {
@@ -18,8 +21,6 @@ type AddOn = {
 };
 
 const skip_runtime: AddOn = require("../build/Release/skip_runtime.node");
-
-import type { AnySkipService } from "@skipruntime/core";
 
 const jsonBinding: JsonBinding = skip_runtime.getJsonBinding();
 const jsonConverter = buildJsonConverter(jsonBinding);

--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -658,13 +658,3 @@ export interface SkipService<
    */
   createGraph(inputCollections: Inputs, context: Context): ResourceInputs;
 }
-
-/**
- * Type-erased SkipService, for use in internal runtime code and consumers
- * that don't need specific type parameters.
- */
-export type AnySkipService = SkipService<
-  NamedInputDefinitions,
-  NamedEagerCollections,
-  NamedEagerCollections
->;

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -21,6 +21,7 @@ import {
 import { sknative } from "../skiplang-std/index.js";
 
 import type * as Internal from "./internal.js";
+import { type AnySkipService } from "./internal.js";
 import {
   type AbstractEagerCollection,
   type CollectionUpdate,
@@ -35,7 +36,6 @@ import {
   type DepSafe,
   type Reducer,
   type Resource,
-  type AnySkipService,
   type Watermark,
   type ExternalService,
   InputDefinition,

--- a/skipruntime-ts/core/src/internal.ts
+++ b/skipruntime-ts/core/src/internal.ts
@@ -1,6 +1,25 @@
 export type * from "../skiplang-json/internal.js";
 import type { T, CJSON } from "../skiplang-json/internal.js";
 export type { Exception } from "../skiplang-std/internal.js";
+import type {
+  SkipService,
+  NamedInputDefinitions,
+  NamedEagerCollections,
+} from "./api.js";
+
+/**
+ * Type-erased SkipService, for use in internal runtime code and consumers
+ * that don't need specific type parameters. Not part of the public
+ * `@skipruntime/core` surface: assigning a concrete SkipService<...> to it
+ * is unsound (Resource<C>.instantiate is contravariant in C), so user code
+ * should use a generic function parameterized over InputDefs/Inputs/
+ * ResourceInputs instead of erasing to this type.
+ */
+export type AnySkipService = SkipService<
+  NamedInputDefinitions,
+  NamedEagerCollections,
+  NamedEagerCollections
+>;
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 

--- a/skipruntime-ts/examples/database.ts
+++ b/skipruntime-ts/examples/database.ts
@@ -1,9 +1,4 @@
-import type {
-  EagerCollection,
-  AnySkipService,
-  Resource,
-  Entry,
-} from "@skipruntime/core";
+import type { EagerCollection, Resource, Entry } from "@skipruntime/core";
 import { InputDefinition } from "@skipruntime/core";
 
 import { runService } from "@skipruntime/server";
@@ -64,11 +59,11 @@ class UsersResource implements Resource<UsersCollection> {
 // Setting up the service
 /*****************************************************************************/
 
-function serviceWithInitialData(users: Entry<string, User>[]): AnySkipService {
+function serviceWithInitialData(users: Entry<string, User>[]) {
   return {
     inputs: { users: new InputDefinition(users) },
     resources: { users: UsersResource },
-    createGraph: (inputCollections) => inputCollections,
+    createGraph: (inputCollections: UsersCollection) => inputCollections,
   };
 }
 

--- a/skipruntime-ts/examples/departures.ts
+++ b/skipruntime-ts/examples/departures.ts
@@ -3,7 +3,6 @@ import type {
   EagerCollection,
   Json,
   Resource,
-  AnySkipService,
 } from "@skipruntime/core";
 import { InputDefinition } from "@skipruntime/core";
 import { runService } from "@skipruntime/server";
@@ -52,7 +51,7 @@ class DeparturesResource implements Resource<ResourceInputs> {
   }
 }
 
-const service: AnySkipService = {
+const service = {
   inputs: { config: new InputDefinition() },
   resources: {
     departures: DeparturesResource,
@@ -68,7 +67,7 @@ const service: AnySkipService = {
       },
     }),
   },
-  createGraph: (ic) => ic,
+  createGraph: (ic: ResourceInputs) => ic,
 };
 
 const server = await runService(service, {

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -4,7 +4,6 @@ import { EventSource } from "eventsource";
 
 import type {
   AbstractEagerCollection,
-  AnySkipService,
   Context,
   EagerCollection,
   Entry,
@@ -13,6 +12,7 @@ import type {
   NamedEagerCollections,
   Resource,
 } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 import { SkipError } from "@skipruntime/core";
 
 import type { Entrypoint } from "./rest.js";

--- a/skipruntime-ts/server/src/server.ts
+++ b/skipruntime-ts/server/src/server.ts
@@ -4,7 +4,12 @@
  * @packageDocumentation
  */
 
-import type { AnySkipService } from "@skipruntime/core";
+import type {
+  NamedEagerCollections,
+  NamedInputDefinitions,
+  SkipService,
+} from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 import {
   registerControlServiceRoutes,
   registerStreamingServiceRoutes,
@@ -92,6 +97,7 @@ export type SkipServer = {
  *   Check that the Skip service is running normally.
  *   Returns HTTP 200 if the service is healthy, for use in monitoring, deployments, and the like.
  *
+ * @typeParam InputDefs - Named input definitions used to seed the service's input collections.
  * @typeParam Inputs - Named collections from which the service computes.
  * @typeParam ResourceInputs - Named collections provided to resource computations.
  * @param service - The SkipService definition to run.
@@ -102,8 +108,12 @@ export type SkipServer = {
  * @param options.no_cors - Disable CORS for the streaming endpoint.
  * @returns Object to manage the running server.
  */
-export async function runService(
-  service: AnySkipService,
+export async function runService<
+  InputDefs extends NamedInputDefinitions,
+  Inputs extends NamedEagerCollections,
+  ResourceInputs extends NamedEagerCollections,
+>(
+  service: SkipService<InputDefs, Inputs, ResourceInputs>,
   options: {
     streaming_port: number;
     control_port: number;
@@ -136,10 +146,16 @@ export async function runService(
       throw e;
     }
   }
-  const instance = await runtime.initService(service).catch((e: unknown) => {
-    console.error("Service could not be initialized; reason: ", e);
-    throw e;
-  });
+  // Erase to AnySkipService at the runtime FFI boundary: initService crosses
+  // into untyped WASM/native territory where per-service type parameters
+  // can't be preserved. This is the one deliberate, internal erasure point --
+  // callers of runService itself never need to touch AnySkipService.
+  const instance = await runtime
+    .initService(service as unknown as AnySkipService)
+    .catch((e: unknown) => {
+      console.error("Service could not be initialized; reason: ", e);
+      throw e;
+    });
 
   const controlApp = express();
   controlApp.use(logger_middleware);

--- a/skipruntime-ts/tests/native_addon/test.ts
+++ b/skipruntime-ts/tests/native_addon/test.ts
@@ -1,4 +1,4 @@
-import type { AnySkipService } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 import { initService } from "@skipruntime/native";
 
 const emptyService: AnySkipService = {

--- a/skipruntime-ts/tests/native_addon_unreleased/test.ts
+++ b/skipruntime-ts/tests/native_addon_unreleased/test.ts
@@ -1,4 +1,4 @@
-import type { AnySkipService } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 import { initService } from "@skipruntime/native";
 
 const emptyService: AnySkipService = {

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -8,7 +8,6 @@ import type {
   LazyCompute,
   LazyCollection,
   Values,
-  AnySkipService,
   Resource,
   Entry,
   ExternalService,
@@ -20,6 +19,7 @@ import type {
   Reducer,
   ChangeManager,
 } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 import { LoadStatus, InputDefinition } from "@skipruntime/core";
 import { Count, Sum } from "@skipruntime/helpers";
 

--- a/skipruntime-ts/wasm/src/browser.ts
+++ b/skipruntime-ts/wasm/src/browser.ts
@@ -1,4 +1,5 @@
-import type { ServiceInstance, AnySkipService } from "@skipruntime/core";
+import type { ServiceInstance } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 
 import { initServiceFor } from "./skipruntime_init.js";
 import { environment as createEnvironment } from "../skipwasm-std/sk_browser.js";

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -10,7 +10,6 @@ import type {
 } from "../../skipwasm-std/index.js";
 import type * as Internal from "@skipruntime/core/internal.js";
 import type {
-  AnySkipService,
   Reducer,
   Mapper,
   LazyCompute,
@@ -1097,11 +1096,11 @@ class LinksImpl implements Links {
 export class ServiceInstanceFactory implements Shared {
   constructor(
     private readonly init: (
-      service: AnySkipService,
+      service: Internal.AnySkipService,
     ) => Promise<ServiceInstance>,
   ) {}
 
-  initService(service: AnySkipService): Promise<ServiceInstance> {
+  initService(service: Internal.AnySkipService): Promise<ServiceInstance> {
     return this.init(service);
   }
 

--- a/skipruntime-ts/wasm/src/node.ts
+++ b/skipruntime-ts/wasm/src/node.ts
@@ -1,4 +1,5 @@
-import type { ServiceInstance, AnySkipService } from "@skipruntime/core";
+import type { ServiceInstance } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 
 import { initServiceFor } from "./skipruntime_init.js";
 import { environment as createEnvironment } from "../skipwasm-std/sk_node.js";

--- a/skipruntime-ts/wasm/src/skipruntime_init.ts
+++ b/skipruntime-ts/wasm/src/skipruntime_init.ts
@@ -9,7 +9,8 @@ import { init as runtimeInit } from "../skipwasm-std/sk_runtime.js";
 import { init as posixInit } from "../skipwasm-std/sk_posix.js";
 import { init as skjsonInit } from "../skipwasm-json/skjson.js";
 import { init as skruntimeInit } from "./internals/skipruntime_module.js";
-import type { ServiceInstance, AnySkipService } from "@skipruntime/core";
+import type { ServiceInstance } from "@skipruntime/core";
+import type { AnySkipService } from "@skipruntime/core/internal.js";
 
 const modules: ModuleInit[] = [
   runtimeInit,


### PR DESCRIPTION
Follow-up to #1162. `AnySkipService` was still part of `@skipruntime/core`'s public surface, and every current example/test used it as the standard way to type a service — but assigning a concrete `SkipService<...>` to it is unsound (`Resource<C>.instantiate` is contravariant in `C`), and skjs soundly rejects it — both the erased-assignment form and the object-literal form (`export const service: AnySkipService = {...}`).

- Move `AnySkipService`'s definition from `api.ts` to `internal.ts`, which already had a dedicated `./internal.js` package-export entry.
- Make `runService` generic over a service's `InputDefs`/`Inputs`/`ResourceInputs`, so callers pass their concrete service directly instead of erasing to `AnySkipService`. The one remaining erasure is a single explicit cast at the runtime's FFI boundary (`initService`) — crossing into the WASM/native layer is a genuine architectural boundary where per-service typing can't survive regardless, so an erasure has to live somewhere, and that's the structurally correct place for it.
- Update `wasm`/`addon`/`helpers`/`tests` to import `AnySkipService` from the new internal entry point (mechanical — these legitimately need the erased type at the FFI boundary).
- Rewrite `database.ts`/`departures.ts` to the sound generic-function pattern (drop the `AnySkipService` annotation, let the concrete shape flow through `runService`'s generic parameter).

Deliberately narrow: doesn't touch the four Docker-built example apps (hackernews/chatroom/blogger/cache_invalidation) — they stay on the old API until the next version bump, tracked separately (matches #1481's publish-logistics list). Two more PRs follow this one (SharedCollections for `ResourceInputs`, then the version bump + bringing those four apps back onto the new API).

## Test plan
- `make check-fmt`: clean
- `SKIP_LINT=1 make check-ts`: clean across every workspace
- `skargo check` (skiplang/core, skiplang/ffi): clean
- `make test-skipruntime-ts`: 59 passing (Native + Wasm)