### PR TITLE
skipruntime: allow createGraph to share lazy collections

### DIFF
--- a/skipruntime-ts/core/src/api.ts
+++ b/skipruntime-ts/core/src/api.ts
@@ -501,6 +501,10 @@ export type NamedEagerCollections = {
   readonly [name: string]: AbstractEagerCollection;
 };
 
+export type SharedCollections = {
+  readonly [name: string]: AbstractEagerCollection | AbstractLazyCollection;
+};
+
 /**
  * Resource provided by a `SkipService`.
  *
@@ -508,7 +512,7 @@ export type NamedEagerCollections = {
  *
  * @typeParam Collections - Collections provided to the resource computation by the service's `createGraph`.
  */
-export interface Resource<Collections extends NamedEagerCollections> {
+export interface Resource<Collections extends SharedCollections> {
   /**
    * Build the reactive compute graph of the reactive resource.
    *
@@ -532,7 +536,7 @@ export interface Resource<Collections extends NamedEagerCollections> {
  * @typeParam Params - Type of the constructor parameter.
  */
 export type ResourceClass<
-  Collections extends NamedEagerCollections,
+  Collections extends SharedCollections,
   Params extends Json,
 > = new (params: Params) => Resource<Collections>;
 
@@ -632,7 +636,7 @@ export type NamedInputDefinitions = {
 export interface SkipService<
   InputDefs extends NamedInputDefinitions,
   Inputs extends NamedEagerCollections,
-  ResourceInputs extends NamedEagerCollections,
+  ResourceInputs extends SharedCollections,
 > {
   /**
    * Input definitions for this service's input collections, including initial data.
@@ -666,5 +670,5 @@ export interface SkipService<
 export type AnySkipService = SkipService<
   NamedInputDefinitions,
   NamedEagerCollections,
-  NamedEagerCollections
+  SharedCollections
 >;

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -22,7 +22,6 @@ import { sknative } from "../skiplang-std/index.js";
 
 import type * as Internal from "./internal.js";
 import {
-  type AbstractEagerCollection,
   type CollectionUpdate,
   type Context,
   type EagerCollection,
@@ -39,6 +38,9 @@ import {
   type Watermark,
   type ExternalService,
   InputDefinition,
+  AbstractEagerCollection,
+  AbstractLazyCollection,
+  type SharedCollections,
 } from "./api.js";
 
 import {
@@ -139,7 +141,7 @@ export class ServiceDefinition {
   createGraph(
     inputCollections: NamedEagerCollections,
     context: Context,
-  ): NamedEagerCollections {
+  ): SharedCollections {
     return this.service.createGraph(inputCollections, context);
   }
 
@@ -283,9 +285,13 @@ class LazyCollectionImpl<K extends Json, V extends Json>
         throw new SkipNonUniqueValueError();
     }
   }
+
+  static getName(coll: AbstractLazyCollection): string {
+    return (coll as LazyCollectionImpl<Json, Json>).lazyCollection;
+  }
 }
 
-class EagerCollectionImpl<K extends Json, V extends Json>
+export class EagerCollectionImpl<K extends Json, V extends Json>
   extends SkManaged
   implements EagerCollection<K, V>
 {
@@ -459,10 +465,8 @@ class EagerCollectionImpl<K extends Json, V extends Json>
     return new EagerCollectionImpl<K2, V2>(collection, this.refs);
   }
 
-  static getName<K extends Json, V extends Json>(
-    coll: EagerCollection<K, V>,
-  ): string {
-    return (coll as EagerCollectionImpl<K, V>).collection;
+  static getName(coll: AbstractEagerCollection): string {
+    return (coll as EagerCollectionImpl<Json, Json>).collection;
   }
 }
 
@@ -1118,17 +1122,23 @@ export class ToBinding {
   // Resource
 
   SkipRuntime_Resource__instantiate(
-    skresource: Handle<Resource<NamedEagerCollections>>,
+    skresource: Handle<Resource<SharedCollections>>,
     skcollections: Pointer<Internal.CJObject>,
   ): string {
     const skjson = this.getJsonConverter();
     const resource = this.handles.get(skresource);
-    const collections: { [key: string]: AbstractEagerCollection } = {};
+    const collections: {
+      [key: string]: AbstractEagerCollection | AbstractLazyCollection;
+    } = {};
     const keysIds = skjson.importJSON(skcollections) as {
-      [key: string]: string;
+      [key: string]: { name: string; type: string };
     };
-    for (const [key, name] of Object.entries(keysIds)) {
-      collections[key] = new EagerCollectionImpl<Json, Json>(name, this);
+    for (const [key, info] of Object.entries(keysIds)) {
+      if (info.type === "eager")
+        collections[key] = new EagerCollectionImpl<Json, Json>(info.name, this);
+      else if (info.type === "lazy")
+        collections[key] = new LazyCollectionImpl<Json, Json>(info.name, this);
+      else throw new Error(`Unknown collection type ${info.type}`);
     }
     const collection = resource.instantiate(collections, new ContextImpl(this));
     return EagerCollectionImpl.getName(
@@ -1150,7 +1160,9 @@ export class ToBinding {
   ): Pointer<Internal.CJObject> {
     const skjson = this.getJsonConverter();
     const service = this.handles.get(skservice);
-    const collections: { [key: string]: AbstractEagerCollection } = {};
+    const collections: {
+      [key: string]: AbstractEagerCollection;
+    } = {};
     const keysIds = skjson.importJSON(skcollections) as {
       [key: string]: string;
     };
@@ -1158,11 +1170,20 @@ export class ToBinding {
       collections[key] = new EagerCollectionImpl<Json, Json>(name, this);
     }
     const result = service.createGraph(collections, new ContextImpl(this));
-    const collectionsNames: { [name: string]: string } = {};
+    const collectionsNames: { [name: string]: { type: string; name: string } } =
+      {};
     for (const [name, collection] of Object.entries(result)) {
-      collectionsNames[name] = EagerCollectionImpl.getName(
-        collection as EagerCollection<Json, Json>,
-      );
+      if (collection instanceof EagerCollectionImpl)
+        collectionsNames[name] = {
+          type: "eager",
+          name: EagerCollectionImpl.getName(collection),
+        };
+      else if (collection instanceof LazyCollectionImpl) {
+        collectionsNames[name] = {
+          type: "lazy",
+          name: LazyCollectionImpl.getName(collection),
+        };
+      } else throw new Error(`Invalid collection type`);
     }
     return skjson.exportJSON(collectionsNames);
   }

--- a/skipruntime-ts/helpers/src/remote.ts
+++ b/skipruntime-ts/helpers/src/remote.ts
@@ -2,16 +2,18 @@
 // in nodejs LTS.
 import { EventSource } from "eventsource";
 
-import type {
-  AbstractEagerCollection,
-  AnySkipService,
-  Context,
-  EagerCollection,
-  Entry,
-  ExternalService,
-  Json,
-  NamedEagerCollections,
-  Resource,
+import {
+  type AnySkipService,
+  type AbstractEagerCollection,
+  type AbstractLazyCollection,
+  type Entry,
+  type ExternalService,
+  type Json,
+  type NamedEagerCollections,
+  type Resource,
+  type SharedCollections,
+  type Context,
+  EagerCollectionImpl,
 } from "@skipruntime/core";
 import { SkipError } from "@skipruntime/core";
 
@@ -112,7 +114,7 @@ export class SkipExternalService implements ExternalService {
   }
 }
 
-class LeaderResource implements Resource<NamedEagerCollections> {
+class LeaderResource implements Resource<SharedCollections> {
   private collection: string;
 
   constructor(param: Json) {
@@ -123,8 +125,15 @@ class LeaderResource implements Resource<NamedEagerCollections> {
       );
   }
 
-  instantiate(collections: NamedEagerCollections): AbstractEagerCollection {
-    if (this.collection in collections) return collections[this.collection]!;
+  instantiate(collections: SharedCollections): AbstractEagerCollection {
+    if (this.collection in collections) {
+      const maybeEagerCollection = collections[this.collection]!;
+      if (maybeEagerCollection instanceof EagerCollectionImpl)
+        return maybeEagerCollection;
+      throw new SkipError(
+        `Unknown eager shared collection in leader: ${this.collection}`,
+      );
+    }
     throw new SkipError(
       `Unknown shared collection in leader: ${this.collection}`,
     );
@@ -151,13 +160,18 @@ export function asLeader(service: AnySkipService): AnySkipService {
  *
  * Instead of running a `service` on one machine, it can be distributed across multiple in a leader-follower architecture, with one "leader" maintaining the shared computation graph and one or more "followers" across which client-requested resource instances are distributed.
  *
- * @returns The *follower* component to run `service` in such a configuration, given the leader's address and the names of the shared computation graph collections to be mirrored from it (typically the `ResourceInputs` of `service`).
+ * The two kinds of shared collection are obtained differently. Eager collections, named in `collections`, are *mirrored* from the leader: the leader maintains them and streams their updates to the follower. Lazy collections cannot be mirrored, since they hold no maintained state to stream; each is instead *rebuilt locally* by the follower, `lazies` mapping its shared name to a function which, given the follower's `Context`, produces the corresponding lazy collection. Together, the two are expected to cover the `ResourceInputs` of `service`.
+ *
+ * @returns The *follower* component to run `service` in such a configuration.
  */
 export function asFollower(
   service: AnySkipService,
   leader: {
     leader: { host: string; streaming_port: number; control_port: number };
     collections: string[];
+    lazies?: {
+      [name: string]: (context: Context) => AbstractLazyCollection;
+    };
   },
 ): AnySkipService {
   return {
@@ -170,9 +184,9 @@ export function asFollower(
     createGraph(
       _inputs: NamedEagerCollections,
       context: Context,
-    ): NamedEagerCollections {
+    ): SharedCollections {
       const mirroredCollections: {
-        [key: string]: EagerCollection<Json, Json>;
+        [name: string]: AbstractEagerCollection | AbstractLazyCollection;
       } = {};
       for (const collection of leader.collections) {
         mirroredCollections[collection] = context.useExternalResource({
@@ -180,6 +194,13 @@ export function asFollower(
           identifier: "leader",
           params: collection,
         });
+      }
+      if (leader.lazies) {
+        for (const [collection, lCollectionGetter] of Object.entries(
+          leader.lazies,
+        )) {
+          mirroredCollections[collection] = lCollectionGetter(context);
+        }
       }
       return mirroredCollections;
     },

--- a/skipruntime-ts/skiplang/core/src/BaseTypes.sk
+++ b/skipruntime-ts/skiplang/core/src/BaseTypes.sk
@@ -112,7 +112,7 @@ base class LazyCompute extends SKStore.LazyCompute<SKStore.Key, SKStore.File> {
 value class Waitable(value: Float)
 
 base class Resource {
-  fun instantiate(collections: Map<String, Collection>): Collection;
+  fun instantiate(collections: Map<String, CollectionBase>): Collection;
 }
 
 base class Service {
@@ -138,7 +138,7 @@ base class Service {
 
   fun createGraph(
     inputCollections: Map<String, Collection>,
-  ): Map<String, Collection>;
+  ): Map<String, CollectionBase>;
 
   fun needResourceReload(name: String): ?Bool;
   fun needInputReload(name: String): Bool;

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -55,7 +55,7 @@ class ResourceDef(
 }
 
 class ServiceFile(
-  value: Map<String, Collection>,
+  value: Map<String, CollectionBase>,
   inputs: Map<String, Collection>,
 ) extends SKStore.File
 
@@ -533,7 +533,11 @@ fun useExternalCollection(
   }
 }
 
-class Collection(dirName: SKStore.DirName) {
+base class CollectionBase {
+  fun getId(): String;
+}
+
+class Collection(dirName: SKStore.DirName) extends CollectionBase {
   //
   static fun forName(name: String): Collection {
     Collection(SKStore.DirName::create(name))
@@ -786,7 +790,7 @@ class Collection(dirName: SKStore.DirName) {
   }
 }
 
-class LazyCollection(private dirName: SKStore.DirName) {
+class LazyCollection(private dirName: SKStore.DirName) extends CollectionBase {
   //
   static fun forName(name: String): LazyCollection {
     LazyCollection(SKStore.DirName::create(name))

--- a/skipruntime-ts/skiplang/core/src/Utils.sk
+++ b/skipruntime-ts/skiplang/core/src/Utils.sk
@@ -96,10 +96,39 @@ fun lazyForName(name: String): LazyCollection {
   LazyCollection::forName(name)
 }
 
-fun collectionsByName(collections: Map<String, Collection>): SKJSON.CJObject {
+fun collectionsByName(
+  collections: Map<String, CollectionBase>,
+): SKJSON.CJObject {
   fields = mutable Vector[];
   collections.each((k, c) -> fields.push((k, SKJSON.CJString(c.getId()))));
   SKJSON.CJObject(SKJSON.CJFields::create(fields.toArray(), x -> x));
+}
+
+fun collectionsByNameAndType(
+  collections: Map<String, CollectionBase>,
+): SKJSON.CJObject {
+  fields = mutable Vector[];
+  collections.each((k, c) -> {
+    name = SKJSON.CJString(c.getId());
+    nameAndType = c match {
+    | LazyCollection _ ->
+      Array[("name", name), ("type", SKJSON.CJString("lazy"))]
+    | _ -> Array[("name", name), ("type", SKJSON.CJString("eager"))]
+    };
+    nameAndTypeObj = SKJSON.CJObject(
+      SKJSON.CJFields::create(nameAndType, x -> x),
+    );
+    fields.push((k, nameAndTypeObj));
+  });
+  SKJSON.CJObject(SKJSON.CJFields::create(fields.toArray(), x -> x));
+}
+
+fun collectionForNameAndType(name: String, type: String): CollectionBase {
+  type match {
+  | "eager" -> Collection::forName(name)
+  | "lazy" -> LazyCollection::forName(name)
+  | _ -> invariant_violation(`Unknown collection type '${type}'`)
+  }
 }
 
 fun runWithResult<T>(f: mutable SKStore.Context ~> T): Result<T, .Exception> {

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -174,10 +174,10 @@ fun createResource(resource: UInt32): ExternResource {
 }
 
 class ExternResource(eptr: SKStore.ExternalPointer) extends Resource {
-  fun instantiate(collections: Map<String, Collection>): Collection {
+  fun instantiate(collections: Map<String, CollectionBase>): Collection {
     collectionName = instantiateOfResource(
       this.eptr.value,
-      collectionsByName(collections),
+      collectionsByNameAndType(collections),
     );
     collectionForName(collectionName)
   }
@@ -266,13 +266,28 @@ class ExternService(eptr: SKStore.ExternalPointer) extends Service {
     buildResourceOfService(this.eptr.value, name, parameters)
   }
 
-  fun createGraph(inputs: Map<String, Collection>): Map<String, Collection> {
-    names = createGraphOfService(this.eptr.value, collectionsByName(inputs));
-    map = mutable Map[];
-    names match {
+  fun createGraph(
+    inputs: Map<String, Collection>,
+  ): Map<String, CollectionBase> {
+    nameAndTypes = createGraphOfService(
+      this.eptr.value,
+      collectionsByName(inputs),
+    );
+    map = mutable Map<String, CollectionBase>[];
+    nameAndTypes match {
     | SKJSON.CJObject(nfields) ->
       for (fieldName => field in nfields) {
-        map![fieldName] = collectionForName(SKJSON.asString(field));
+        field match {
+        | nt @ SKJSON.CJObject _ ->
+          type = SKJSON.getString(nt, "type").fromSome(
+            "missing 'type' field in createGraph result",
+          );
+          name = SKJSON.getString(nt, "name").fromSome(
+            "missing 'name' field in createGraph result",
+          );
+          map![fieldName] = collectionForNameAndType(name, type)
+        | _ -> invariant_violation("Invalid field type")
+        }
       }
     };
     map.chill()

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -370,6 +370,35 @@ const lazyService: AnySkipService = {
   },
 };
 
+//// testSharedLazy
+
+type Lazy_NN = {
+  input: EagerCollection<number, number>;
+  lazy: LazyCollection<number, number>;
+};
+
+class SharedLazyResource implements Resource<Lazy_NN> {
+  instantiate(cs: Lazy_NN): EagerCollection<number, number> {
+    return cs.input.map(MapLazy, cs.lazy);
+  }
+}
+
+const sharedLazyService: AnySkipService = {
+  inputs: { input: new InputDefinition() },
+  resources: { lazy: SharedLazyResource },
+
+  createGraph(inputCollections: Input_NN, context: Context) {
+    const lazy = context.createLazyCollection(
+      TestLazyAdd,
+      inputCollections.input,
+    );
+    return {
+      ...inputCollections,
+      lazy,
+    };
+  },
+};
+
 //// testMapReduce
 
 class TestOddEven implements Mapper<number, number, number, number> {
@@ -1390,6 +1419,34 @@ export function initTests(
 
   it("testLazy", async () => {
     const service = await initService(lazyService);
+    try {
+      const resource = "lazy";
+      await service.update("input", [
+        [0, [10]],
+        [1, [20]],
+      ]);
+      expect(await service.getAll(resource)).toEqual([
+        [0, [2]],
+        [1, [2]],
+      ]);
+      await service.update("input", [[2, [4]]]);
+      expect(await service.getAll(resource)).toEqual([
+        [0, [2]],
+        [1, [2]],
+        [2, [2]],
+      ]);
+      await service.update("input", [[2, []]]);
+      expect(await service.getAll(resource)).toEqual([
+        [0, [2]],
+        [1, [2]],
+      ]);
+    } finally {
+      await service.close();
+    }
+  });
+
+  it("testSharedLazy", async () => {
+    const service = await initService(sharedLazyService);
     try {
       const resource = "lazy";
       await service.update("input", [


### PR DESCRIPTION
`SkipService.createGraph` could only return eager collections, so a lazy collection built there could not be handed to resources: the FFI carried the shared collections as a name-only map, which the TypeScript side always decoded back into an `EagerCollection`.

Carry the kind alongside the name. `collectionsByNameAndType` encodes each shared collection as `{name, type}`, with type "eager" or "lazy", and `collectionForNameAndType` decodes it; both directions reject an unknown type. On the Skip side, a new `CollectionBase` base class over `Collection` and `LazyCollection` lets `createGraph` and `Resource.instantiate` traffic in either kind.

On the TypeScript side, `SharedCollections` widens `NamedEagerCollections` to `AbstractEagerCollection | AbstractLazyCollection` and becomes the `ResourceInputs` bound of `SkipService`, `Resource` and `ResourceClass`.

In a leader-follower deployment, a lazy collection cannot be mirrored from the leader: it holds no maintained state to stream. `asFollower` therefore gains a `lazies` option, mapping each shared name to a function that rebuilds the collection locally from the follower's `Context`, and `LeaderResource` now rejects a shared collection that is not eager instead of mirroring it.

`testSharedLazy` covers a lazy collection returned by `createGraph` and read by a resource's mapper, across inserts and deletes.