### PR TITLE
skipruntime: add updateAll to write several input collections atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - `ServiceInstance.updateAll` and `SkipServiceBroker.updateAll` to write to
+   several input collections atomically, along with the `PATCH /v1/inputs`
+   control route backing them
+
 ## [0.0.19] - 2025-11-16
 
 ### Added

--- a/skipruntime-ts/addon/src/tojs.cc
+++ b/skipruntime-ts/addon/src/tojs.cc
@@ -52,6 +52,7 @@ CJSON SkipRuntime_Runtime__getAll(char* resource, CJObject jsonParams);
 CJSON SkipRuntime_Runtime__getForKey(char* resource, CJObject jsonParams,
                                      CJSON key);
 CJSON SkipRuntime_Runtime__update(char* input, CJSON values);
+CJSON SkipRuntime_Runtime__updateAll(CJSON collections);
 double SkipRuntime_Runtime__fork(char* input);
 double SkipRuntime_Runtime__merge(CJArray);
 double SkipRuntime_Runtime__abortFork();
@@ -682,6 +683,20 @@ Napi::Value UpdateOfRuntime(const Napi::CallbackInfo& info) {
   return result;
 }
 
+Napi::Value UpdateAllOfRuntime(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!info[0].IsExternal()) {
+    throw Napi::TypeError::New(env, "The parameter must be a pointer.");
+  }
+  Napi::Value result;
+  NatTryCatch(env, [&result, &info, env](Napi::Env) {
+    CJSON skcollections = info[0].As<Napi::External<void>>().Data();
+    CJSON skresult = SkipRuntime_Runtime__updateAll(skcollections);
+    result = Napi::External<void>::New(env, skresult);
+  });
+  return result;
+}
+
 Napi::Value ForkOfRuntime(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() != 1) {
@@ -850,6 +865,8 @@ Napi::Value GetToJSBinding(const Napi::CallbackInfo& info) {
   AddFunction(env, binding, "SkipRuntime_Runtime__reload", ReloadOfRuntime);
   AddFunction(env, binding, "SkipRuntime_Runtime__closeResourceStreams",
               CloseResourceStreamsOfRuntime);
+  AddFunction(env, binding, "SkipRuntime_Runtime__updateAll",
+              UpdateAllOfRuntime);
 
   return binding;
 }

--- a/skipruntime-ts/core/src/binding.ts
+++ b/skipruntime-ts/core/src/binding.ts
@@ -178,6 +178,10 @@ export interface FromBinding {
     values: Pointer<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
   ): Pointer<Internal.CJSON>;
 
+  SkipRuntime_Runtime__updateAll(
+    collections: Pointer<Internal.CJObject>,
+  ): Pointer<Internal.CJSON>;
+
   SkipRuntime_Runtime__fork(name: string): Handle<Error>;
   SkipRuntime_Runtime__merge(
     ignore: Pointer<Internal.CJArray<Internal.CJString>>,

--- a/skipruntime-ts/core/src/index.ts
+++ b/skipruntime-ts/core/src/index.ts
@@ -126,6 +126,10 @@ export class ServiceDefinition {
     return Object.keys(this.service.inputs);
   }
 
+  hasInput(name: string): boolean {
+    return name in this.service.inputs;
+  }
+
   resources(): string[] {
     return Object.keys(this.service.resources as object);
   }
@@ -785,6 +789,9 @@ export class ServiceInstance {
     collection: string,
     entries: Entry<K, V>[],
   ): Promise<void> {
+    if (!this.definition.hasInput(collection)) {
+      throw new SkipUnknownCollectionError(`Unknown input '${collection}'`);
+    }
     this.refs.setFork(this.forkName);
     const result = this.refs.runWithGC(() => {
       const json = this.refs.json();
@@ -792,6 +799,62 @@ export class ServiceInstance {
         this.refs.binding.SkipRuntime_Runtime__update(
           collection,
           this.refs.json().exportJSON(entries),
+        ),
+        true,
+      );
+    });
+    if (Array.isArray(result)) {
+      const handles = result as Handle<Promise<void>>[];
+      const promises = handles.map((h) => this.refs.handles.deleteHandle(h));
+      await Promise.all(promises);
+    } else {
+      const errorHdl = result as Handle<Error>;
+      throw this.refs.handles.deleteHandle(errorHdl);
+    }
+  }
+
+  /**
+   * Update multiple inputs collection
+   * @param collections - The collections to update with the values
+   */
+  async updateAll(collections: {
+    [name: string]: Entry<Json, Json>[];
+  }): Promise<void> {
+    for (const input of Object.keys(collections)) {
+      if (!this.definition.hasInput(input)) {
+        throw new SkipUnknownCollectionError(`Unknown input '${input}'`);
+      }
+    }
+    this.refs.setFork(this.forkName);
+    const uuid = crypto.randomUUID();
+    const fork = this.fork(uuid);
+    try {
+      await fork.updateAll_(collections);
+      fork.merge([]);
+    } catch (ex: unknown) {
+      fork.abortFork();
+      if (ex instanceof Error) {
+        const matches =
+          /^(?:InvariantViolation: )?Invariant violation: Directory not found: \/([^/]+)\/$/.exec(
+            ex.message,
+          );
+        if (matches?.length === 2) {
+          throw new SkipUnknownCollectionError(`Unknown input '${matches[1]}'`);
+        }
+      }
+      throw ex;
+    }
+  }
+
+  private async updateAll_(collections: {
+    [name: string]: Entry<Json, Json>[];
+  }): Promise<void> {
+    this.refs.setFork(this.forkName);
+    const result = this.refs.runWithGC(() => {
+      const json = this.refs.json();
+      return json.importJSON(
+        this.refs.binding.SkipRuntime_Runtime__updateAll(
+          this.refs.json().exportJSON(collections),
         ),
         true,
       );

--- a/skipruntime-ts/helpers/src/rest.ts
+++ b/skipruntime-ts/helpers/src/rest.ts
@@ -194,6 +194,26 @@ export class SkipServiceBroker {
   }
 
   /**
+   * Write multiple entries to several collections atomically.
+   *
+   * The whole batch is applied in a single update: subscribers observe one
+   * notification instead of one per collection, and no intermediate state in
+   * which only part of the collections has been written. If any collection
+   * cannot be written, none of them are.
+   *
+   * @param inputs - Entries to write, keyed by the name of the input collection to update; each name must be a key of the `Inputs` type parameter of the `SkipService` running at `entrypoint`.
+   * @returns {void}
+   */
+  async updateAll(inputs: {
+    [name: string]: Entry<Json, Json>[];
+  }): Promise<void> {
+    await fetchJSON(`${this.entrypoint}/v1/inputs`, "PATCH", {
+      body: inputs,
+      timeout: this.timeout,
+    });
+  }
+
+  /**
    * Remove all values associated with a key in a collection.
    *
    * @typeParam K - Type of keys.

--- a/skipruntime-ts/server/src/rest.ts
+++ b/skipruntime-ts/server/src/rest.ts
@@ -83,6 +83,25 @@ export function registerControlServiceRoutes(
   });
 
   // WRITES
+  app.patch("/v1/inputs", (req, res) => {
+    if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+      res.status(400).json(`Bad request body ${JSON.stringify(req.body)}`);
+      return;
+    }
+
+    service
+      .updateAll(req.body as { [name: string]: Entry<Json, Json>[] })
+      .then(() => res.sendStatus(200))
+      .catch((e: unknown) => {
+        if (e instanceof SkipUnknownCollectionError) {
+          res.sendStatus(404);
+        } else {
+          console.error(e);
+          res.status(500).json({ error: "Internal server error" });
+        }
+      });
+  });
+
   app.patch("/v1/inputs/:collection", (req, res) => {
     if (!Array.isArray(req.body)) {
       res.status(400).json(`Bad request body ${JSON.stringify(req.body)}`);

--- a/skipruntime-ts/skiplang/core/src/Runtime.sk
+++ b/skipruntime-ts/skiplang/core/src/Runtime.sk
@@ -1040,6 +1040,7 @@ private fun writeInCollection(
   dirName: SKStore.DirName,
   values: Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>,
   isInit: Bool = false,
+  update: Bool = true,
 ): Array<Waitable> {
   chdl = SKStore.EHandle(JSONID::keyType, JSONFile::type, dirName);
   keys = if (isInit) {
@@ -1059,9 +1060,13 @@ private fun writeInCollection(
   });
   toAdd.each(added -> chdl.writeArray(context, added.i0, added.i1));
   keys.each(key -> chdl.writeArray(context, key, Array[]));
-  // Do not check garbage collection to prevent closing resources
-  context.update();
-  getSubscriptions(context);
+  if (update) {
+    // Do not check garbage collection to prevent closing resources
+    context.update();
+    getSubscriptions(context);
+  } else {
+    Array[]
+  }
 }
 
 fun update(
@@ -1070,6 +1075,24 @@ fun update(
   values: Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>,
 ): Array<Waitable> {
   writeInCollection(context, SKStore.DirName::create(`/${collection}/`), values)
+}
+
+fun updateAll(
+  context: mutable SKStore.Context,
+  collections: Array<(String, Array<(SKJSON.CJSON, Array<SKJSON.CJSON>)>)>,
+): Array<Waitable> {
+  for (collection in collections) {
+    _ = writeInCollection(
+      context,
+      SKStore.DirName::create(`/${collection.i0}/`),
+      collection.i1,
+      /* isInit */ false,
+      /* update */ false,
+    );
+  };
+  // Do not check garbage collection to prevent closing resources
+  context.update();
+  getSubscriptions(context);
 }
 
 fun delete(

--- a/skipruntime-ts/skiplang/ffi/src/FFI.sk
+++ b/skipruntime-ts/skiplang/ffi/src/FFI.sk
@@ -698,6 +698,34 @@ fun updateOfRuntime(input: String, values: SKJSON.CJArray): SKJSON.CJSON {
   }
 }
 
+@export("SkipRuntime_Runtime__updateAll")
+fun updateAllOfRuntime(collections: SKJSON.CJObject): SKJSON.CJSON {
+  runWithResult(context ~> {
+    handles = updateAll(
+      context,
+      collections match {
+      | SKJSON.CJObject(fields) ->
+        fields
+          .items()
+          .map(item ->
+            (
+              item.i0,
+              SKJSON.expectArray(item.i1).map(v -> {
+                e = SKJSON.expectArray(v);
+                (e[0], SKJSON.expectArray(e[1]))
+              }),
+            )
+          )
+          .collect(Array)
+      },
+    );
+    SKJSON.CJArray(handles.map(h -> SKJSON.CJFloat(h.value)))
+  }) match {
+  | Success(result) -> result
+  | Failure(err) -> SKJSON.CJFloat(getErrorHdl(err))
+  }
+}
+
 @export("SkipRuntime_Runtime__fork")
 fun forkOfRuntime(name: String): Float {
   try {

--- a/skipruntime-ts/tests/src/tests.ts
+++ b/skipruntime-ts/tests/src/tests.ts
@@ -20,7 +20,11 @@ import type {
   Reducer,
   ChangeManager,
 } from "@skipruntime/core";
-import { LoadStatus, InputDefinition } from "@skipruntime/core";
+import {
+  LoadStatus,
+  InputDefinition,
+  SkipUnknownCollectionError,
+} from "@skipruntime/core";
 import { Count, Sum } from "@skipruntime/helpers";
 
 import { it as mit, type AsyncFunc } from "mocha";
@@ -1294,6 +1298,72 @@ export function initTests(
     }
   });
 
+  it("testUpdateFailure", async () => {
+    const service = await initService(map1Service);
+    try {
+      const resource = "map1";
+      try {
+        await service.update("input1", [["1", [10]]]);
+        throw new Error("Error was not thrown");
+      } catch (e: unknown) {
+        expect(e).toBeA(SkipUnknownCollectionError);
+        expect((e as Error).message).toEqual("Unknown input 'input1'");
+      }
+      expect(await service.getAll(resource)).toEqual([]);
+    } finally {
+      await service.close();
+    }
+  });
+
+  it("testUpdateAll1", async () => {
+    const service = await initService(map2Service);
+    try {
+      const resource = "map2";
+      const constantResourceId1 = "unsafe.identifier.1";
+      await service.instantiateResource(constantResourceId1, resource, {});
+      const notifier = new Notifier(service, constantResourceId1);
+      notifier.checkInit([]);
+      await service.updateAll({
+        input1: [["1", [10]]],
+        input2: [["1", [20]]],
+      });
+      const values1: Entry<string, number>[] = [["1", [30]]];
+      notifier.checkUpdate(values1);
+      expect(await service.getAll(resource)).toEqual(values1);
+      await service.updateAll({
+        input1: [["2", [3]]],
+        input2: [["2", [7]]],
+      });
+      const values2: Entry<string, number>[] = [["2", [10]]];
+      notifier.checkUpdate(values2);
+      expect(await service.getArray(resource, "2")).toEqual([10]);
+      notifier.close();
+    } finally {
+      await service.close();
+    }
+  });
+
+  it("testUpdateAllFailure", async () => {
+    const service = await initService(map2Service);
+    try {
+      const resource = "map2";
+      try {
+        await service.updateAll({
+          input1: [["1", [10]]],
+          input2: [["1", [20]]],
+          input3: [["1", [30]]],
+        });
+        throw new Error("Error was not thrown");
+      } catch (e: unknown) {
+        expect(e).toBeA(SkipUnknownCollectionError);
+        expect((e as Error).message).toEqual("Unknown input 'input3'");
+      }
+      expect(await service.getAll(resource)).toEqual([]);
+    } finally {
+      await service.close();
+    }
+  });
+
   it("testMap3", async () => {
     const service = await initService(map3Service);
     try {
@@ -1311,6 +1381,29 @@ export function initTests(
       await service.close();
     }
   });
+
+  it("testUpdateAll2", async () => {
+    const service = await initService(map3Service);
+    try {
+      const resource = "map3";
+      await service.updateAll({
+        input1: [["1", [1, 2, 3]]],
+        input2: [["1", [10]]],
+      });
+      expect(await service.getArray(resource, "1")).toEqual([36]);
+      await service.updateAll({
+        input1: [["2", [3]]],
+        input2: [["2", [7]]],
+      });
+      expect(await service.getAll(resource)).toEqual([
+        ["1", [36]],
+        ["2", [10]],
+      ]);
+    } finally {
+      await service.close();
+    }
+  });
+
   it("valueMapper", async () => {
     const service = await initService(oneToOneMapperService);
     try {

--- a/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
+++ b/skipruntime-ts/wasm/src/internals/skipruntime_module.ts
@@ -189,6 +189,10 @@ export interface FromWasm {
     values: ptr<Internal.CJArray<Internal.CJArray<Internal.CJSON>>>,
   ): ptr<Internal.CJSON>;
 
+  SkipRuntime_Runtime__updateAll(
+    collections: ptr<Internal.CJObject>,
+  ): ptr<Internal.CJSON>;
+
   SkipRuntime_Runtime__fork(name: ptr<Internal.String>): Handle<Error>;
   SkipRuntime_Runtime__merge(
     ignore: ptr<Internal.CJArray<Internal.CJString>>,
@@ -667,6 +671,12 @@ export class WasmFromBinding implements FromBinding {
       this.utils.exportString(input),
       toPtr(values),
     );
+  }
+
+  SkipRuntime_Runtime__updateAll(
+    collections: Pointer<Internal.CJObject>,
+  ): ptr<Internal.CJSON> {
+    return this.fromWasm.SkipRuntime_Runtime__updateAll(toPtr(collections));
   }
 
   SkipRuntime_Runtime__fork(name: string): Handle<Error> {


### PR DESCRIPTION
Updating N input collections required N calls to `update`, each triggering its own recomputation and its own round of subscriber notifications. Beyond the cost, subscribers observed intermediate states in which only part of the collections had been written, and a failure midway left the earlier writes applied.

Add `updateAll`, which writes a whole batch in one shot:

- `writeInCollection` (Runtime.sk) gains an `update` flag so several collections can be written before a single `context.update()` and a single `getSubscriptions()` drain -- one recomputation, one notification.
- `SkipRuntime_Runtime__updateAll` is exported from the FFI and wired through both the native addon and the wasm bindings, mirroring `update`.
- `ServiceInstance.updateAll` runs the batch in a fork, merged on success and aborted on failure, so the update is all-or-nothing.
- `SkipServiceBroker.updateAll` and the `PATCH /v1/inputs` control route expose it over HTTP, the batch counterpart of `PATCH /v1/inputs/:collection`.

Tests cover the batch on two services, assert that a batch produces exactly one subscriber notification where two sequential updates produce two, and check that a batch naming an unknown collection throws and leaves none of the collections written.